### PR TITLE
Enforce ensemble slots and gender-restricted items on reincarnation

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -687,6 +687,26 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return (isGreatSuccess, RandomQuality);
         }
 
+        public ClientItemInfo LookupInfoByUID(DdonGameServer server, string itemUID)
+        {
+            var item = server.Database.SelectStorageItemByUId(itemUID);
+            if (item == null)
+            {
+                throw new ItemDoesntExistException(itemUID);
+            }
+            return LookupInfoByItem(server, item);
+        }
+
+        public ClientItemInfo LookupInfoByItem(DdonGameServer server, Item item)
+        {
+            var id = item.ItemId;
+            if (!server.AssetRepository.ClientItemInfos.ContainsKey(id))
+            {
+                throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INTERNAL_ERROR);
+            }
+            return server.AssetRepository.ClientItemInfos[id];
+        }
+
     }
 
     [Serializable]

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterEditUpdateCharacterEditParamExHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterEditUpdateCharacterEditParamExHandler.cs
@@ -30,25 +30,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             //Client won't let you reincarnate if you're wearing a gender-locked item, but EquipmentTemplates also have to be cleaned.
-            foreach (JobId job in Enum.GetValues(typeof(JobId)))
-            {
-                foreach (EquipType equipType in Enum.GetValues(typeof(EquipType)))
-                {
-                    foreach (EquipSlot equipSlot in Enumerable.Range(1, 15))
-                    {
-                        Item? item = client.Character.EquipmentTemplate.GetEquipItem(job, equipType, (byte)equipSlot);
-                        if (item is null) continue;
-                        ClientItemInfo itemInfo = Server.ItemManager.LookupInfoByItem(Server, item);
-                        if (itemInfo.Gender == Gender.Any) continue;
-                        if ((client.Character.EditInfo.Sex == 1 && itemInfo.Gender == Gender.Female)
-                            || (client.Character.EditInfo.Sex == 2 && itemInfo.Gender == Gender.Male))
-                        {
-                            client.Character.EquipmentTemplate.SetEquipItem(null, job, equipType, (byte)equipSlot);
-                            Server.Database.DeleteEquipItem(client.Character.CommonId, job, equipType, (byte)equipSlot);
-                        }
-                    }
-                }
-            }
+            Server.EquipManager.CleanGenderedEquipTemplates(Server, client.Character);
 
             client.Send(new S2CCharacterEditUpdateCharacterEditParamExRes());
             foreach(Client other in Server.ClientLookup.GetAll()) {

--- a/Arrowgene.Ddon.Shared/Model/ClientItemInfo.cs
+++ b/Arrowgene.Ddon.Shared/Model/ClientItemInfo.cs
@@ -68,6 +68,19 @@ namespace Arrowgene.Ddon.Shared.Model
             }
         }
 
+        public EquipSlot? EquipSlot { get
+            {
+                if (SubCategory is null) return null;
+                else if (SubCategory > ItemSubCategory.JewelrySubCategoryOffset) return Model.EquipSlot.Jewelry1; //All Jewelry
+                else if (SubCategory == ItemSubCategory.EquipEnsemble) return (Model.EquipSlot.ArmorBody); //Ensembles
+                else if (SubCategory == ItemSubCategory.EquipLantern) return (Model.EquipSlot.Lantern); //Lanterns
+                else if (SubCategory > ItemSubCategory.EquipSlotOffset) return (EquipSlot)(SubCategory - ItemSubCategory.EquipSlotOffset); //Other armor
+                else if (SubCategory == ItemSubCategory.WeaponShield || SubCategory == ItemSubCategory.WeaponRod) return Model.EquipSlot.WepSub; //Subweapons
+                else if (SubCategory > ItemSubCategory.WeaponCategoryOffset) return Model.EquipSlot.WepMain; //Main weapons
+                else return null;
+            } 
+        }
+
         public override string ToString()
         {
             return String.Format("{0} <{1}>", Name, ItemId);

--- a/Arrowgene.Ddon.Shared/Model/ItemSubCategory.cs
+++ b/Arrowgene.Ddon.Shared/Model/ItemSubCategory.cs
@@ -11,6 +11,7 @@ namespace Arrowgene.Ddon.Shared.Model
         UseDoorKey = 8,
 
         //MaterialCategory, offset by 100
+        MaterialCategoryOffset = 100,
         MaterialInorganicMetal = 101,
         MaterialInorganicOre = 102,
         MaterialInorganicSand = 103,
@@ -43,6 +44,7 @@ namespace Arrowgene.Ddon.Shared.Model
         MaterialDragonAbility = 133,
 
         //WeaponCategory, offset by 200
+        WeaponCategoryOffset = 200,
         WeaponHand = 200,
         WeaponSword = 201,
         WeaponShield = 202,
@@ -59,6 +61,7 @@ namespace Arrowgene.Ddon.Shared.Model
         WeaponMagickSword = 215,
 
         //EquipSlot, offset by 300
+        EquipSlotOffset = 300,
         EquipArmorHelm = 303,
         EquipArmorBody = 304,
         EquipClothingBody = 305,
@@ -71,6 +74,7 @@ namespace Arrowgene.Ddon.Shared.Model
         EquipEnsemble = 312,
 
         //JewelrySubCategory, offset by 400
+        JewelrySubCategoryOffset = 400,
         JewelryCommon = 426,
         JewelryRing = 442,
         JewelryBracelet = 458,


### PR DESCRIPTION
- Equipping an Ensemble unequips your other armor slots (Head, Arms, Legs, Upper Clothes, Lower Clothes, Accessory/Overwear). Addresses issue #156.
- Equipping any of those items while wearing an Ensemble unequips the ensemble.
- Reincarnating and changing genders clears any gender-restricted items from your equipment templates. Addresses #215.

The client already prevents you from attempting reincarnation if you're actively wearing a gender-restricted item, so that particular check isn't needed.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
