### PR TITLE
HotFix: EquipPoints write to DB correctly

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
@@ -128,6 +128,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 equipItem.ItemId = equipItem.ItemId;
                 equipItem.EquipPoints = currentTotalEquipPoint;
+                UpdateCharacterItem(client, equipItemUID, equipItem, charid, updateCharacterItemNtc, CurrentEquipInfo);
                 res = CreateEquipPointResponse(equipItemUID, addEquipPoint, currentTotalEquipPoint, goldRequired, IsGreatSuccess, CurrentEquipInfo, canContinue, dummydata);
             }
 


### PR DESCRIPTION
If you didn't fully finish an upgrade the points didn't write to the DB, meaning on relog you would lose all the progress.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
