### PR TITLE
Fix: More updates to DB transaction stuff

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/EquipManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/EquipManager.cs
@@ -1,6 +1,6 @@
 #nullable enable
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
@@ -107,7 +107,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
         }
 
-        public void HandleChangeEquipList(DdonGameServer server, GameClient client, CharacterCommon characterToEquipTo, List<CDataCharacterEquipInfo> changeCharacterEquipList, ItemNoticeType updateType, List<StorageType> storageTypes, Action sendResponse, DbConnection? connectionIn = null)
+        public (IPacketStructure, IPacketStructure) HandleChangeEquipList(DdonGameServer server, GameClient client, CharacterCommon characterToEquipTo, List<CDataCharacterEquipInfo> changeCharacterEquipList, ItemNoticeType updateType, List<StorageType> storageTypes, DbConnection? connectionIn = null)
         {
             S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
             {
@@ -214,10 +214,6 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 });
             }
 
-            client.Send(updateCharacterItemNtc);
-
-            sendResponse.Invoke();
-
             // Notify other players
             if (characterToEquipTo is Character character)
             {
@@ -229,10 +225,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     // TODO: Unk0
                 };
 
-                foreach (Client otherClient in server.ClientLookup.GetAll())
-                {
-                    otherClient.Send(changeCharacterEquipNtc);
-                }
+                return (updateCharacterItemNtc, changeCharacterEquipNtc);
             } 
             else if(characterToEquipTo is Pawn pawn)
             {
@@ -245,11 +238,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     // TODO: Unk0
                 };
 
-                foreach (Client otherClient in server.ClientLookup.GetAll())
-                {
-                    otherClient.Send(changePawnEquipNtc);
-                }
+                return (updateCharacterItemNtc, changePawnEquipNtc);
             }
+
+            throw new ResponseErrorException(ErrorCode.ERROR_CODE_FAIL); //TODO: Find a better code.
         }
         public void GetEquipTypeandSlot(Equipment equipment, string uid, out EquipType equipType, out byte equipSlot)
         {

--- a/Arrowgene.Ddon.GameServer/Chat/Command/Commands/JobCommand.cs
+++ b/Arrowgene.Ddon.GameServer/Chat/Command/Commands/JobCommand.cs
@@ -1,10 +1,10 @@
-using System;
-using System.Linq;
-using System.Collections.Generic;
 using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.GameServer.Handler;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
-using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
 {
@@ -15,11 +15,11 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
         public override string Key => "job";
         public override string HelpText => "usage: `/job [job]`";
 
-        private DdonGameServer _server;
+        private JobChangeJobHandler _jobChangeHandler;
 
         public JobCommand(DdonGameServer server)
         {
-            _server = server;
+            _jobChangeHandler = new JobChangeJobHandler(server);
         }
 
         public override void Execute(string[] command, GameClient client, ChatMessage message, List<ChatResponse> responses)
@@ -72,7 +72,12 @@ namespace Arrowgene.Ddon.GameServer.Chat.Command.Commands
             }
             else
             {
-                _server.JobManager.SetJob(client, client.Character, (JobId) job);
+                _jobChangeHandler.Handle(client,
+                    new StructurePacket<C2SJobChangeJobReq>(
+                        new C2SJobChangeJobReq()
+                        {
+                            JobId = (JobId)job
+                        }));
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterEditUpdatePawnEditParamHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterEditUpdatePawnEditParamHandler.cs
@@ -1,5 +1,4 @@
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
@@ -24,13 +23,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
             Pawn pawn = client.Character.PawnBySlotNo(packet.SlotNo);
             pawn.EditInfo = packet.EditInfo;
             Server.Database.UpdateEditInfo(pawn);
-            foreach(Client other in Server.ClientLookup.GetAll()) {
-                other.Send(new S2CCharacterEditUpdateEditParamNtc() {
-                    CharacterId = pawn.CharacterId,
-                    PawnId = pawn.PawnId,
-                    EditInfo = pawn.EditInfo
-                });
-            }
+
+            client.Party.SendToAllExcept(new S2CCharacterEditUpdateEditParamNtc()
+            {
+                CharacterId = pawn.CharacterId,
+                PawnId = pawn.PawnId,
+                EditInfo = pawn.EditInfo
+            }, client);
 
             return new S2CCharacterEditUpdatePawnEditParamRes();
         }

--- a/Arrowgene.Ddon.GameServer/Handler/EquipChangeCharacterEquipHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EquipChangeCharacterEquipHandler.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
@@ -21,20 +23,30 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SEquipChangeCharacterEquipReq> packet)
         {
+            (S2CItemUpdateCharacterItemNtc itemNtc, S2CEquipChangeCharacterEquipNtc equipNtc) equipResult = (null, null);
+
             Server.Database.ExecuteInTransaction(connection =>
             {
-                equipManager.HandleChangeEquipList(
+                equipResult = ((S2CItemUpdateCharacterItemNtc, S2CEquipChangeCharacterEquipNtc))equipManager.HandleChangeEquipList(
                     Server, client, 
                     client.Character, 
                     packet.Structure.ChangeCharacterEquipList, 
                     ItemNoticeType.ChangeEquip, 
-                    new List<StorageType>() { StorageType.ItemBagEquipment }, () => {
-                    client.Send(new S2CEquipChangeCharacterEquipRes()
-                        {
-                            CharacterEquipList = packet.Structure.ChangeCharacterEquipList
-                            // TODO: Unk0
-                        });
-                    }, connection);
+                    new List<StorageType>() { StorageType.ItemBagEquipment }, 
+                    connection);
+            });
+
+            client.Send(equipResult.itemNtc);
+
+            foreach (Client otherClient in Server.ClientLookup.GetAll())
+            {
+                otherClient.Send(equipResult.equipNtc); //TODO: Investigate if we need to send this to *everyone*.
+            }
+
+            client.Send(new S2CEquipChangeCharacterEquipRes()
+            {
+                CharacterEquipList = packet.Structure.ChangeCharacterEquipList
+                // TODO: Unk0
             });
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/EquipChangeCharacterStorageEquipHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EquipChangeCharacterStorageEquipHandler.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
@@ -20,15 +21,32 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SEquipChangeCharacterStorageEquipReq> packet)
         {
+            (S2CItemUpdateCharacterItemNtc itemNtc, S2CEquipChangeCharacterEquipNtc equipNtc) equipResult = (null, null);
+
             Server.Database.ExecuteInTransaction(connection =>
             {
-                equipManager.HandleChangeEquipList(Server, client, client.Character, packet.Structure.ChangeCharacterEquipList, ItemNoticeType.ChangeStorageEquip, ItemManager.BoxStorageTypes, () => {
-                    client.Send(new S2CEquipChangeCharacterStorageEquipRes()
-                    {
-                        CharacterEquipList = packet.Structure.ChangeCharacterEquipList
-                        // TODO: Unk0
-                    });
-                }, connection);
+                equipResult = ((S2CItemUpdateCharacterItemNtc, S2CEquipChangeCharacterEquipNtc))
+                equipManager.HandleChangeEquipList(
+                    Server, 
+                    client, 
+                    client.Character, 
+                    packet.Structure.ChangeCharacterEquipList, 
+                    ItemNoticeType.ChangeStorageEquip, 
+                    ItemManager.BoxStorageTypes,
+                    connection);
+            });
+
+            client.Send(equipResult.itemNtc);
+
+            foreach (Client otherClient in Server.ClientLookup.GetAll())
+            {
+                otherClient.Send(equipResult.equipNtc);
+            }
+
+            client.Send(new S2CEquipChangeCharacterStorageEquipRes()
+            {
+                CharacterEquipList = packet.Structure.ChangeCharacterEquipList
+                // TODO: Unk0
             });
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/EquipChangePawnEquipHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EquipChangePawnEquipHandler.cs
@@ -1,11 +1,11 @@
-using System.Collections.Generic;
-using System.Linq;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -22,17 +22,32 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SEquipChangePawnEquipReq> packet)
         {
+            (S2CItemUpdateCharacterItemNtc itemNtc, S2CEquipChangePawnEquipNtc equipNtc) equipResult = (null, null);
+
             Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
             Server.Database.ExecuteInTransaction(connection =>
             {
-                equipManager.HandleChangeEquipList(Server, client, pawn, packet.Structure.ChangeCharacterEquipList, ItemNoticeType.ChangePawnEquip, new List<StorageType>() { StorageType.ItemBagEquipment }, () => {
-                    client.Send(new S2CEquipChangePawnEquipRes()
-                    {
-                        PawnId = packet.Structure.PawnId,
-                        CharacterEquipList = packet.Structure.ChangeCharacterEquipList
-                        // TODO: Unk0
-                    });
-                }, connection);
+                equipResult = ((S2CItemUpdateCharacterItemNtc, S2CEquipChangePawnEquipNtc))
+                equipManager.HandleChangeEquipList(
+                    Server, 
+                    client, 
+                    pawn, 
+                    packet.Structure.ChangeCharacterEquipList, 
+                    ItemNoticeType.ChangePawnEquip, 
+                    new List<StorageType>() { StorageType.ItemBagEquipment },  
+                    connection);
+            });
+
+            client.Send(equipResult.itemNtc);
+
+            //Only the party needs to be updated, because only they can see pawns.
+            client.Party.SendToAllExcept(equipResult.equipNtc, client);
+
+            client.Send(new S2CEquipChangePawnEquipRes()
+            {
+                PawnId = packet.Structure.PawnId,
+                CharacterEquipList = packet.Structure.ChangeCharacterEquipList
+                // TODO: Unk0
             });
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/EquipChangePawnStorageEquipHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EquipChangePawnStorageEquipHandler.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
@@ -21,18 +22,32 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SEquipChangePawnStorageEquipReq> packet)
         {
+            (S2CItemUpdateCharacterItemNtc itemNtc, S2CEquipChangePawnEquipNtc equipNtc) equipResult = (null, null);
+
             Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
             Server.Database.ExecuteInTransaction(connection =>
             {
-                equipManager.HandleChangeEquipList(Server, client, pawn, packet.Structure.ChangeCharacterEquipList, ItemNoticeType.ChangeStoragePawnEquip, ItemManager.BoxStorageTypes, () =>
-                {
-                    client.Send(new S2CEquipChangePawnStorageEquipRes()
-                    {
-                        PawnId = packet.Structure.PawnId,
-                        CharacterEquipList = packet.Structure.ChangeCharacterEquipList
-                        // TODO: Unk0
-                    });
-                }, connection);
+                equipResult = ((S2CItemUpdateCharacterItemNtc, S2CEquipChangePawnEquipNtc))
+                equipManager.HandleChangeEquipList(
+                    Server, 
+                    client, 
+                    pawn, 
+                    packet.Structure.ChangeCharacterEquipList, 
+                    ItemNoticeType.ChangeStoragePawnEquip, 
+                    ItemManager.BoxStorageTypes,
+                    connection);
+            });
+
+            client.Send(equipResult.itemNtc);
+
+            //Only the party needs to be updated, because only they can see pawns.
+            client.Party.SendToAllExcept(equipResult.equipNtc, client); 
+
+            client.Send(new S2CEquipChangePawnStorageEquipRes()
+            {
+                PawnId = packet.Structure.PawnId,
+                CharacterEquipList = packet.Structure.ChangeCharacterEquipList
+                // TODO: Unk0
             });
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/ItemConsumeStorageItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ItemConsumeStorageItemHandler.cs
@@ -26,19 +26,23 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     UpdateType = ItemNoticeType.ConsumeBag
                 };
 
-                foreach (CDataStorageItemUIDList consumeItem in req.Structure.ConsumeItemList)
+                Server.Database.ExecuteInTransaction(connection => 
                 {
-                    CDataItemUpdateResult itemUpdate;
-                    if(consumeItem.SlotNo == 0)
+                    foreach (CDataStorageItemUIDList consumeItem in req.Structure.ConsumeItemList)
                     {
-                        itemUpdate = Server.ItemManager.ConsumeItemByUId(Server, client.Character, consumeItem.StorageType, consumeItem.ItemUId, consumeItem.Num);
+                        CDataItemUpdateResult itemUpdate;
+                        if (consumeItem.SlotNo == 0)
+                        {
+                            itemUpdate = Server.ItemManager.ConsumeItemByUId(Server, client.Character, consumeItem.StorageType, consumeItem.ItemUId, consumeItem.Num, connection);
+                        }
+                        else
+                        {
+                            itemUpdate = Server.ItemManager.ConsumeItemInSlot(Server, client.Character, consumeItem.StorageType, consumeItem.SlotNo, consumeItem.Num, connection);
+                        }
+                        ntc.UpdateItemList.Add(itemUpdate);
                     }
-                    else
-                    {
-                        itemUpdate = Server.ItemManager.ConsumeItemInSlot(Server, client.Character, consumeItem.StorageType, consumeItem.SlotNo, consumeItem.Num);
-                    }
-                    ntc.UpdateItemList.Add(itemUpdate);
-                }
+                });
+                
                 client.Send(ntc);
             }
             catch(Exception _)

--- a/Arrowgene.Ddon.GameServer/Handler/JobChangeJobHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobChangeJobHandler.cs
@@ -5,6 +5,7 @@ using Arrowgene.Logging;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Entity;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -21,10 +22,20 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SJobChangeJobReq> packet)
         {
+            (S2CJobChangeJobRes jobRes, S2CItemUpdateCharacterItemNtc itemNtc, S2CJobChangeJobNtc jobNtc) jobResult = (null, null, null);
+
             Server.Database.ExecuteInTransaction(connection =>
             {
+                jobResult = ((S2CJobChangeJobRes, S2CItemUpdateCharacterItemNtc, S2CJobChangeJobNtc))
                 jobManager.SetJob(client, client.Character, packet.Structure.JobId, connection);
             });
+
+            foreach (GameClient otherClient in Server.ClientLookup.GetAll())
+            {
+                otherClient.Send(jobResult.jobNtc);
+            }
+            client.Send(jobResult.itemNtc);
+            client.Send(jobResult.jobRes);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/JobChangePawnJobHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobChangePawnJobHandler.cs
@@ -21,11 +21,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SJobChangePawnJobReq> packet)
         {
+            (S2CJobChangePawnJobRes jobRes, S2CItemUpdateCharacterItemNtc itemNtc, S2CJobChangePawnJobNtc jobNtc) jobResult = (null, null, null);
+
             Pawn pawn = client.Character.Pawns.Where(pawn => pawn.PawnId == packet.Structure.PawnId).Single();
             Server.Database.ExecuteInTransaction(connection =>
             {
+                jobResult = ((S2CJobChangePawnJobRes, S2CItemUpdateCharacterItemNtc, S2CJobChangePawnJobNtc))
                 jobManager.SetJob(client, pawn, packet.Structure.JobId, connection);
             });
+
+            foreach (GameClient otherClient in Server.ClientLookup.GetAll())
+            {
+                otherClient.Send(jobResult.jobNtc);
+            }
+            client.Send(jobResult.itemNtc);
+            client.Send(jobResult.jobRes);
         }
     }
 }


### PR DESCRIPTION
Move packet IO out of transactions; managers return packet tuples that handlers are expected to send after the transaction closes.

Hopefully addresses some of the lag under load that was causing timeouts, especially since some of the equipment packets involved serverwide notices.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
