### PR TITLE
HOTFIX: Move CrestStartAttachElement OUT of a transaction temporarily.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartAttachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartAttachElementHandler.cs
@@ -54,52 +54,49 @@ namespace Arrowgene.Ddon.GameServer.Handler
             uint totalCost = (uint)(craftInfo.Cost * request.CraftElementList.Count);
             uint totalExp = (uint)(craftInfo.Exp * request.CraftElementList.Count);
 
-            Server.Database.ExecuteInTransaction(connection =>
+            updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 0, 0));
+            foreach (var element in request.CraftElementList)
             {
-                updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 0, 0));
-                foreach (var element in request.CraftElementList)
+                uint crestId = Server.ItemManager.LookupItemByUID(Server, element.ItemUId);
+
+                Server.Database.InsertCrest(client.Character.CommonId, request.EquipItemUId, element.SlotNo, crestId, 0);
+                result.EquipElementParamList.Add(new CDataEquipElementParam()
                 {
-                    uint crestId = Server.ItemManager.LookupItemByUID(Server, element.ItemUId, connection);
+                    CrestId = crestId,
+                    SlotNo = element.SlotNo,
+                });
 
-                    Server.Database.InsertCrest(client.Character.CommonId, request.EquipItemUId, element.SlotNo, crestId, 0);
-                    result.EquipElementParamList.Add(new CDataEquipElementParam()
-                    {
-                        CrestId = crestId,
-                        SlotNo = element.SlotNo,
-                    });
-
-                    item.EquipElementParamList.Add(new CDataEquipElementParam()
-                    {
-                        CrestId = crestId,
-                        SlotNo = element.SlotNo,
-                    });
-
-                    // Consume the crest
-                    updateCharacterItemNtc.UpdateItemList.AddRange(
-                        Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, element.ItemUId, 1));
-                }
-
-                updateCharacterItemNtc.UpdateType = ItemNoticeType.StartAttachElement;
-                updateCharacterItemNtc.UpdateWalletList.Add(Server.WalletManager.RemoveFromWallet(client.Character, WalletType.Gold, totalCost));
-                updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 1, 1));
-                client.Send(updateCharacterItemNtc);
-
-                Pawn leadPawn = Server.CraftManager.FindPawn(client, request.CraftMainPawnId);
-                if (CraftManager.CanPawnExpUp(leadPawn))
+                item.EquipElementParamList.Add(new CDataEquipElementParam()
                 {
-                    CraftManager.HandlePawnExpUpNtc(client, leadPawn, totalExp, 0);
-                    if (CraftManager.CanPawnRankUp(leadPawn))
-                    {
-                        CraftManager.HandlePawnRankUpNtc(client, leadPawn);
-                    }
-                    Server.Database.UpdatePawnBaseInfo(leadPawn);
-                }
-                else
+                    CrestId = crestId,
+                    SlotNo = element.SlotNo,
+                });
+
+                // Consume the crest
+                updateCharacterItemNtc.UpdateItemList.AddRange(
+                    Server.ItemManager.ConsumeItemByUIdFromMultipleStorages(Server, client.Character, ItemManager.BothStorageTypes, element.ItemUId, 1));
+            }
+
+            updateCharacterItemNtc.UpdateType = ItemNoticeType.StartAttachElement;
+            updateCharacterItemNtc.UpdateWalletList.Add(Server.WalletManager.RemoveFromWallet(client.Character, WalletType.Gold, totalCost));
+            updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 1, 1));
+            client.Send(updateCharacterItemNtc);
+
+            Pawn leadPawn = Server.CraftManager.FindPawn(client, request.CraftMainPawnId);
+            if (CraftManager.CanPawnExpUp(leadPawn))
+            {
+                CraftManager.HandlePawnExpUpNtc(client, leadPawn, totalExp, 0);
+                if (CraftManager.CanPawnRankUp(leadPawn))
                 {
-                    // Mandatory to send otherwise the UI gets stuck.
-                    CraftManager.HandlePawnExpUpNtc(client, leadPawn, 0, 0);
+                    CraftManager.HandlePawnRankUpNtc(client, leadPawn);
                 }
-            });
+                Server.Database.UpdatePawnBaseInfo(leadPawn);
+            }
+            else
+            {
+                // Mandatory to send otherwise the UI gets stuck.
+                CraftManager.HandlePawnExpUpNtc(client, leadPawn, 0, 0);
+            }
             return result;
         }
     }


### PR DESCRIPTION
Super fast hotfix for crests on develop. Will be superseded later by @Conner-Schaffer's changes.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
