### PR TITLE
Hotfix: Lobby HP reset bug.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
@@ -67,10 +67,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
 
             uint id = client.Character.CharacterId;
-            HashSet<GameClient> targetClients = new HashSet<GameClient>()
-            {
-                client
-            };
+            HashSet<GameClient> targetClients = new HashSet<GameClient>();
             HashSet<GameClient> gatherClients = new HashSet<GameClient>();
 
             if (HubMembers.ContainsKey(previousStageId))


### PR DESCRIPTION
Hotfixes weird lobby HP resetting bug due to using cached serverside data regarding the character to overwrite the client's own data regarding the player.

Might restore the "zombie bug" where you spawn in to WDT with 0 HP, but that may have been addressed by other mechanisms.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
