### PR TITLE
Fix: Job item consumption

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/ItemUseJobItemsHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ItemUseJobItemsHandler.cs
@@ -29,7 +29,15 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             foreach (CDataItemUIdList itemUIdListElement in packet.Structure.ItemUIdList)
             {
-                _itemManager.ConsumeItemByUId(Server, client.Character, StorageType.ItemBagJob, itemUIdListElement.UId, itemUIdListElement.Num);
+                var update = _itemManager.ConsumeItemByUId(Server, client.Character, StorageType.ItemBagJob, itemUIdListElement.UId, itemUIdListElement.Num);
+                if (update != null)
+                {
+                    ntc.UpdateItemList.Add(update);
+                }
+                else
+                {
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_NUM_SHORT);
+                }
             }
 
             client.Send(ntc);


### PR DESCRIPTION
Addresses #520 . Job items were being consumed serverside and in the database, but the item notice wasn't properly constructed so the client was never notified of the new amount.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
