### PR TITLE
Hotfix: Regular enemies not dropping loot.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
@@ -127,4 +127,9 @@ public class InstanceEnemyManager : InstanceAssetManager<byte, Enemy, InstancedE
             _EnemyData.Clear();
         }
     }
+
+    public ushort GetSubgroup(StageId stageId)
+    {
+        return _CurrentSubgroup.GetValueOrDefault(stageId);
+    }
 }

--- a/Arrowgene.Ddon.GameServer/GatheringItems/InstanceDropItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/InstanceDropItemManager.cs
@@ -15,7 +15,8 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
 
         protected override List<GatheringItem> FetchAssetsFromRepository(StageId stage, uint setId)
         {
-            List<InstancedEnemy> enemiesInSet =  _client.Party.InstanceEnemyManager.GetAssets(stage, (byte) setId);
+            ushort currentSubGroup = _client.Party.InstanceEnemyManager.GetSubgroup(stage);
+            List<InstancedEnemy> enemiesInSet =  _client.Party.InstanceEnemyManager.GetAssets(stage, (byte)currentSubGroup);
             if(enemiesInSet != null && setId < enemiesInSet.Count)
             {
                 Enemy enemy = enemiesInSet[(int) setId];


### PR DESCRIPTION
The enemy-kill-loot-table logic was using their position index (within their set) for both their subgroup layer and their position index when it came time to figure out what died, leading to 99% of spawns failing to find any valid loot for enemies in the 1st and higher positions.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
