### PR TITLE
Fix: Hobolic Cave StageID for SafeStages

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/StageManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/StageManager.cs
@@ -50,7 +50,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             61, // Golden Tankard Inn
             66, // Gritten Fort
             78, // Pawn Cathedral
-            98, // Hobolic Cave
+            95, // Hobolic Cave
             137, // Mysree Grove Shrine
             139, // Zandora Wastelands Shrine
             141, // Breya Coast (Summer Event Hub Area)


### PR DESCRIPTION
Sets the correct ID, previously 98 (appears to be a dungeon lol), now its 95, which is correct.
Can now invite your pawns at the riftstone in Hobolic Cave.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
