### PR TITLE
Fix: Translation patch process properly applies quest info

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/ClientCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/ClientCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -221,15 +221,9 @@ namespace Arrowgene.Ddon.Cli.Command
                             GmdCsv.Entry matchCsvEntry = null;
                             foreach (GmdCsv.Entry csvEntry in gmdCsvEntries)
                             {
-                                if (!string.IsNullOrEmpty(entry.Key) && csvEntry.Key == entry.Key)
+                                if (!string.IsNullOrEmpty(entry.Key) && csvEntry.Key == entry.Key && entry.ReadIndex == csvEntry.ReadIndex)
                                 {
-                                    // matched based on key
-                                    matchCsvEntry = csvEntry;
-                                    break;
-                                }
-
-                                if (entry.ReadIndex == csvEntry.ReadIndex)
-                                {
+                                    // Both key AND index have to match, because there are gui entries with duplicate keys.
                                     matchCsvEntry = csvEntry;
                                     break;
                                 }


### PR DESCRIPTION
In the quest data, the title and description share a key, but the patcher accepts the first matching key as a valid string for replacement. This results in both the title and description of each quest being "translated" as solely the title.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
