### PR TITLE
Feat:  Pawn reactions.

### DIFF
--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -120,6 +120,7 @@ namespace Arrowgene.Ddon.Database
         bool DeletePawn(uint pawnId);
         bool UpdatePawnBaseInfo(Pawn pawn);
         uint GetPawnOwnerCharacterId(uint pawnId);
+        bool ReplacePawnReaction(uint pawnId, CDataPawnReaction pawnReaction, DbConnection? connectionIn = null);
 
         // Pawn Training Status
         bool ReplacePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus);

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -489,6 +489,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new PawnRentRegisteredPawnHandler(this));
             AddHandler(new PawnJoinPartyRentedPawnHandler(this));
             AddHandler(new PawnReturnRentedPawnHandler(this));
+            AddHandler(new PawnUpdatePawnReactionListHandler(this));
 
             AddHandler(new PhotoPhotoTakeHandler(this));
 

--- a/Arrowgene.Ddon.GameServer/Handler/PawnCreatePawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnCreatePawnHandler.cs
@@ -462,6 +462,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             pawn.LearnedAbilities = pawn.EquippedAbilitiesDictionary.SelectMany(jobAndAugs => jobAndAugs.Value).Where(aug => aug != null).ToList();
             pawn.TrainingPoints = int.MaxValue;
             pawn.AvailableTraining = uint.MaxValue;
+            pawn.PawnReactionList = Enumerable.Range(1, 11).Select(x => new CDataPawnReaction() { ReactionType = (byte)x, MotionNo = 1 }).ToList();
 
             // Add current job's equipment to the equipment storage
             // EquipmentTemplate.TOTAL_EQUIP_SLOTS * 2

--- a/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnReactionListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnUpdatePawnReactionListHandler.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class PawnUpdatePawnReactionListHandler : GameRequestPacketHandler<C2SPawnUpdatePawnReactionListReq, S2CPawnUpdatePawnReactionListRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PawnDeleteMyPawnHandler));
+
+        public PawnUpdatePawnReactionListHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CPawnUpdatePawnReactionListRes Handle(GameClient client, C2SPawnUpdatePawnReactionListReq request)
+        {
+            Pawn pawn = client.Character.Pawns.Find(x => x.PawnId == request.PawnId)
+                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PAWN_INVALID);
+
+            pawn.PawnReactionList = request.PawnReactionList;
+            Server.Database.ExecuteInTransaction(conn =>
+            {
+                foreach (var reaction in request.PawnReactionList)
+                {
+                    Server.Database.ReplacePawnReaction(request.PawnId, reaction, conn);
+                }
+            });
+                
+            var res = new S2CPawnUpdatePawnReactionListRes()
+            {
+                PawnId = request.PawnId,
+                PawnReactionList = pawn.PawnReactionList
+            };
+            var ntc = new S2CPawnUpdatePawnReactionListNtc()
+            {
+                PawnId = request.PawnId,
+                PawnReactionList = pawn.PawnReactionList
+            };
+
+            client.Party.SendToAllExcept(ntc, client);
+            return res;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -677,6 +677,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SPawnJoinPartyRentedPawnReq.Serializer());
             Create(new C2SPawnReturnRentedPawnReq.Serializer());
             Create(new C2SPawnGetNoraPawnListReq.Serializer());
+            Create(new C2SPawnUpdatePawnReactionListReq.Serializer());
 
             Create(new C2SProfileGetCharacterProfileReq.Serializer());
             Create(new C2SProfileGetMyCharacterProfileReq.Serializer());
@@ -1206,6 +1207,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CPawnJoinPartyRentedPawnRes.Serializer());
             Create(new S2CPawnReturnRentedPawnRes.Serializer());
             Create(new S2CPawnGetNoraPawnListRes.Serializer());
+            Create(new S2CPawnUpdatePawnReactionListRes.Serializer());
+            Create(new S2CPawnUpdatePawnReactionListNtc.Serializer());
 
             Create(new S2CProfileGetCharacterProfileRes.Serializer());
             Create(new S2CProfileGetMyCharacterProfileRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnUpdatePawnReactionListReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SPawnUpdatePawnReactionListReq.cs
@@ -1,0 +1,37 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SPawnUpdatePawnReactionListReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_PAWN_UPDATE_PAWN_REACTION_LIST_REQ;
+
+        public C2SPawnUpdatePawnReactionListReq()
+        {
+            PawnReactionList = new();
+        }
+
+        public uint PawnId { get; set; }
+        public List<CDataPawnReaction> PawnReactionList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SPawnUpdatePawnReactionListReq>
+        {
+            public override void Write(IBuffer buffer, C2SPawnUpdatePawnReactionListReq obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+                WriteEntityList<CDataPawnReaction>(buffer, obj.PawnReactionList);
+            }
+
+            public override C2SPawnUpdatePawnReactionListReq Read(IBuffer buffer)
+            {
+                C2SPawnUpdatePawnReactionListReq obj = new C2SPawnUpdatePawnReactionListReq();
+                obj.PawnId = ReadUInt32(buffer);
+                obj.PawnReactionList = ReadEntityList<CDataPawnReaction>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnUpdatePawnReactionListNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnUpdatePawnReactionListNtc.cs
@@ -1,0 +1,37 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPawnUpdatePawnReactionListNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.S2C_PAWN_UPDATE_PAWN_REACTION_LIST_NTC;
+
+        public S2CPawnUpdatePawnReactionListNtc()
+        {
+            PawnReactionList = new();
+        }
+
+        public uint PawnId { get; set; }
+        public List<CDataPawnReaction> PawnReactionList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CPawnUpdatePawnReactionListNtc>
+        {
+            public override void Write(IBuffer buffer, S2CPawnUpdatePawnReactionListNtc obj)
+            {
+                WriteUInt32(buffer, obj.PawnId);
+                WriteEntityList<CDataPawnReaction>(buffer, obj.PawnReactionList);
+            }
+
+            public override S2CPawnUpdatePawnReactionListNtc Read(IBuffer buffer)
+            {
+                S2CPawnUpdatePawnReactionListNtc obj = new S2CPawnUpdatePawnReactionListNtc();
+                obj.PawnId = ReadUInt32(buffer);
+                obj.PawnReactionList = ReadEntityList<CDataPawnReaction>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnUpdatePawnReactionListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CPawnUpdatePawnReactionListRes.cs
@@ -1,0 +1,41 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CPawnUpdatePawnReactionListRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_PAWN_UPDATE_PAWN_REACTION_LIST_RES;
+
+        public S2CPawnUpdatePawnReactionListRes()
+        {
+            PawnReactionList = new();
+        }
+
+        public uint PawnId { get; set; }
+        public List<CDataPawnReaction> PawnReactionList { get; set; }
+
+
+        public class Serializer : PacketEntitySerializer<S2CPawnUpdatePawnReactionListRes>
+        {
+            public override void Write(IBuffer buffer, S2CPawnUpdatePawnReactionListRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+                WriteUInt32(buffer, obj.PawnId);
+                WriteEntityList<CDataPawnReaction>(buffer, obj.PawnReactionList);
+
+            }
+
+            public override S2CPawnUpdatePawnReactionListRes Read(IBuffer buffer)
+            {
+                S2CPawnUpdatePawnReactionListRes obj = new S2CPawnUpdatePawnReactionListRes();
+                ReadServerResponse(buffer, obj);
+                WriteUInt32(buffer, obj.PawnId);
+                WriteEntityList<CDataPawnReaction>(buffer, obj.PawnReactionList);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Pawn.cs
+++ b/Arrowgene.Ddon.Shared/Model/Pawn.cs
@@ -94,6 +94,7 @@ namespace Arrowgene.Ddon.Shared.Model
                         .Where(skill => skill != null)
                         .ToList(),
                 ExtendParam = ExtendedParams,
+                PawnReactionList = PawnReactionList,
                 // TODO: Add rest of fileds so full structure can be populated here
             };
         }

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -485,12 +485,12 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_PAWN_LOST_PAWN_GOLDEN_REVIVE_RES = new PacketId(8, 23, 2, "S2C_PAWN_LOST_PAWN_GOLDEN_REVIVE_RES", ServerType.Game, PacketSource.Server); // ロストポーン復活(黄金石消費)に
         public static readonly PacketId C2S_PAWN_LOST_PAWN_WALLET_REVIVE_REQ = new PacketId(8, 24, 1, "C2S_PAWN_LOST_PAWN_WALLET_REVIVE_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_PAWN_LOST_PAWN_WALLET_REVIVE_RES = new PacketId(8, 24, 2, "S2C_PAWN_LOST_PAWN_WALLET_REVIVE_RES", ServerType.Game, PacketSource.Server); // ロストポーン復活(通貨消費)に
-        public static readonly PacketId C2S_PAWN_8_25_1_REQ = new PacketId(8, 25, 1, "C2S_PAWN_8_25_1_REQ", ServerType.Game, PacketSource.Client);
-        public static readonly PacketId S2C_PAWN_8_25_2_RES = new PacketId(8, 25, 2, "S2C_PAWN_8_25_2_RES", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_PAWN_8_25_16_NTC = new PacketId(8, 25, 16, "S2C_PAWN_8_25_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId C2S_PAWN_8_25_1_REQ = new PacketId(8, 25, 1, "C2S_PAWN_8_25_1_REQ", ServerType.Game, PacketSource.Client); // C2S_RENTAL_PAWN_LOST_REQ?
+        public static readonly PacketId S2C_PAWN_8_25_2_RES = new PacketId(8, 25, 2, "S2C_PAWN_8_25_2_RES", ServerType.Game, PacketSource.Server); // S2C_RENTAL_PAWN_LOST_RES?
+        public static readonly PacketId S2C_PAWN_8_25_16_NTC = new PacketId(8, 25, 16, "S2C_PAWN_8_25_16_NTC", ServerType.Game, PacketSource.Server); // S2C_RENTAL_PAWN_LOST_NTC?
         public static readonly PacketId C2S_PAWN_UPDATE_PAWN_REACTION_LIST_REQ = new PacketId(8, 26, 1, "C2S_PAWN_UPDATE_PAWN_REACTION_LIST_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_PAWN_UPDATE_PAWN_REACTION_LIST_RES = new PacketId(8, 26, 2, "S2C_PAWN_UPDATE_PAWN_REACTION_LIST_RES", ServerType.Game, PacketSource.Server); // ポーンリアクションリスト更新に
-        public static readonly PacketId S2C_PAWN_8_26_16_NTC = new PacketId(8, 26, 16, "S2C_PAWN_8_26_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_PAWN_UPDATE_PAWN_REACTION_LIST_NTC = new PacketId(8, 26, 16, "S2C_PAWN_UPDATE_PAWN_REACTION_LIST_NTC", ServerType.Game, PacketSource.Server, "S2C_PAWN_8_26_16_NTC");
         public static readonly PacketId C2S_PAWN_UPDATE_PAWN_SHARE_RANGE_REQ = new PacketId(8, 27, 1, "C2S_PAWN_UPDATE_PAWN_SHARE_RANGE_REQ", ServerType.Game, PacketSource.Client);
         public static readonly PacketId S2C_PAWN_UPDATE_PAWN_SHARE_RANGE_RES = new PacketId(8, 27, 2, "S2C_PAWN_UPDATE_PAWN_SHARE_RANGE_RES", ServerType.Game, PacketSource.Server); // ポーン公開設定更新に
         public static readonly PacketId C2S_PAWN_GET_PAWN_HISTORY_LIST_REQ = new PacketId(8, 28, 1, "C2S_PAWN_GET_PAWN_HISTORY_LIST_REQ", ServerType.Game, PacketSource.Client);
@@ -2420,7 +2420,7 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_PAWN_8_25_16_NTC);
             AddPacketIdEntry(packetIds, C2S_PAWN_UPDATE_PAWN_REACTION_LIST_REQ);
             AddPacketIdEntry(packetIds, S2C_PAWN_UPDATE_PAWN_REACTION_LIST_RES);
-            AddPacketIdEntry(packetIds, S2C_PAWN_8_26_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_PAWN_UPDATE_PAWN_REACTION_LIST_NTC);
             AddPacketIdEntry(packetIds, C2S_PAWN_UPDATE_PAWN_SHARE_RANGE_REQ);
             AddPacketIdEntry(packetIds, S2C_PAWN_UPDATE_PAWN_SHARE_RANGE_RES);
             AddPacketIdEntry(packetIds, C2S_PAWN_GET_PAWN_HISTORY_LIST_REQ);

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -323,6 +323,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool UpdateOrbGainExtendParam(uint commonId, CDataOrbGainExtendParam Param) { return true; }
         public bool UpdatePawnBaseInfo(Pawn pawn) { return true; }
         public bool UpdatePawnTrainingStatus(uint pawnId, JobId job, byte[] pawnTrainingStatus) { return true; }
+        public bool ReplacePawnReaction(uint pawnId, CDataPawnReaction pawnReaction, DbConnection? connectionIn = null) { return true; }
         public bool ReplacePawnCraftProgress(CraftProgress craftProgress) { return true; }
         public bool InsertPawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null) { return true; }
         public bool InsertIfNotExistsPawnCraftProgress(CraftProgress craftProgress) { return true; }


### PR DESCRIPTION
Finishes adding the handling for pawn reactions. The machinery for writing them to the DB, reading them to the Pawn model, and sending them to the client was done long ago, but the actual packets for updating them never got implemented.

Existing pawns do not have reactions but can get them set by using the menu option at any rift stone (Select pawn -> Pawn reaction settings). Since some instances may have large amounts of legacy pawns, a migration would add 11 useless entries per unloved, abandoned pawn, so one is not required in this case. New pawns are automatically set to "Any" reaction for all 11 circumstances, the default value the client provides in the UI.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
