### PR TITLE
Feat: S2 board quests

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000010.json
@@ -2,7 +2,7 @@
   "state_machine": "GenericStateMachine",
   "type": "Light",
   "quest_id": 40000010,
-  "base_level": 12,
+  "base_level": 10,
   "minimum_item_rank": 0,
   "discoverable": false,
   "comment": "Area Order: Temple Outskirts Demon Extermination",
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 2502
+      "amount": 1864
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1797
+      "amount": 1086
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 759
+      "amount": 522
     }
   ],
   "blocks": [
@@ -39,8 +39,8 @@
     {
       "type": "KillTargetEnemies",
       "announce_type": "Accept",
-      "enemy_id": "79",
-      "level": 12,
+      "enemy_id": "101",
+      "level": 10,
       "amount": 1
     }
   ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000030.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 11862
+      "amount": 7547
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 30657
+      "amount": 19506
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 3630
+      "amount": 2309
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000050.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000050.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1518
+      "amount": 1380
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 690
+      "amount": 627
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 375
+      "amount": 341
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000070.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000070.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 3228
+      "amount": 2560
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 3876
+      "amount": 3074
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 1194
+      "amount": 947
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000090.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000090.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 5811
+      "amount": 3840
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 22041
+      "amount": 14568
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 3051
+      "amount": 2016
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000110.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000110.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 11862
+      "amount": 7547
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 30657
+      "amount": 19506
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 3630
+      "amount": 2309
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000130.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000130.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1518
+      "amount": 1380
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 690
+      "amount": 627
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 375
+      "amount": 341
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000150.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000150.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 5241
+      "amount": 3552
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 17679
+      "amount": 11984
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 2715
+      "amount": 1840
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000170.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000170.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 21138
+      "amount": 13007
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 41052
+      "amount": 25261
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4230
+      "amount": 2602
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000184.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000184.json
@@ -5,7 +5,7 @@
   "base_level": 40,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Looking for a Hero!!",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000185.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000185.json
@@ -5,7 +5,7 @@
   "base_level": 42,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "If Your Hands are Free",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000186.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000186.json
@@ -5,7 +5,7 @@
   "base_level": 42,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "I'll Test You",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000187.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000187.json
@@ -5,7 +5,7 @@
   "base_level": 43,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "A Safe Zoma!",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000190.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000190.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 22764
+      "amount": 13604
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 53334
+      "amount": 31874
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4851
+      "amount": 2899
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000191.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000191.json
@@ -5,7 +5,7 @@
   "base_level": 21,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Dealing in Zandora Goods",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000193.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000193.json
@@ -5,7 +5,7 @@
   "base_level": 21,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Any Great Finds?",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000195.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000195.json
@@ -5,7 +5,7 @@
   "base_level": 46,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "However You Can Get Your Hands on It!",
   "light_quest_details": {
     "area_id": 11,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000208.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000208.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 6021
+      "amount": 3947
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 23628
+      "amount": 15492
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 3165
+      "amount": 2075
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000209.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000209.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 6021
+      "amount": 3947
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 23628
+      "amount": 15492
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 3165
+      "amount": 2075
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000210.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000210.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 6021
+      "amount": 3947
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 23628
+      "amount": 15492
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 3165
+      "amount": 2075
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000230.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000230.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1518
+      "amount": 1380
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 690
+      "amount": 627
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 375
+      "amount": 341
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000250.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000250.json
@@ -2,7 +2,7 @@
   "state_machine": "GenericStateMachine",
   "type": "Light",
   "quest_id": 40000250,
-  "base_level": 55,
+  "base_level": 60,
   "minimum_item_rank": 0,
   "discoverable": false,
   "comment": "Area Order: Mergoda Demon Extermination",
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 24414
+      "amount": 25670
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 67602
+      "amount": 47850
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 5490
+      "amount": 3503
     }
   ],
   "blocks": [
@@ -39,8 +39,8 @@
     {
       "type": "KillTargetEnemies",
       "announce_type": "Accept",
-      "enemy_id": "105",
-      "level": 55,
+      "enemy_id": "26",
+      "level": 60,
       "amount": 1
     }
   ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000254.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000254.json
@@ -2,7 +2,7 @@
   "state_machine": "GenericStateMachine",
   "type": "Light",
   "quest_id": 40000254,
-  "base_level": 51,
+  "base_level": 50,
   "minimum_item_rank": 0,
   "discoverable": false,
   "comment": "Essence Extraction",
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 5381
+      "amount": 5311
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 13072
+      "amount": 12444
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 1161
+      "amount": 1131
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000266.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000266.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 21138
+      "amount": 13007
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 41052
+      "amount": 25261
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4230
+      "amount": 2602
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000267.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000267.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 21138
+      "amount": 13007
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 41052
+      "amount": 25261
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4230
+      "amount": 2602
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000268.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000268.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 21138
+      "amount": 13007
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 41052
+      "amount": 25261
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4230
+      "amount": 2602
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000269.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000269.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 21138
+      "amount": 13007
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 41052
+      "amount": 25261
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4230
+      "amount": 2602
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000270.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000270.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 22764
+      "amount": 13604
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 53334
+      "amount": 31874
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4851
+      "amount": 2899
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000286.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000286.json
@@ -5,7 +5,7 @@
   "base_level": 45,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Investigate Wasteland Creatures",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000288.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000288.json
@@ -5,7 +5,7 @@
   "base_level": 50,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Notice to Forbidden Zone Explorers: Regarding Enemy Encounters",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 22764
+      "amount": 13604
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 53334
+      "amount": 31874
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4851
+      "amount": 2899
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000289.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000289.json
@@ -5,7 +5,7 @@
   "base_level": 50,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Instructions to Forbidden Zone Explorers: Regarding Enemy Encounters",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 22764
+      "amount": 13604
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 53334
+      "amount": 31874
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 4851
+      "amount": 2899
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000290.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000290.json
@@ -14,17 +14,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 24414
+      "amount": 14224
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 67602
+      "amount": 39388
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 5490
+      "amount": 3198
     }
   ],
   "blocks": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000293.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000293.json
@@ -5,7 +5,7 @@
   "base_level": 21,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Deserving Close Inspection",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000294.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000294.json
@@ -5,7 +5,7 @@
   "base_level": 41,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "An Epicure Seeks Spices",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000295.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000295.json
@@ -5,7 +5,7 @@
   "base_level": 46,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "For a Friend with Unusual Tastes",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000297.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000297.json
@@ -5,7 +5,7 @@
   "base_level": 36,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "May I Ask A Favor?",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000298.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40000298.json
@@ -5,7 +5,7 @@
   "base_level": 21,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "comment": "!untranslated!",
+  "comment": "Notice to Forbidden Zone Explorers: Regarding Acquired Items",
   "light_quest_details": {
     "area_id": 10,
     "board_type": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200001.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200001,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Teach Them a Lesson",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "278",
+      "level": 63,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200002.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200002,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "For Clean Bedsheets",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "279",
+      "level": 63,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200003.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200003,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Set Off By a Robbery",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "215",
+      "level": 63,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200004.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200004,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Flower's Revenge",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "185",
+      "level": 63,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200005.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200005,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Securing Transport Routes",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "182",
+      "level": 63,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200006.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200006,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Investigating Bloodbane Isle Wildlife Activities",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "42",
+      "level": 63,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200007.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200007,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Half of the Crowd",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19558
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 31603
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2183
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "249",
+      "level": 63,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200008.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200008,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Cooperate with Subjugation",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 15013
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 27985
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2049
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "211",
+      "level": 60,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200009.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200009,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "To Maintain a Clean Environment",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 25670
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 47850
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3503
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "83",
+      "level": 60,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200010.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200010,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Bloodbane Isle Demon Extermination",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 14372
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41004
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3258
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "98",
+      "level": 56,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200011.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200011,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Investigating Medicine's Effects",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 865
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1484
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 366
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7981,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200012.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200012,
+  "base_level": 26,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Supplies for a Souvenir",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1008
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2482
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 483
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7848,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200013.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200013,
+  "base_level": 6,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Bath After Work",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 302
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 131
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 72
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7994,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200014.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200014,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Where Is It",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5070
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 10115
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1015
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 8018,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200015.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200015,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Back Alley Market Demand",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5070
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 10115
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1015
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 9059,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200016.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200016,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Wanting to Help Investigate",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 865
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1484
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 366
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7967,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200017.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200017,
+  "base_level": 41,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "For the Bloodbane Isle Scouts With Strange Tastes",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3361
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 7604
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 874
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7859,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200018.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200018,
+  "base_level": 41,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "My Thanks",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3361
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 7604
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 874
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7898,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200019.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200019,
+  "base_level": 36,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Bloodbane Isle Delicacy",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 16
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1404
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5513
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 738
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7830,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200021.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200021,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "For A Quiet Rest",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 64005
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 67824
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4132
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "254",
+      "level": 70,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200022.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200022.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200022,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Teeth Marks on the Calf",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 64005
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 67824
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4132
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "240",
+      "level": 70,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200023.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200023,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Run-In on the Path",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 37301
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 57313
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3814
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "246",
+      "level": 65,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200024.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200024,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "I Could Use a Hand Sometimes",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 25670
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 47850
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3503
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "79",
+      "level": 60,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200025.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200025.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200025,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Pang of Conscience",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 37301
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 57313
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3814
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "25",
+      "level": 65,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200026.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200026,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Preparing for Major Cleanup",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 163559
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 92193
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4789
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "255",
+      "level": 80,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200027.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200027,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Cause of My Back Pain",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 163559
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 92193
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4789
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "241",
+      "level": 80,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200028.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200028.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200028,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "We All Need Rest",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 163559
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 92193
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4789
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "245",
+      "level": 80,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200031.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200031.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200031,
+  "base_level": 54,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Self-Sufficiency for Health",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5613
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 15069
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1250
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 11408,
+          "amount": 10
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200032.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200032.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200032,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "If There's Any Left Over",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15971,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200033.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200033.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200033,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Just This Once",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 16497
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1311
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 11774,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200034.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200034.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200034,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Sample is Just as Reported",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15963,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200035.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200035.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200035,
+  "base_level": 82,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Substitute for a Poultice",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 73500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 42691
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2153
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 17873,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200036.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200036.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200036,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Buyback Prices Up",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15927,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200037.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200037.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200037,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Fun at Bloodbane Isle",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15926,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200038.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200038.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200038,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "An Addictive Flavor",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16116,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200039.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200039.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200039,
+  "base_level": 54,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Please Procure This Privately",
+  "light_quest_details": {
+    "area_id": 13,
+    "board_type": 1,
+    "board_id": 17
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5613
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 15069
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1250
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 11504,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200041.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200041.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200041,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Warning to Travelers",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "184",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200042.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200042.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200042,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Laundry Thief",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "213",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200043.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200043.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200043,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "I've Been Wondering",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "186",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200044.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200044.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200044,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Driven From Their Homes",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "192",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200045.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200045.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200045,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Springing Out From the Shade of a Tree",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "197",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200046.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200046.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200046,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Wounded Demon",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "44",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200047.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200047.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200047,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "An Unsettled Gaze",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "252",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200048.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200048.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200048,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Punishment for Ransacking Books",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "43",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200049.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200049.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200049,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Rumors on the Wind",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "249",
+      "level": 73,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200050.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200050.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200050,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Elan Demon Extermination",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "250",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200051.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200051.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200051,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Shopping List for Next Time",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15947,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200052.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200052.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200052,
+  "base_level": 11,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Specially Made Equipment",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 543
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 158
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7980,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200053.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200053.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200053,
+  "base_level": 11,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "I Don't Want to Cause Trouble",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 543
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 158
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7845,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200054.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200054.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200054,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Hermitage's Refurbished Goods",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 865
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1484
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 366
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7967,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200055.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200055.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200055,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Trap for Hunting Deer",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15949,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200056.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200056.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200056,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Smoke to Enhance the Flavor",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15948,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200057.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200057.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200057,
+  "base_level": 76,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Polish Into Beads",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 53396
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 35317
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1950
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16120,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200058.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200058.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200058,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A New Prototype",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15925,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200059.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200059.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200059,
+  "base_level": 74,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Agreed Too Quickly",
+  "light_quest_details": {
+    "area_id": 14,
+    "board_type": 1,
+    "board_id": 18
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 43248
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 33044
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1884
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16002,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200061.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200061.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200061,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Today's Record",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "292",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200062.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200062.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200062,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Precautionary Extermination",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "288",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200063.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200063.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200063,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Protect the Food Warehouse!",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "214",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200064.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200064.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200064,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Hindering Restock",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "50",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200065.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200065.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200065,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Hindering Food Procurement",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "46",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200066.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200066.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200066,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Expectations Unmet",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "246",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200067.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200067.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200067,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Little Watchman",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 64005
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 67824
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4132
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "240",
+      "level": 70,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200068.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200068.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200068,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Veteran's Claim",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 64005
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 67824
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4132
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "250",
+      "level": 70,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200069.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200069.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200069,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Why the Deer Are Fewer",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "206",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200070.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200070.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200070,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Farana Demon Extermination",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "258",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200071.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200071.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200071,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "An Errand While You're Here",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15944,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200072.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200072.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200072,
+  "base_level": 82,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Losing Streak",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 73500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 42691
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2153
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 17873,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200073.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200073.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200073,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Girl's Inquisitive Mind",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 71211
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 40140
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2085
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 18655,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200074.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200074.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200074,
+  "base_level": 82,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "In Search of Delicious Liquor",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 73500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 42691
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2153
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 17856,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200075.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200075.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200075,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "We Don't Handle Those Goods",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15969,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200076.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200076.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200076,
+  "base_level": 54,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Sudden Need",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5613
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 15069
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1250
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 11408,
+          "amount": 10
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200077.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200077.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200077,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Preparing for a Trip",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 16497
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1311
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 13223,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200078.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200078.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200078,
+  "base_level": 26,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "It Flew Off the Shelves",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1008
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2482
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 483
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7849,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200079.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200079.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200079,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Demon-Warding Incense",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 19
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15945,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200081.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200081.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200081,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Researching Each Day's Exhaustion",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "185",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200082.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200082.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200082,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Afraid to Walk Alone",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "279",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200083.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200083.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200083,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Blood of the Clamoring Beasts",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "278",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200084.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200084.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200084,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "They're After the Crops",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "194",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200085.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200085.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200085,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Usual Subjugation Efforts",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "291",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200086.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200086.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200086,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Detestable Herb Thief",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "227",
+      "level": 75,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200087.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200087.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200087,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Ensure the Children's Safety",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "230",
+      "level": 75,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200088.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200088.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200088,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Reawakened Memories",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "228",
+      "level": 75,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200089.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200089.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200089,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Prayer for Everyone's Safety",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "231",
+      "level": 75,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200090.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200090.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200090,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Morrow Demon Extermination",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 64005
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 67824
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4132
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "280",
+      "level": 70,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200091.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200091.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200091,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Perfect Inventory Management",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15952,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200092.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200092.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200092,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Overworked Watchman",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 865
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1484
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 366
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7981,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200093.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200093.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200093,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Shadows of That Damned Lot",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15950,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200094.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200094.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200094,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Is It Bug Repellent?",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15951,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200095.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200095.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200095,
+  "base_level": 31,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Before the Balm Runs Out",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1182
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3815
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 608
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7995,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200096.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200096.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200096,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Secret Pet",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15959,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200097.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200097.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200097,
+  "base_level": 54,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Request for You",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5613
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 15069
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1250
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 11408,
+          "amount": 10
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200098.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200098.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200098,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Traveler's Souvenirs",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15953,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200099.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200099.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200099,
+  "base_level": 72,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Not Fit for a Field",
+  "light_quest_details": {
+    "area_id": 16,
+    "board_type": 1,
+    "board_id": 20
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 34498
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 30861
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1817
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16008,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200101.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200101.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200101,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Material to Persuade Mama",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "29",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200102.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200102.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200102,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "If Only I Had a Weapon",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "260",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200103.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200103.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200103,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Soldier's Intuition",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "294",
+      "level": 75,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200104.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200104.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200104,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Watch Over the Village Yourselves",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "295",
+      "level": 75,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200105.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200105.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200105,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Secret Place for Picking Herbs",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "287",
+      "level": 75,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200106.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200106.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200106,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Some Kind of Curse?",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "211",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200107.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200107.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200107,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Small Matter to Settle",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "165",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200108.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200108.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200108,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "What Attacked the Cows",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "55",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200109.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200109.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200109,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Gate Is the Face of the Village",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "164",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200110.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200110.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200110,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Kingal Demon Extermination",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "23",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200111.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200111.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200111,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Just Want to Play",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15953,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200112.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200112.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200112,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Substitute for Fishing Bait",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15955,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200113.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200113.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200113,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Unique Firestarter Recipe",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15954,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200114.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200114.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200114,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Base for Tomorrow's Milk",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5070
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 10115
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1015
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 8018,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200115.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200115.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200115,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Everyone's Favorite Meat Pies!",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15973,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200116.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200116.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200116,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Even If It's For Harvesting",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5070
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 10115
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1015
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7911,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200117.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200117.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200117,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Gourmet Livestock",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5070
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 10115
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1015
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7753,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200118.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200118.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200118,
+  "base_level": 52,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Repair Materials for the Wall",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5455
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 13719
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1190
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 9441,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200119.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200119.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200119,
+  "base_level": 72,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The State of Shena's Kitchen",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 21
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 34498
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 30861
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1817
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16008,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200121.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200121.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200121,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "To A Strong Person",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 30782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 38230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2411
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "37",
+      "level": 68,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200122.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200122.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200122,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Scare Them Off",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "34",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200123.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200123.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200123,
+  "base_level": 69,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Loitering Footsteps",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 34532
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 39648
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2458
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "190",
+      "level": 69,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200124.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200124.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200124,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "No More Being Scared",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "182",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200125.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200125.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200125,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "So Scary I Can't Sleep",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "50",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200126.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200126.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200126,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Those Monsters Will Be Back",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 38782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 41096
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2504
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "187",
+      "level": 70,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200127.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200127.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200127,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "This Rare Settlement",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "191",
+      "level": 75,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200128.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200128.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200128,
+  "base_level": 69,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "I'll Pay Up",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 57167
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 65636
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4069
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "251",
+      "level": 69,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200129.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200129.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200129,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Gazing with Goggling Eyes",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "239",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200130.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200130.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200130,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Manun Demon Extermination",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 167078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 106151
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 5128
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "351",
+      "level": 85,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200131.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200131.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200131,
+  "base_level": 74,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Darin's Request",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 43248
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 33044
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1884
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16001,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200132.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200132.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200132,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "The Guard is Busy",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 865
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1484
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 366
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7981,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200133.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200133.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200133,
+  "base_level": 26,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Hough's Secret Field",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1008
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2482
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 483
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7861,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200134.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200134.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200134,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "For Oncoming Age",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15944,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200135.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200135.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200135,
+  "base_level": 26,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Trap to Protect the Village",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1008
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2482
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 483
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7879,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200136.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200136.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200136,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Vora's Mean Trick",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15913,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200137.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200137.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200137,
+  "base_level": 31,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Recent Favorites",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1182
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3815
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 608
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 7857,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200138.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200138.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200138,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Unique Repair Materials",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 21547
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 26761
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1687
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15946,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200139.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200139.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200139,
+  "base_level": 66,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Where Did That Bag Go?",
+  "light_quest_details": {
+    "area_id": 15,
+    "board_type": 1,
+    "board_id": 22
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16995
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 24841
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1624
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15960,
+          "amount": 3
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200141.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200141.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200141,
+  "base_level": 78,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Tell Me What You Said Just Now",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 91599
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 53832
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2882
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "261",
+      "level": 78,
+      "amount": 2
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200142.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200142.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200142,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Clamor That Reaches the Tower",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 68782
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 48814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2739
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "212",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200143.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200143.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200143,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Reason for the Reduced Harvest",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "100",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200144.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200144.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200144,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Broken Basket",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "27",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200145.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200145.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200145,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Worried for the Young Ones",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "99",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200146.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200146.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200146,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Commotion in the Tower",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 55284
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 45631
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2644
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "30",
+      "level": 73,
+      "amount": 3
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200147.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200147.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200147,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Ensuring Safety if Nothing Else",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "244",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200148.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200148.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200148,
+  "base_level": 78,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "An Elder's Monologue",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 147949
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 86948
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4654
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "242",
+      "level": 78,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200149.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200149.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200149,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Briefing to Capture the Tower?",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 111928
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 79435
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 4457
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "272",
+      "level": 75,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200150.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200150.json
@@ -1,0 +1,47 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200150,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Area Order: Tower of Ivanos Outskirts Demon\nExtermination",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 167078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 106151
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 5128
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "KillTargetEnemies",
+      "announce_type": "Accept",
+      "enemy_id": "372",
+      "level": 85,
+      "amount": 1
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200151.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200151.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200151,
+  "base_level": 62,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Materials Brought Back from Afar",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 23060
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 36060
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2538
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 11805,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200152.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200152.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200152,
+  "base_level": 82,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Message Postponed",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 117659
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 68341
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3446
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 17866,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200153.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200153.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200153,
+  "base_level": 76,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "A Trickster's Proposal",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 86669
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 57325
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3165
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15996,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200154.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200154.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200154,
+  "base_level": 72,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Carrying One's Provisions",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 56601
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 50634
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2982
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16013,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200155.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200155.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200155,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Transaction Strategies",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 44803
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 47477
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2892
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15934,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200156.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200156.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200156,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Scrubbed Tiles",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 44803
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 47477
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2892
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 15933,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200157.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200157.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200157,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "An Optimist's Proposal",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 44803
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 47477
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2892
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 16117,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200158.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200158.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200158,
+  "base_level": 82,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Scrimping and Saving",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 117659
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 68341
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 3446
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 17856,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200159.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q40200159.json
@@ -1,0 +1,50 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "Light",
+  "quest_id": 40200159,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "comment": "Anxious Hoarding",
+  "light_quest_details": {
+    "area_id": 17,
+    "board_type": 1,
+    "board_id": 23
+  },
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 10060
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 28702
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 2281
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [
+        {
+          "type": "EmDieLight"
+        }
+      ]
+    },
+    {
+      "type": "DeliverItemsLight",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 13223,
+          "amount": 1
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestBoardBaseId.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestBoardBaseId.cs
@@ -23,7 +23,10 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         Dana = 19, // Dana, Dana Centrum
         Morfaul = 20, // Morfaul, Morfaul Centrum
         Glyndwr = 21, // Glyndwr, Glyndwr Centrum
-
+        ManunVillage = 22,
+        TowerOfIvanos = 23,
+        ClanBoard = 24, // For the first set of clan quests
+        ClanBoardHighDifficulty = 25, // For the second quest of clan quests
         RathniteFoothills = 26, // All of Rathnite Foothills
         FelyanaWilderness = 27, // All of Felyana Wilderness
         SpecialQuestBoard = 28, // In WDT, possibly elsewhere.


### PR DESCRIPTION
Adds another 100-odd board quests for the following quest boards:
- Bloodbane Isle Expedition Base North and South
- Protector's Retreat, Elan Water Grove
- Dana Centrum, Falana Plains
- Manun Village, Falana Plains
- Morfaul Centrum, Morrow Woods
- Glyndwr Centrum, Kingal Canyon
- Tower of Ivanos, Kingal Canyon

Also tweaks some of the targets for S1 board targets and reduces some of the "large boss" rewards multiplier (from 3 at all levels to 3.0~1.5 decaying with level).

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
