### PR TITLE
Hotfix for Area Rank Party Issues

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/AreaGetLeaderAreaReleaseListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/AreaGetLeaderAreaReleaseListHandler.cs
@@ -26,15 +26,23 @@ namespace Arrowgene.Ddon.GameServer.Handler
             //var pcap = EntitySerializer.Get<S2CAreaGetLeaderAreaReleaseListRes>().Read(GameFull.data_Dump_117);
 
             var result = new S2CAreaGetLeaderAreaReleaseListRes();
-            var clientRank = client.Character.AreaRanks;
-            var completedQuests = client.Character.CompletedQuests;
-            foreach ((var area, var rank) in clientRank)
+            var leader = client.Party.Leader;
+
+            if (client.Party.Leader is null)
+            {
+                // No unlocks without a leader to pull AR from.
+                return result;
+            }
+
+            var leaderRank = leader.Client.Character.AreaRanks;
+            var completedQuests = leader.Client.Character.CompletedQuests;
+            foreach ((var area, var rank) in leaderRank)
             {
                 // The client gets very angry if the unlocks are desynced from their actual ranks,
                 // so spoof the rank in AreaGetAreaBaseInfoListHandler too.
                 var releaseList = Server.AssetRepository.AreaRankSpotInfoAsset[area]
                 .Where(spot => spot.UnlockRank > 0 || spot.UnlockQuest > 0)
-                .Where(spot => Server.AreaRankManager.CheckSpot(client, spot))
+                .Where(spot => Server.AreaRankManager.CheckSpot(leader.Client, spot))
                 .Select(spot => new CDataCommonU32(spot.SpotId))
                 .ToList();
 

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -21,11 +21,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             PacketQueue queue = new();
             S2CStageAreaChangeRes res = new S2CStageAreaChangeRes();
-            res.StageNo = (uint) StageManager.ConvertIdToStageNo(packet.StageId);
-            res.IsBase = false; // This is set true for audience chamber and WDT for example
+            res.StageNo = StageManager.ConvertIdToStageNo(packet.StageId);
+            res.IsBase = StageManager.IsSafeArea(packet.StageId); // This is set true for audience chamber and WDT for example
 
             // Order is notices sent manually, then the response, then other queued notices for Epitaph Road stuff.
-            client.Enqueue(res, queue); 
 
             uint previousStageId = client.Character.Stage.Id;
 
@@ -43,9 +42,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 pawn.StageNo = res.StageNo;
             }
 
-            if (StageManager.IsSafeArea(client.Character.Stage))
+            if (res.IsBase)
             {
-                res.IsBase = true;
                 client.Character.LastSafeStageId = packet.StageId;
 
                 bool shouldReset = true;
@@ -74,6 +72,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     client.Party.SendToAll(new S2CInstanceAreaResetNtc());
                 }
             }
+
+            client.Enqueue(res, queue);
 
             if (client.Party.ExmInProgress && BoardManager.BoardIdIsExm(client.Party.ContentId))
             {


### PR DESCRIPTION
Quick hotfix.
 - Fix party functions in inns. 
 - Fix area rank unlocks not depending on the leader's state rather than the individual state.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
