### PR TITLE
Fix: Verbose storage errors

### DIFF
--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -120,7 +120,7 @@ namespace Arrowgene.Ddon.Database
             Character searchingCharacter,
             CDataPawnSearchParameter searchParams
         );
-        bool DeletePawn(uint pawnId);
+        bool DeletePawn(uint pawnId, DbConnection? connectionIn = null);
         bool UpdatePawnBaseInfo(Pawn pawn, DbConnection? connectionIn = null);
         uint GetPawnOwnerCharacterId(uint pawnId, DbConnection? connectionIn = null);
         bool ReplacePawnReaction(uint pawnId, CDataPawnReaction pawnReaction, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -385,16 +385,19 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return pawns;
         }
 
-        public bool DeletePawn(uint pawnId)
+        public bool DeletePawn(uint pawnId, DbConnection? connectionIn = null)
         {
-            int rowsAffected = ExecuteNonQuery(
-                SqlDeletePawn,
-                command =>
-                {
-                    AddParameter(command, "@pawn_id", pawnId);
-                }
-            );
-            return rowsAffected > NoRowsAffected;
+            return ExecuteQuerySafe<int>(connectionIn, connection =>
+            {
+                return ExecuteNonQuery(
+                    connection,
+                    SqlDeletePawn,
+                    command =>
+                    {
+                        AddParameter(command, "@pawn_id", pawnId);
+                    }
+                );
+            }) > NoRowsAffected;
         }
 
         public bool UpdatePawnBaseInfo(Pawn pawn, DbConnection? connectionIn = null)

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -209,7 +209,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool DeleteEquippedAbility(uint commonId, JobId equippedToJob, byte slotNo) { return true; }
         public bool DeleteEquippedCustomSkill(uint commonId, JobId job, byte slotNo) { return true; }
         public bool DeleteNormalSkillParam(uint commonId, JobId job, uint skillNo) { return true; }
-        public bool DeletePawn(uint pawnId) { return true; }
+        public bool DeletePawn(uint pawnId, DbConnection? connectionIn = null) { return true; }
         public bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null) { return true; }
         public bool DeleteReleasedWarpPoint(uint characterId, uint warpPointId) { return true; }
         public bool DeleteShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }


### PR DESCRIPTION
Make the error logging slightly more clear for server owners when somebody's storage gets messed up and they have to be manually untangled.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
