### PR TITLE
Hotfix: Fix item unlocks not mirroring properly in memory without a relog.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -253,6 +253,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     ItemId = (uint)item
                 }, queue);
                 var unlockType = itemInfo.Category == 6 ? UnlockableItemCategory.FurnitureItem : UnlockableItemCategory.CraftingRecipe;
+                client.Character.UnlockableItems.Add((unlockType, (uint)item));
                 _Server.Database.InsertUnlockedItem(client.Character.CharacterId, unlockType, (uint)item, connectionIn);
                 return (queue, true);
             }


### PR DESCRIPTION

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
