### PR TITLE
Improve TEX/DDS conversion

### DIFF
--- a/Arrowgene.Ddon.Client/ArcArchive.cs
+++ b/Arrowgene.Ddon.Client/ArcArchive.cs
@@ -331,7 +331,7 @@ namespace Arrowgene.Ddon.Client
             File.WriteAllBytes(fileInfo.FullName, file.Data);
         }
 
-        protected override void Read(IBuffer buffer)
+        public override void Read(IBuffer buffer)
         {
             _files.Clear();
 
@@ -380,7 +380,7 @@ namespace Arrowgene.Ddon.Client
             }
         }
 
-        protected override void Write(IBuffer buffer)
+        public override void Write(IBuffer buffer)
         {
             byte[] magicTag = Encoding.UTF8.GetBytes(MagicTag);
             buffer.WriteBytes(magicTag);

--- a/Arrowgene.Ddon.Client/ClientFile.cs
+++ b/Arrowgene.Ddon.Client/ClientFile.cs
@@ -61,9 +61,9 @@ namespace Arrowgene.Ddon.Client
             Open(buffer);
         }
 
-        protected abstract void Read(IBuffer buffer);
+        public abstract void Read(IBuffer buffer);
 
-        protected abstract void Write(IBuffer buffer);
+        public abstract void Write(IBuffer buffer);
 
         protected void WriteMtString(IBuffer buffer, string str)
         {

--- a/Arrowgene.Ddon.Client/Resource/StageToSpot.cs
+++ b/Arrowgene.Ddon.Client/Resource/StageToSpot.cs
@@ -19,7 +19,7 @@ namespace Arrowgene.Ddon.Client.Resource
             Entries = new List<Entry>();
         }
 
-        protected override void Read(IBuffer buffer)
+        public override void Read(IBuffer buffer)
         {
             uint data = buffer.ReadUInt32();
             uint dataNum = buffer.ReadUInt32();
@@ -30,7 +30,7 @@ namespace Arrowgene.Ddon.Client.Resource
             }
         }
 
-        protected override void Write(IBuffer buffer)
+        public override void Write(IBuffer buffer)
         {
             throw new System.NotImplementedException();
         }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Dds/DdsHeaderFlags.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Dds/DdsHeaderFlags.cs
@@ -5,9 +5,12 @@ namespace Arrowgene.Ddon.Client.Resource.Texture.Dds;
 [Flags]
 public enum DdsHeaderFlags : uint
 {
-    Texture = 0x00001007,
-    MipMap = 0x00020000,
-    Volume = 0x00800000,
-    Pitch = 0x00000008,
-    LinearSize = 0x00080000,
+    Caps = 0x1,            
+    Height = 0x2,          
+    Width = 0x4,           
+    Pitch = 0x8,           
+    PixelFormat = 0x1000,  //13
+    MipMapCount = 0x20000, //18
+    LinearSize = 0x80000,  //20
+    Depth = 0x800000,      //24
 }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Dds/DdsTexture.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Dds/DdsTexture.cs
@@ -85,7 +85,7 @@ namespace Arrowgene.Ddon.Client.Resource.Texture.Dds
             else
             {
                 Metadata.ArraySize = 1;
-                if (Header.Flags.HasFlag(DdsHeaderFlags.Volume))
+                if (Header.Flags.HasFlag(DdsHeaderFlags.Depth))
                 {
                     Metadata.Dimension = TexDimension.Texture3D;
                 }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Dds/DdsTexture.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Dds/DdsTexture.cs
@@ -142,10 +142,8 @@ namespace Arrowgene.Ddon.Client.Resource.Texture.Dds
             }
         }
 
-        public void Save(string path)
+        protected override void WriteResource(IBuffer buffer)
         {
-            StreamBuffer buffer = new StreamBuffer();
-            buffer.WriteString(DdsHeader.Magic);
             buffer.WriteUInt32(Header.Size);
             buffer.WriteUInt32((uint) Header.Flags);
             buffer.WriteUInt32(Header.Height);
@@ -185,7 +183,12 @@ namespace Arrowgene.Ddon.Client.Resource.Texture.Dds
             {
                 buffer.WriteBytes(Images[i].Data);
             }
+        }
 
+        public void Save(string path)
+        {
+            StreamBuffer buffer = new StreamBuffer();
+            Write(buffer);
             File.WriteAllBytes(path, buffer.GetAllBytes());
         }
     }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Dds/PixelFormat.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Dds/PixelFormat.cs
@@ -16,6 +16,11 @@ public struct DDSPixelFormat
                (uint) Convert.ToByte(char4) << 24;
     }
 
+    public static string FormatFourCc(uint fourCc)
+    {
+        return $"{(char) (fourCc & 0xFF)}{(char) ((fourCc >> 8) & 0xFF)}{(char) ((fourCc >> 16) & 0xFF)}{(char) ((fourCc >> 24) & 0xFF)}";
+    }
+
     public uint Size;
     public DdsPixelFormatFlag Flags;
     public uint FourCc;

--- a/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeader.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeader.cs
@@ -6,6 +6,10 @@ public struct TexHeader
 {
     public const int Size = 12;
 
+    public uint _header4;
+    public uint _header8;
+    public uint _header12;
+
     public TexHeaderVersion Version;
     public uint Height;
     public uint Width;
@@ -23,25 +27,15 @@ public struct TexHeader
 
     public void Decode(byte[] bytes)
     {
-        uint header4 = BitConverter.ToUInt32(bytes, 0);
-        uint header8 = BitConverter.ToUInt32(bytes, 4);
-        uint header12 = BitConverter.ToUInt32(bytes, 8);
+        _header4 = BitConverter.ToUInt32(bytes, 0);
+        _header8 = BitConverter.ToUInt32(bytes, 4);
+        _header12 = BitConverter.ToUInt32(bytes, 8);
 
-        HasSphericalHarmonicsFactor = (header4 & 0xF0000000) == 0x60000000;
+        HasSphericalHarmonicsFactor = (_header4 & 0xF0000000) == 0x60000000;
 
-        uint versionBits16__0_15 = header4 & ((1 << 16) - 1);
-        uint alphaBits8__16_23 = (header4 >> 16) & ((1 << 8) - 1);
-        uint shiftBits4__24_27 = (header4 >> 24) & ((1 << 4) - 1);
-        uint typeBits4__28_31 = (header4 >> 28) & ((1 << 4) - 1); // switchNum 1,2|3|6
-
-        uint mipMapCountBits6_0__5 = header8 & ((1 << 6) - 1);
-        uint widthBits13_6__18 = (header8 >> 6) & ((1 << 13) - 1);
-        uint heightBits13_19__31 = (header8 >> 19) & ((1 << 13) - 1);
-
-        uint textureArraySizeBits8__0_7 = header12 & ((1 << 8) - 1);
-        uint pixelFormatBits8__8_15 = (header12 >> 8) & ((1 << 8) - 1);
-        uint depthBits13__16_28 = (header12 >> 16) & ((1 << 13) - 1);
-        uint unkBits3__29_31 = (header12 >> 29) & ((1 << 3) - 1);
+        _parseHeader4(_header4, out var versionBits16__0_15, out var alphaBits8__16_23, out var shiftBits4__24_27, out var typeBits4__28_31);
+        _parseHeader8(_header8, out var mipMapCountBits6_0__5, out var widthBits13_6__18, out var heightBits13_19__31);
+        _parseHeader12(_header12, out var textureArraySizeBits8__0_7, out var pixelFormatBits8__8_15, out var depthBits13__16_28, out var unkBits3__29_31);
 
         Version = (TexHeaderVersion)versionBits16__0_15;
         Alpha = alphaBits8__16_23;
@@ -96,5 +90,28 @@ public struct TexHeader
         result[10] = bytes12[2];
         result[11] = bytes12[3];
         return result;
+    }
+
+    public static void _parseHeader4(uint header4, out TexHeaderVersion version, out uint alpha, out uint shift, out TexType type)
+    {
+        version = (TexHeaderVersion) (header4 & ((1 << 16) - 1));
+        alpha = (header4 >> 16) & ((1 << 8) - 1);
+        shift = (header4 >> 24) & ((1 << 4) - 1);
+        type = (TexType) ((header4 >> 28) & ((1 << 4) - 1)); // switchNum 1,2|3|6
+    }
+
+    public static void _parseHeader8(uint header8, out uint mipMapCount, out uint width, out uint height)
+    {
+        mipMapCount = header8 & ((1 << 6) - 1);
+        width = (header8 >> 6) & ((1 << 13) - 1);
+        height = (header8 >> 19) & ((1 << 13) - 1);
+    }
+
+    public static void _parseHeader12(uint header12, out uint textureArraySize, out TexPixelFormat pixelFormat, out uint depth, out uint unknownB)
+    {
+        textureArraySize = header12 & ((1 << 8) - 1);
+        pixelFormat = (TexPixelFormat) ((header12 >> 8) & ((1 << 8) - 1));
+        depth = (header12 >> 16) & ((1 << 13) - 1);
+        unknownB = (header12 >> 29) & ((1 << 3) - 1);
     }
 }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeader.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeader.cs
@@ -15,7 +15,7 @@ public struct TexHeader
     public TexPixelFormat PixelFormat;
     public byte TextureArraySize;
     public uint MipMapCount;
-    public uint UnknownA;
+    public TexType Type;
     public uint UnknownB;
     public bool HasSphericalHarmonicsFactor;
 
@@ -29,10 +29,10 @@ public struct TexHeader
 
         HasSphericalHarmonicsFactor = (header4 & 0xF0000000) == 0x60000000;
 
-        uint versionBits12__0_11 = header4 & ((1 << 12) - 1);
-        uint alphaBits12__12_23 = (header4 >> 12) & ((1 << 12) - 1);
+        uint versionBits16__0_15 = header4 & ((1 << 16) - 1);
+        uint alphaBits8__16_23 = (header4 >> 16) & ((1 << 8) - 1);
         uint shiftBits4__24_27 = (header4 >> 24) & ((1 << 4) - 1);
-        uint unkBits4__28_31 = (header4 >> 28) & ((1 << 4) - 1); // switchNum 1,2|3|6
+        uint typeBits4__28_31 = (header4 >> 28) & ((1 << 4) - 1); // switchNum 1,2|3|6
 
         uint mipMapCountBits6_0__5 = header8 & ((1 << 6) - 1);
         uint widthBits13_6__18 = (header8 >> 6) & ((1 << 13) - 1);
@@ -43,10 +43,10 @@ public struct TexHeader
         uint depthBits13__16_28 = (header12 >> 16) & ((1 << 13) - 1);
         uint unkBits3__29_31 = (header12 >> 29) & ((1 << 3) - 1);
 
-        Version = (TexHeaderVersion)versionBits12__0_11;
-        Alpha = alphaBits12__12_23;
+        Version = (TexHeaderVersion)versionBits16__0_15;
+        Alpha = alphaBits8__16_23;
         Shift = shiftBits4__24_27;
-        UnknownA = unkBits4__28_31;
+        Type = (TexType)typeBits4__28_31;
         MipMapCount = mipMapCountBits6_0__5;
         Width = widthBits13_6__18 << (byte) shiftBits4__24_27;
         Height = heightBits13_19__31 << (byte) shiftBits4__24_27;
@@ -62,7 +62,7 @@ public struct TexHeader
             (uint) Version
             | ((uint) Alpha << 12)
             | ((uint) Shift << 24)
-            | ((uint) UnknownA << 28);
+            | ((uint) Type << 28);
 
         if (HasSphericalHarmonicsFactor)
         {

--- a/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeaderVersion.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeaderVersion.cs
@@ -1,8 +1,8 @@
 ﻿namespace Arrowgene.Ddon.Client.Resource.Texture.Tex;
 
-public enum TexHeaderVersion : byte
+public enum TexHeaderVersion : short
 {
     Unknown = 0,
-    Ddon = 0x9D,
-    Ddda = 0x99
+    Ddon = 0x209D,
+    Ddda = 0x0099 // TODO: Verify this
 }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeaderVersion.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexHeaderVersion.cs
@@ -4,5 +4,5 @@ public enum TexHeaderVersion : short
 {
     Unknown = 0,
     Ddon = 0x209D,
-    Ddda = 0x0099 // TODO: Verify this
+    Ddda = 0x0099
 }

--- a/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexType.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/Tex/TexType.cs
@@ -1,0 +1,16 @@
+namespace Arrowgene.Ddon.Client.Resource.Texture.Tex
+{
+    public enum TexType
+    {
+        Undefined = 0x0,
+        Texture1D = 0x1,
+        Texture2D = 0x2,
+        Texture3D = 0x3,
+        Texture1DArray = 0x4,
+        Texture2DArray = 0x5,
+        Cube = 0x6,
+        CubeArray = 0x7,
+        Texture2DMS = 0x8,
+        Texture2DMSArray = 0x9
+    }
+}

--- a/Arrowgene.Ddon.Client/Resource/Texture/TexConvert.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/TexConvert.cs
@@ -10,6 +10,7 @@ public static class TexConvert
     public static DdsTexture ToDdsTexture(TexTexture texTexture)
     {
         DdsTexture ddsTexture = new DdsTexture();
+        ddsTexture.Magic = DdsHeader.Magic;
         ddsTexture.Header.Size = DdsHeader.StructSize;
         ddsTexture.Header.Flags = GetDDSDFlags(texTexture.Header);
         ddsTexture.Header.Height = texTexture.Header.Height;
@@ -55,6 +56,7 @@ public static class TexConvert
         }
 
         TexTexture texTexture = new TexTexture();
+        texTexture.Magic = TexTexture.TexHeaderMagic;
         texTexture.Header.Version = headerVersion;
         texTexture.Header.Height = (uint) ddsTexture.Metadata.Height;
         texTexture.Header.Width = (uint) ddsTexture.Metadata.Width;

--- a/Arrowgene.Ddon.Client/Resource/Texture/TexConvert.cs
+++ b/Arrowgene.Ddon.Client/Resource/Texture/TexConvert.cs
@@ -1,4 +1,6 @@
-﻿using Arrowgene.Ddon.Client.Resource.Texture.Dds;
+﻿using System;
+using System.Linq;
+using Arrowgene.Ddon.Client.Resource.Texture.Dds;
 using Arrowgene.Ddon.Client.Resource.Texture.Tex;
 
 namespace Arrowgene.Ddon.Client.Resource.Texture;
@@ -9,16 +11,16 @@ public static class TexConvert
     {
         DdsTexture ddsTexture = new DdsTexture();
         ddsTexture.Header.Size = DdsHeader.StructSize;
-        ddsTexture.Header.Flags = 0; // TODO
+        ddsTexture.Header.Flags = GetDDSDFlags(texTexture.Header);
         ddsTexture.Header.Height = texTexture.Header.Height;
         ddsTexture.Header.Width = texTexture.Header.Width;
-        ddsTexture.Header.PitchOrLinearSize = 0; // TODO
+        ddsTexture.Header.PitchOrLinearSize = GetDDSPitchOrLinearSize(texTexture);
         ddsTexture.Header.Depth = texTexture.Header.Depth;
         ddsTexture.Header.MipMapCount = texTexture.Header.MipMapCount;
         ddsTexture.Header.Reserved1 = new uint[11];
-        ddsTexture.Header.PixelFormat = DDSPixelFormat.DDSPF_DXT1; // TODO
-        ddsTexture.Header.Caps = 0; // TODO
-        ddsTexture.Header.Caps2 = 0; // TODO
+        ddsTexture.Header.PixelFormat = GetDDSPixelFormat(texTexture.Header);
+        ddsTexture.Header.Caps = GetDDSCapsFlags(texTexture.Header);
+        ddsTexture.Header.Caps2 = GetDDSCaps2Flags(texTexture.Header);
         ddsTexture.Header.Caps3 = 0; // TODO
         ddsTexture.Header.Caps4 = 0; // TODO
         ddsTexture.Header.Reserved2 = 0;
@@ -46,6 +48,12 @@ public static class TexConvert
 
     public static TexTexture ToTexTexture(DdsTexture ddsTexture, TexHeaderVersion headerVersion)
     {
+        DdsHeaderFlags requiredHeaderFlags = DdsHeaderFlags.Caps | DdsHeaderFlags.Height | DdsHeaderFlags.Width | DdsHeaderFlags.PixelFormat;
+        if ((ddsTexture.Header.Flags & requiredHeaderFlags) != requiredHeaderFlags)
+        {
+            throw new Exception("Unsupported DDS header flags");
+        }
+
         TexTexture texTexture = new TexTexture();
         texTexture.Header.Version = headerVersion;
         texTexture.Header.Height = (uint) ddsTexture.Metadata.Height;
@@ -53,10 +61,10 @@ public static class TexConvert
         texTexture.Header.Shift = 0; // TODO
         texTexture.Header.Alpha = 0; // TODO
         texTexture.Header.Depth = (uint) ddsTexture.Metadata.Depth;
-        texTexture.Header.PixelFormat = 0; // TODO
+        texTexture.Header.PixelFormat = GetTexPixelFormat(ddsTexture); // TODO
         texTexture.Header.TextureArraySize = (byte) ddsTexture.Metadata.ArraySize;
         texTexture.Header.MipMapCount = (uint) ddsTexture.Metadata.MipLevels;
-        texTexture.Header.UnknownA = 0; // TODO
+        texTexture.Header.Type = GetTexType(ddsTexture.Header);
         texTexture.Header.UnknownB = 0; // TODO
         texTexture.Header.HasSphericalHarmonicsFactor = false;
 
@@ -68,5 +76,183 @@ public static class TexConvert
         }
 
         return texTexture;
+    }
+
+    private static DdsHeaderFlags GetDDSDFlags(TexHeader header) {
+        DdsHeaderFlags ddsdFlags = DdsHeaderFlags.Caps
+                | DdsHeaderFlags.Height
+                | DdsHeaderFlags.Width
+                | DdsHeaderFlags.PixelFormat;
+        if (header.MipMapCount > 1) {
+            ddsdFlags |= DdsHeaderFlags.MipMapCount;
+        }
+        // Assume any BC-derivative is compressed and some form of FOURCC DXT1-5 style format
+        if (header.PixelFormat.ToString().StartsWith("FORMAT_BC")) {
+            ddsdFlags |= DdsHeaderFlags.LinearSize;
+        } else {
+            ddsdFlags |= DdsHeaderFlags.Pitch;
+        }
+        return ddsdFlags;
+    }
+
+    private static uint GetDDSPitchOrLinearSize(TexTexture texTexture) {
+        // For compressed textures the linear size is equal to the first non-mip-mapped face
+        if (texTexture.Header.PixelFormat.ToString().StartsWith("FORMAT_BC")) {
+            // For DDON this is fine, because there are only 2D & CubeMap textures, 
+            // which means either there is an array of size 1 or 6 and for cube maps
+            // all faces will share the same size.
+            if (texTexture.Header.MipMapCount == 1) {
+                return texTexture.Images.Last().Offset - texTexture.Images.First().Offset;
+            } else if (texTexture.Header.MipMapCount > 1) {
+                return texTexture.Images[1].Offset - texTexture.Images[0].Offset;
+            } else {
+                throw new Exception("Invalid MipMapCount value encountered");
+            }
+        } else {
+            // For non-compressed textures the linear size is equal to channels * total bits
+            switch (texTexture.Header.PixelFormat) {
+                case TexPixelFormat.FORMAT_B8G8R8A8_UNORM:
+                case TexPixelFormat.FORMAT_B8G8R8A8_UNORM_SRGB:
+                    return 128;
+                case TexPixelFormat.FORMAT_R32_FLOAT:
+                    return 32;
+                case TexPixelFormat.FORMAT_B4G4R4A4_UNORM:
+                    return 64;
+                default:
+                    throw new Exception("Unsupported format: " + texTexture.Header.PixelFormat.ToString());
+            };
+        }
+    }
+
+    private static DDSPixelFormat GetDDSPixelFormat(TexHeader header) {
+        DDSPixelFormat ddspf;
+        if (
+                header.PixelFormat == TexPixelFormat.FORMAT_BC1_UNORM
+                        || header.PixelFormat == TexPixelFormat.FORMAT_BC1_UNORM_SRGB
+                        || header.PixelFormat == TexPixelFormat.FORMAT_BCX_GRAYSCALE
+        ) {
+            ddspf = DDSPixelFormat.DDSPF_DXT1;
+            ddspf.Flags = DdsPixelFormatFlag.DDS_FOURCC;
+        } else if (
+                header.PixelFormat == TexPixelFormat.FORMAT_BC2_UNORM_SRGB
+        ) {
+            ddspf = DDSPixelFormat.DDSPF_DXT3;
+            ddspf.Flags = DdsPixelFormatFlag.DDS_FOURCC;
+        } else if (
+                header.PixelFormat == TexPixelFormat.FORMAT_BC3_UNORM_SRGB
+                        || header.PixelFormat == TexPixelFormat.FORMAT_BCX_NH
+                        || header.PixelFormat == TexPixelFormat.FORMAT_BCX_NM2
+                        || header.PixelFormat == TexPixelFormat.FORMAT_BCX_YCCA_SRGB
+        ) {
+            ddspf = DDSPixelFormat.DDSPF_DXT5;
+            ddspf.Flags = DdsPixelFormatFlag.DDS_FOURCC;
+        } else if (
+                header.PixelFormat == TexPixelFormat.FORMAT_B8G8R8A8_UNORM
+                        || header.PixelFormat == TexPixelFormat.FORMAT_B8G8R8A8_UNORM_SRGB
+                        || header.PixelFormat == TexPixelFormat.FORMAT_R32_FLOAT
+        ) {
+            ddspf = new DDSPixelFormat();
+            ddspf.Flags = DdsPixelFormatFlag.DDS_ALPHAPIXELS | DdsPixelFormatFlag.DDS_RGB;
+            ddspf.RgbBitCount = 32;
+            ddspf.BBitMask = 0xFF_00_00_00;
+            ddspf.GBitMask = 0x00_FF_00_00;
+            ddspf.RBitMask = 0x00_00_FF_00;
+            ddspf.ABitMask = 0x00_00_00_FF;
+        } else if (
+                header.PixelFormat == TexPixelFormat.FORMAT_B4G4R4A4_UNORM
+        ) {
+            ddspf = new DDSPixelFormat();
+            ddspf.Flags = DdsPixelFormatFlag.DDS_ALPHAPIXELS | DdsPixelFormatFlag.DDS_RGB;
+            ddspf.RgbBitCount = 16;
+            ddspf.BBitMask = 0b1111_0000_0000_0000;
+            ddspf.GBitMask = 0b0000_1111_0000_0000;
+            ddspf.RBitMask = 0b0000_0000_1111_0000;
+            ddspf.ABitMask = 0b0000_0000_0000_1111;
+        }
+        else
+        {
+            throw new Exception("Unsupported format: " + header.PixelFormat.ToString());
+        }
+        ddspf.Size = 32;
+        return ddspf;
+    }
+
+    private static DdsCaps GetDDSCapsFlags(TexHeader header) {
+        DdsCaps capsFlags = DdsCaps.Texture;
+        // Mip Map
+        if (header.MipMapCount > 1) {
+            capsFlags |= DdsCaps.MipMap;
+        }
+        // Cube Map
+        if (header.Type == TexType.Cube) {
+            capsFlags |= DdsCaps.Complex;
+        }
+        return capsFlags;
+    }
+
+    private static DdsCaps2 GetDDSCaps2Flags(TexHeader header) {
+        DdsCaps2 caps2Flags = 0;
+        if (header.Type == TexType.Cube) {
+            caps2Flags |= DdsCaps2.CubeMapAllFaces;
+        }
+        return caps2Flags;
+    }
+
+    private static TexType GetTexType(DdsHeader ddsHeader)
+    {
+        // DDON only makes use of 2D & Cube
+        return (ddsHeader.Caps2 & DdsCaps2.CubeMapAllFaces) != 0 
+            ? TexType.Cube 
+            : TexType.Texture2D;
+    }
+
+    private static TexPixelFormat GetTexPixelFormat(DdsTexture ddsTexture)
+    {
+        if(ddsTexture.Header.PixelFormat.Size != 32)
+        {
+            throw new Exception("Unsupported DDS pixel format size: " + ddsTexture.Header.PixelFormat.Size);
+        }
+
+        switch (ddsTexture.Header.PixelFormat.Flags)
+        {
+            case DdsPixelFormatFlag.DDS_FOURCC:
+                switch (ddsTexture.Header.PixelFormat.FourCc)
+                {
+                    case 0x31545844: // 'DXT1'
+                        return TexPixelFormat.FORMAT_BC1_UNORM;
+                    case 0x33545844: // 'DXT3'
+                        return TexPixelFormat.FORMAT_BC2_UNORM;
+                    case 0x35545844: // 'DXT5'
+                        return TexPixelFormat.FORMAT_BC3_UNORM_SRGB;
+                    default:
+                        throw new Exception("Unsupported FOURCC format: " + ddsTexture.Header.PixelFormat.FourCc);
+                }
+            case DdsPixelFormatFlag.DDS_ALPHAPIXELS | DdsPixelFormatFlag.DDS_RGB:
+                switch (ddsTexture.Header.PixelFormat.RgbBitCount)
+                {
+                    case 32:
+                        if (ddsTexture.Header.PixelFormat.RBitMask != 0x00_00_FF_00 ||
+                            ddsTexture.Header.PixelFormat.GBitMask != 0x00_FF_00_00 ||
+                            ddsTexture.Header.PixelFormat.BBitMask != 0xFF_00_00_00 ||
+                            ddsTexture.Header.PixelFormat.ABitMask != 0x00_00_00_FF)
+                        {
+                            throw new Exception("Unsupported RGBA bit mask");
+                        }
+                        return TexPixelFormat.FORMAT_B8G8R8A8_UNORM;
+                    case 16:
+                        if (ddsTexture.Header.PixelFormat.RBitMask != 0b0000_0000_1111_0000 ||
+                            ddsTexture.Header.PixelFormat.GBitMask != 0b0000_1111_0000_0000 ||
+                            ddsTexture.Header.PixelFormat.BBitMask != 0b1111_0000_0000_0000 ||
+                            ddsTexture.Header.PixelFormat.ABitMask != 0b0000_0000_0000_1111)
+                        {
+                            throw new Exception("Unsupported RGBA bit mask");
+                        }
+                        return TexPixelFormat.FORMAT_B4G4R4A4_UNORM;
+                    default:
+                        throw new Exception("Unsupported RGBA bit count: " + ddsTexture.Header.PixelFormat.RgbBitCount);
+                }
+            default:
+                throw new Exception("Unsupported DDS pixel format flag: " + ddsTexture.Header.PixelFormat.Flags.ToString("X8"));
+        }
     }
 }

--- a/Arrowgene.Ddon.Client/ResourceFile.cs
+++ b/Arrowgene.Ddon.Client/ResourceFile.cs
@@ -14,7 +14,7 @@ namespace Arrowgene.Ddon.Client
         // TODO Magic Validation
         // protected abstract string ExpectedMagic { get; }
 
-        protected override void Read(IBuffer buffer)
+        public override void Read(IBuffer buffer)
         {
             if (buffer.Size < 8)
             {
@@ -33,7 +33,7 @@ namespace Arrowgene.Ddon.Client
             }
         }
 
-        protected override void Write(IBuffer buffer)
+        public override void Write(IBuffer buffer)
         {
             byte[] magicTag = Encoding.UTF8.GetBytes(Magic);
             buffer.WriteBytes(magicTag);


### PR DESCRIPTION
Port over @Sehkah's TEX/DDS conversion implementation from ddon-extractor, using a method similar to ARCtool's to convert from DDS back to TEX by storing the original headers information in a txt file.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
