### PR TITLE
Fix: Last chance exception logging

### DIFF
--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -73,6 +73,10 @@ namespace Arrowgene.Ddon.Cli
 
         private static void Main(string[] args)
         {
+            AppDomain currentDomain = default(AppDomain);
+            currentDomain = AppDomain.CurrentDomain;
+            // Handler for unhandled exceptions.
+            currentDomain.UnhandledException += GlobalUnhandledExceptionHandler;
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
 
             Console.WriteLine("Program started");
@@ -411,6 +415,13 @@ namespace Arrowgene.Ddon.Cli
                 using StreamWriter sw = new StreamWriter(filePath, append: true);
                 sw.WriteLine(text);
             }
+        }
+
+        private static void GlobalUnhandledExceptionHandler(object sender, UnhandledExceptionEventArgs e)
+        {
+            Exception ex = default(Exception);
+            ex = (Exception)e.ExceptionObject;
+            Logger.Error(ex.Message + "\n" + ex.StackTrace);
         }
     }
 }


### PR DESCRIPTION
Ensure that unhandled critical exceptions still log so we can figure out why things are crashing.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
