### PR TITLE
fix: Fix issue with scripts not using asset path correctly

### DIFF
--- a/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
+++ b/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
@@ -30,7 +30,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
 
             if (libsPath != "")
             {
-                LibsRoot = $"{ScriptsRoot}{Path.DirectorySeparatorChar}{libsPath}";
+                LibsRoot = Path.Combine(ScriptsRoot, libsPath);
             }
         }
 
@@ -58,14 +58,16 @@ namespace Arrowgene.Ddon.Shared.Scripting
         /// <param name="path">Path to the main script being executed</param>
         private void EmitScriptsAsDllForDebug(Script script, string path)
         {
-            if (!Directory.Exists("script_assemblies"))
+            // Put the debug assemblies in <asset_path>/net9.0/Files
+            var assembliesPath = Path.Combine(ScriptsRoot, "../../script_assemblies");
+            if (!Directory.Exists(assembliesPath))
             {
-                Directory.CreateDirectory("script_assemblies");
+                Directory.CreateDirectory(assembliesPath);
             }
 
             var compilation = script.GetCompilation();
 
-            var outputPath = Path.Combine("script_assemblies", $"{Path.GetFileNameWithoutExtension(path)}.dll");
+            var outputPath = Path.Combine(assembliesPath, $"{Path.GetFileNameWithoutExtension(path)}.dll");
             var emitOptions = new EmitOptions()
                 .WithDebugInformationFormat(DebugInformationFormat.Pdb)
                 .WithPdbFilePath(outputPath);

--- a/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
+++ b/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
@@ -28,9 +28,9 @@ namespace Arrowgene.Ddon.Server.Scripting.modules
 
         public string TemplatesDirectory {get; private set;}
 
-        public GameServerSettingsModule()
+        public GameServerSettingsModule(string scriptsRoot)
         {
-            TemplatesDirectory = Path.Combine("Files/Assets/scripts/settings", "templates");
+            TemplatesDirectory = Path.Combine(scriptsRoot, "settings/templates");
 
             SettingsData = new ScriptableSettings();
             GameSettings = new GameSettings(SettingsData);

--- a/Arrowgene.Ddon.Server/ServerScriptManager.cs
+++ b/Arrowgene.Ddon.Server/ServerScriptManager.cs
@@ -17,11 +17,12 @@ namespace Arrowgene.Ddon.Server
 
         private Globals Globals { get; set; }
 
-        public GameServerSettingsModule GameServerSettingsModule { get; private set; } = new GameServerSettingsModule();
-
+        public GameServerSettingsModule GameServerSettingsModule { get; private set; }
         public ServerScriptManager(string assetsPath) : base(assetsPath, "")
         {
             Globals = new Globals();
+
+            GameServerSettingsModule = new GameServerSettingsModule(ScriptsRoot);
 
             // Add modules to the list so the generic logic can iterate over all scripting modules
             ScriptModules[GameServerSettingsModule.ModuleRoot] = GameServerSettingsModule;


### PR DESCRIPTION
- Fixed an issue where the script project didn't output templates files to the correct location when run from the command line.
- Fixed an issue where the script project didn't output the debug assemblies to the correct location.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
