### PR TITLE
Add support for an in-memory usage pattern of SQLite with backups.

### DIFF
--- a/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
+++ b/Arrowgene.Ddon.Database/Arrowgene.Ddon.Database.csproj
@@ -21,7 +21,7 @@
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
         <PackageReference Include="Arrowgene.Logging" Version="1.2.1" />
-        <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
+        <PackageReference Include="System.Data.SQLite" Version="1.0.119" />
         <PackageReference Include="Npgsql" Version="7.0.7" />
         <PackageReference Include="MySqlConnector" Version="2.2.7" />
     </ItemGroup>

--- a/Arrowgene.Ddon.Database/DatabaseSetting.cs
+++ b/Arrowgene.Ddon.Database/DatabaseSetting.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.Serialization;
-using Arrowgene.Ddon.Database.Model;
 using Arrowgene.Ddon.Shared;
 
 namespace Arrowgene.Ddon.Database
@@ -19,46 +18,60 @@ namespace Arrowgene.Ddon.Database
             User = string.Empty;
             Password = string.Empty;
             WipeOnStartup = false;
+            EnableTracing = false;
 
             string envDbType = Environment.GetEnvironmentVariable("DB_TYPE");
             if (!string.IsNullOrEmpty(envDbType))
             {
                 Type = envDbType;
             }
+
             string envDbFolder = Environment.GetEnvironmentVariable("DB_FOLDER");
             if (!string.IsNullOrEmpty(envDbFolder))
             {
                 DatabaseFolder = envDbFolder;
             }
+
             string envDbHost = Environment.GetEnvironmentVariable("DB_HOST");
             if (!string.IsNullOrEmpty(envDbHost))
             {
                 Host = envDbHost;
             }
+
             string envDbPort = Environment.GetEnvironmentVariable("DB_PORT");
             if (!string.IsNullOrEmpty(envDbPort))
             {
                 Port = Convert.ToInt16(envDbPort);
             }
+
             string envDbDatabase = Environment.GetEnvironmentVariable("DB_DATABASE");
             if (!string.IsNullOrEmpty(envDbDatabase))
             {
                 Database = envDbDatabase;
             }
+
             string envDbUser = Environment.GetEnvironmentVariable("DB_USER");
             if (!string.IsNullOrEmpty(envDbUser))
             {
                 User = envDbUser;
             }
+
             string envDbPass = Environment.GetEnvironmentVariable("DB_PASS");
             if (!string.IsNullOrEmpty(envDbPass))
             {
                 Password = envDbPass;
             }
+
             string envDbWipeOnStartup = Environment.GetEnvironmentVariable("DB_WIPE_ON_STARTUP");
             if (!string.IsNullOrEmpty(envDbWipeOnStartup))
             {
                 WipeOnStartup = Convert.ToBoolean(envDbWipeOnStartup);
+            }
+
+            string envDbEnableTracing = Environment.GetEnvironmentVariable("DB_ENABLE_TRACING");
+            if (!string.IsNullOrEmpty(envDbEnableTracing))
+            {
+                EnableTracing = Convert.ToBoolean(envDbEnableTracing);
             }
         }
 
@@ -72,6 +85,7 @@ namespace Arrowgene.Ddon.Database
             Password = databaseSettings.Password;
             Database = databaseSettings.Database;
             WipeOnStartup = databaseSettings.WipeOnStartup;
+            EnableTracing = databaseSettings.EnableTracing;
         }
 
         [DataMember(Order = 0)] public string Type { get; set; }
@@ -89,5 +103,7 @@ namespace Arrowgene.Ddon.Database
         [DataMember(Order = 6)] public string Database { get; set; }
 
         [DataMember(Order = 7)] public bool WipeOnStartup { get; set; }
+        
+        [DataMember(Order = 8)] public bool EnableTracing { get; set; }
     }
 }

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -666,5 +666,6 @@ namespace Arrowgene.Ddon.Database
         Dictionary<ItemId, byte> SelectMyRoomCustomization(uint characterId, DbConnection? connectionIn = null);
         bool UpsertMyRoomCustomization(uint characterId, byte layoutId, uint itemId, DbConnection? connectionIn = null);
         bool DeleteMyRoomCustomization(uint characterId, uint itemId, DbConnection? connectionIn = null);
+        void Stop();
     }
 }

--- a/Arrowgene.Ddon.Database/Model/DatabaseType.cs
+++ b/Arrowgene.Ddon.Database/Model/DatabaseType.cs
@@ -4,6 +4,7 @@
     {
         SQLite,
         PostgreSQL,
-        MariaDb
+        MariaDb,
+        SQLiteInMemory
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDb.cs
@@ -186,6 +186,8 @@ namespace Arrowgene.Ddon.Database.Sql.Core
             return result;
         }
 
+        public abstract void Stop();
+
         protected override void Exception(Exception ex, string query)
         {
             Logger.Exception(ex);

--- a/Arrowgene.Ddon.Database/Sql/DdonMariaDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonMariaDb.cs
@@ -32,6 +32,11 @@ namespace Arrowgene.Ddon.Database.Sql
             return true;
         }
 
+        public override void Stop()
+        {
+            Logger.Info("Stopping database connection.");
+        }
+
         private string BuildConnectionString(string host, string user, string password, string database)
         {
             MySqlConnectionStringBuilder builder = new MySqlConnectionStringBuilder

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -56,6 +56,11 @@ namespace Arrowgene.Ddon.Database.Sql
             return !tableExists;
         }
 
+        public override void Stop()
+        {
+            Logger.Info("Stopping database connection.");
+        }
+
         private string BuildConnectionString(string host, string user, string password, string database)
         {
             NpgsqlConnectionStringBuilder builder = new NpgsqlConnectionStringBuilder

--- a/Arrowgene.Ddon.Database/Sql/DdonSqLiteDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonSqLiteDb.cs
@@ -9,17 +9,11 @@ namespace Arrowgene.Ddon.Database.Sql
     public class DdonSqLiteDb : DdonSqlDb<SQLiteConnection, SQLiteCommand, SQLiteDataReader>, IDatabase
     {
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonSqLiteDb));
-
-
-        public const string MemoryDatabasePath = ":memory:";
-
         private readonly string _databasePath;
         private string _connectionString;
-        private SQLiteConnection _memoryConnection;
 
         public DdonSqLiteDb(string databasePath, bool wipeOnStartup)
         {
-            _memoryConnection = null;
             _databasePath = databasePath;
             if (wipeOnStartup)
             {
@@ -46,14 +40,6 @@ namespace Arrowgene.Ddon.Database.Sql
 
             ReusableConnection = new SQLiteConnection(_connectionString);
 
-            if (_databasePath == MemoryDatabasePath)
-            {
-                throw new NotSupportedException("Connections are utilized via `using`, disposing the connection. In Memory DB only available for lifetime of connection");
-                _memoryConnection = new SQLiteConnection(_connectionString);
-                _memoryConnection.Open();
-                return true;
-            }
-
             if (!File.Exists(_databasePath))
             {
                 FileStream fs = File.Create(_databasePath);
@@ -63,6 +49,11 @@ namespace Arrowgene.Ddon.Database.Sql
             }
 
             return false;
+        }
+
+        public override void Stop()
+        {
+            Logger.Info("Stopping database connection.");
         }
 
         private string BuildConnectionString(string source)

--- a/Arrowgene.Ddon.Database/Sql/DdonSqLiteInMemoryDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonSqLiteInMemoryDb.cs
@@ -1,0 +1,137 @@
+﻿using System.Data.SQLite;
+using System.IO;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.Database.Sql
+{
+    /// <summary>
+    /// WARNING: Usage in production scenarios is discouraged, check caveats.
+    /// 
+    /// This database approach will make use of a file-based SQLite DB as a starting point to ingest all data into memory,
+    /// and afterward operate purely in-memory. Once the application performs a graceful shutdown it will backup the database to disk.
+    /// A graceful shutdown can be triggered either by exiting ("e" key) console mode or by triggering SIGTERM/SIGINT (ctrl+c) in service ("--service" flag) mode.
+    ///
+    /// <see href="https://sqlite.org/inmemorydb.html">Check out the SQLite documentation.</see>
+    ///
+    /// Caveats:
+    ///     - In case of hard process crashes all progress while the DB resided in memory will be lost.
+    ///     - While this approach avoids disk I/O, careful it requires a keep-alive connection as the DB is deleted once no connections are present.
+    /// </summary>
+    public class DdonSqLiteInMemoryDb : DdonSqLiteDb
+    {
+        private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonSqLiteInMemoryDb));
+        private readonly string _fileDatabasePath;
+        private string _memoryConnectionString;
+        private SQLiteConnection _fileConnection;
+        private SQLiteConnection _backupFileConnection;
+        private SQLiteConnection _keepAliveMemoryConnection;
+        private bool _isRunning;
+
+        public DdonSqLiteInMemoryDb(string databasePath, bool wipeOnStartup) : base(databasePath, wipeOnStartup)
+        {
+            _fileDatabasePath = databasePath;
+
+            _fileConnection = null;
+            _backupFileConnection = null;
+            _keepAliveMemoryConnection = null;
+        }
+
+        public override bool CreateDatabase()
+        {
+            bool databaseExists = File.Exists(_fileDatabasePath);
+            if (!databaseExists)
+            {
+                using (File.Create(_fileDatabasePath)) ;
+            }
+
+            // Establish file-based connection setup
+            string fileConnectionString = BuildFileConnectionString(_fileDatabasePath);
+            string backupFileConnectionString = BuildFileConnectionString(_fileDatabasePath + ".backup");
+            if (fileConnectionString == null)
+            {
+                Logger.Error($"Failed to build connection string for {_fileDatabasePath}");
+                return false;
+            }
+
+            _fileConnection = new SQLiteConnection(fileConnectionString);
+            _backupFileConnection = new SQLiteConnection(backupFileConnectionString);
+
+            // Establish memory-based connection setup
+            _memoryConnectionString = BuildMemoryConnectionString();
+
+            _keepAliveMemoryConnection = new SQLiteConnection(_memoryConnectionString);
+            _keepAliveMemoryConnection.Open();
+            ReusableConnection = new SQLiteConnection(_memoryConnectionString);
+
+            // Load the file-based DB contents into memory
+            ReusableConnection.Open();
+            _fileConnection.Open();
+            _fileConnection.BackupDatabase(ReusableConnection, "main", "main", -1, null, 5000);
+            _fileConnection.Close();
+            ReusableConnection.Close();
+
+            _isRunning = true;
+            
+            // If database had to be freshly created ensure that initial schema creation will run.
+            return !databaseExists;
+        }
+
+        public override void Stop()
+        {
+            if (_isRunning)
+            {
+                Logger.Info("Stopping database connection.");
+
+                _backupFileConnection.Open();
+                _fileConnection.Open();
+                // Dump the in-memory DB to file to not lose progress by overwriting the original file.
+                _fileConnection.BackupDatabase(_backupFileConnection, "main", "main", -1, null, 5000);
+                _keepAliveMemoryConnection.BackupDatabase(_fileConnection, "main", "main", -1, null, 5000);
+
+                _backupFileConnection.Close();
+                _fileConnection.Close();
+                _keepAliveMemoryConnection.Close();
+            }
+
+            _isRunning = false;
+        }
+
+        private static string BuildFileConnectionString(string source)
+        {
+            SQLiteConnectionStringBuilder builder = new SQLiteConnectionStringBuilder
+            {
+                DataSource = source,
+                Version = 3,
+                ForeignKeys = true,
+                Pooling = true,
+                // Set ADO.NET conformance flag https://system.data.sqlite.org/index.html/info/e36e05e299
+                Flags = SQLiteConnectionFlags.Default | SQLiteConnectionFlags.StrictConformance
+            };
+
+            string connectionString = builder.ToString();
+            Logger.Info($"Connection String: {connectionString}");
+            return connectionString;
+        }
+
+        private static string BuildMemoryConnectionString()
+        {
+            SQLiteConnectionStringBuilder builder = new SQLiteConnectionStringBuilder
+            {
+                DataSource = "memory.db",
+                Version = 3,
+                ForeignKeys = true,
+                Pooling = true,
+                // Set ADO.NET conformance flag https://system.data.sqlite.org/index.html/info/e36e05e299
+                Flags = SQLiteConnectionFlags.Default | SQLiteConnectionFlags.StrictConformance
+            };
+            string connectionString = builder.ConnectionString + ";mode=memory;cache=shared";
+            Logger.Info($"Connection String: {connectionString}");
+            return connectionString;
+        }
+
+        protected override SQLiteConnection OpenNewConnection()
+        {
+            return new SQLiteConnection(_memoryConnectionString).OpenAndReturn();
+        }
+    }
+}

--- a/Arrowgene.Ddon.Server/DdonServer.cs
+++ b/Arrowgene.Ddon.Server/DdonServer.cs
@@ -88,6 +88,7 @@ namespace Arrowgene.Ddon.Server
         {
             _server.Stop();
             _consumer.Dispose();
+            Database.Stop();
         }
 
         protected void AddHandler(IPacketHandler<TClient> packetHandler)

--- a/Arrowgene.Ddon.Test/Arrowgene.Ddon.Test.csproj
+++ b/Arrowgene.Ddon.Test/Arrowgene.Ddon.Test.csproj
@@ -18,13 +18,13 @@
     </PropertyGroup>
     <Import Project="./../SetSourceRevision.targets" />
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -483,6 +483,7 @@ namespace Arrowgene.Ddon.Test.Database
         public Dictionary<ItemId, byte> SelectMyRoomCustomization(uint characterId, DbConnection? connectionIn = null) { return new(); }
         public bool UpsertMyRoomCustomization(uint characterId, byte layoutId, uint itemId, DbConnection? connectionIn = null) { return true; }
         public bool DeleteMyRoomCustomization(uint characterId, uint itemId, DbConnection? connectionIn = null) { return true; }
+        public void Stop() { }
 
         public void AddParameter(DbCommand command, string name, object? value, DbType type) { }
         public void AddParameter(DbCommand command, string name, string value) { }

--- a/deploy/Arrowgene.Ddon.config.json
+++ b/deploy/Arrowgene.Ddon.config.json
@@ -140,7 +140,8 @@
     "User": "",
     "Password": "",
     "Database": "Ddon",
-    "WipeOnStartup": true
+    "WipeOnStartup": true,
+    "EnableTracing": true
   },
   "AssetPath": "\/var\/ddon\/server\/Files\/Assets"
 }

--- a/deploy/postgresql/docker-compose.pgloader.yml
+++ b/deploy/postgresql/docker-compose.pgloader.yml
@@ -23,3 +23,14 @@ services:
       interval: 10s
       timeout: 1s
       retries: 3
+      
+  pgloader:
+    image: dimitri/pgloader:latest
+    depends_on:
+      psql:
+        condition: service_healthy
+    volumes:
+      - ../../Arrowgene.Ddon.Cli/bin/Debug/net9.0/Files/Database/db.sqlite:/db.sqlite:ro
+    entrypoint: pgloader
+    command: sqlite:///db.sqlite postgresql://root:root@psql:5432/postgres
+

--- a/docker-compose.psql.yml
+++ b/docker-compose.psql.yml
@@ -43,7 +43,7 @@ services:
 
   db:
     container_name: ddon-db
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     ports:
       # Database
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - DB_FOLDER=/var/ddon/server/Files/Database
       - DB_PORT=3306
       - DB_WIPE_ON_STARTUP=false
+      - DB_ENABLE_TRACING=true
     volumes:
       - ddon-server-sqlite-volume:/var/ddon/server/Files/Database
       - ./Arrowgene.Ddon.config.local_dev.json:/var/ddon/server/Files/Arrowgene.Ddon.config.json:ro


### PR DESCRIPTION
Makes use of built-in capabilities of SQLite to be loaded as an in-memory database.

It is semantically equivalent to running SQLite as a disk-based database, except there are less safety features enabled which should be faster as well.

This is "easily" achieved by doing the following:
- Create a named memory mode instance of SQLite with shared cache for threaded access.
- Use the "online" (i.e. DB can run, and only what is read is read-locked and what is written is exclusively locked) backup API for easy transfers between memory<->file.
- Establish a "keep alive" connection to avoid deletion of in-memory DB.
- Upon graceful shutdown (e-key in console mode, ctrl-c in --service mode) the in-memory DB is dumped to disk, which will be re-used in the next start-up cycle.

Changes:
- Introduces a new DB type "SQLiteInMemory" which can be provided via the configs JSON.
- Introduces a new subclass "DdonSqLiteInMemoryDb" of DdonSqliteDb.
- Introduces a new abstract "Stop" method for databases.

Open points:
- Periodic online backups via configurable timers could further support usability in production scenarios.

References:
- https://sqlite.org/backup.html
- https://sqlite.org/inmemorydb.html

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
