### PR TITLE
fix: Fix reported bugs by players

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -3406,5 +3406,36 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
             return IsExmQuest(quest.QuestId);
         }
+
+        private static Dictionary<QuestAreaId, ContentsRelease> WorldQuestRequiredUnlocks = new Dictionary<QuestAreaId, ContentsRelease>()
+        {
+            // S2
+            [QuestAreaId.BloodbaneIsle] = ContentsRelease.BloodbaneIsleWorldQuests,
+            [QuestAreaId.ElanWaterGrove] = ContentsRelease.ElanWaterGroveWorldQuests,
+            [QuestAreaId.FaranaPlains] = ContentsRelease.FaranaPlainsWorldQuests,
+            [QuestAreaId.MorrowForest] = ContentsRelease.MorrowForestWorldQuests,
+            [QuestAreaId.KingalCanyon] = ContentsRelease.KingalCanyonWorldQuests,
+            // S3
+            [QuestAreaId.RathniteFoothills] = ContentsRelease.RathniteFoothillsWorldQuests,
+            [QuestAreaId.FeryanaWilderness] = ContentsRelease.FeryanaWildernessWorldQuests,
+            [QuestAreaId.MegadosysPlateau] = ContentsRelease.MegadosysPlateauWorldQuests,
+            [QuestAreaId.UrtecaMountains] = ContentsRelease.UrtecaMountainsWorldQuests,
+        };
+
+        public static bool HasWorldQuestAreaReleased(Character character, QuestAreaId questAreaId)
+        {
+            if (!character.HasContentReleased(ContentsRelease.WorldQuests))
+            {
+                return false;
+            }
+
+            if (!WorldQuestRequiredUnlocks.ContainsKey(questAreaId))
+            {
+                return true;
+            }
+
+            var releaseId = WorldQuestRequiredUnlocks[questAreaId];
+            return character.HasContentReleased(releaseId);
+        }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetAdventureGuideQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetAdventureGuideQuestListHandler.cs
@@ -18,21 +18,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-        private Dictionary<QuestAreaId,ContentsRelease> WorldQuestRequiredUnlocks = new Dictionary<QuestAreaId, ContentsRelease>()
-        {
-            // S2
-            [QuestAreaId.BloodbaneIsle] = ContentsRelease.BloodbaneIsleWorldQuests,
-            [QuestAreaId.ElanWaterGrove] = ContentsRelease.ElanWaterGroveWorldQuests,
-            [QuestAreaId.FaranaPlains] = ContentsRelease.FaranaPlainsWorldQuests,
-            [QuestAreaId.MorrowForest] = ContentsRelease.MorrowForestWorldQuests,
-            [QuestAreaId.KingalCanyon] = ContentsRelease.KingalCanyonWorldQuests,
-            // S3
-            [QuestAreaId.RathniteFoothills] = ContentsRelease.RathniteFoothillsWorldQuests,
-            [QuestAreaId.FeryanaWilderness] = ContentsRelease.FeryanaWildernessWorldQuests,
-            [QuestAreaId.MegadosysPlateau] = ContentsRelease.MegadosysPlateauWorldQuests,
-            [QuestAreaId.UrtecaMountains] = ContentsRelease.UrtecaMountainsWorldQuests,
-        };
-
         public override S2CQuestGetAdventureGuideQuestListRes Handle(GameClient client, C2SQuestGetAdventureGuideQuestListReq request)
         {
             // var pcap0 = EntitySerializer.Get<S2CQuestGetAdventureGuideQuestListRes>().Read(GameFull.Dump_196.AsBuffer());
@@ -73,11 +58,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                     var questState = QuestManager.GetQuestStateManager(client, quest).GetQuestState(quest);
 
-                    var step = (questState == null) ? 0 : questState.Step;
+                    var step = questState?.Step ?? 0;
                     if (quest.QuestType == QuestType.World)
                     {
                         // World quests are identified by lestania news
-                        // it seems when selecting world quests to bavigate to, they crash
+                        // This feature seems to make that obsolete
+                        // Defer world quests to lestania news for now
                         continue;
                     }
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestInfoListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestInfoListHandler.cs
@@ -1,9 +1,7 @@
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
-using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -23,7 +21,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             };
 
             // Return a blank list for areas that you haven't seen the Area Master for.
-            if (!client.Character.AreaRanks.TryGetValue(request.DistributeId, out var rank) || rank.Rank == 0)
+            if (!QuestManager.HasWorldQuestAreaReleased(client.Character, request.DistributeId) || !client.Character.AreaRanks.TryGetValue(request.DistributeId, out var rank) || rank.Rank == 0)
             {
                 return res;
             }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -3,6 +3,7 @@ using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
@@ -23,47 +24,53 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             client.Character.AreaId = request.DistributeId;
 
-            S2CQuestGetSetQuestListRes res = new S2CQuestGetSetQuestListRes();
+            S2CQuestGetSetQuestListRes res = new S2CQuestGetSetQuestListRes()
+            {
+                DistributeId = request.DistributeId
+            };
 
             // Remove all world quests which have no progress made
             client.Party.QuestState.RemoveInactiveWorldQuests();
 
-            /**
-             * World quests get added here instead of QuestGetWorldManageQuestListHandler because
-             * "World Manage Quests" are different from "World Quests". World manage quests appear
-             * to control the state of the game world (doors, paths, gates, etc.). World quests
-             * are random fetch, deliver and kill type quests.
-             */
-
-            // Populate state for all quests currently in progress by the player
-            foreach (var questScheduleId in client.Party.QuestState.GetActiveQuestScheduleIds())
+            if (QuestManager.HasWorldQuestAreaReleased(client.Character, request.DistributeId))
             {
-                Quest quest = client.Party.QuestState.GetQuest(questScheduleId);
-                if (quest is null || !QuestManager.IsWorldQuest(quest.QuestId))
+                /**
+                 * World quests get added here instead of QuestGetWorldManageQuestListHandler because
+                 * "World Manage Quests" are different from "World Quests". World manage quests appear
+                 * to control the state of the game world (doors, paths, gates, etc.). World quests
+                 * are random fetch, deliver and kill type quests.
+                 */
+
+                // Populate state for all quests currently in progress by the player
+                foreach (var questScheduleId in client.Party.QuestState.GetActiveQuestScheduleIds())
                 {
-                    continue;
+                    Quest quest = client.Party.QuestState.GetQuest(questScheduleId);
+                    if (quest is null || !QuestManager.IsWorldQuest(quest.QuestId))
+                    {
+                        continue;
+                    }
+
+                    CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
+                    QuestState questState = client.Party.QuestState.GetQuestState(quest);
+                    res.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, questStats?.ClearCount ?? 0));
                 }
 
-                CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
-                QuestState questState = client.Party.QuestState.GetQuestState(quest);
-                res.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, questStats?.ClearCount ?? 0));
-            }
-
-            foreach (var questScheduleId in client.Party.QuestState.AreaQuests(request.DistributeId))
-            {
-                Quest quest = QuestManager.GetQuestByScheduleId(questScheduleId);
-
-                if (quest is null 
-                    || client.Party.QuestState.IsQuestActive(questScheduleId) 
-                    || client.Party.QuestState.IsCompletedWorldQuest(questScheduleId))
+                foreach (var questScheduleId in client.Party.QuestState.AreaQuests(request.DistributeId))
                 {
-                    // Skip quests already populated or completed
-                    continue;
-                }
+                    Quest quest = QuestManager.GetQuestByScheduleId(questScheduleId);
 
-                CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
-                res.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
-                client.Party.QuestState.AddNewQuest(quest, 0);
+                    if (quest is null
+                        || client.Party.QuestState.IsQuestActive(questScheduleId)
+                        || client.Party.QuestState.IsCompletedWorldQuest(questScheduleId))
+                    {
+                        // Skip quests already populated or completed
+                        continue;
+                    }
+
+                    CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
+                    res.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
+                    client.Party.QuestState.AddNewQuest(quest, 0);
+                }
             }
 
             // Add Debug Quest

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -122,22 +122,6 @@ namespace Arrowgene.Ddon.GameServer.Quests
             return result;
         }
 
-        public List<CDataQuestExp> BaseExpRewards()
-        {
-            var result = new List<CDataQuestExp>();
-            foreach (var pointReward in ExpRewards)
-            {
-                result.Add(new CDataQuestExp()
-                {
-                    Type = pointReward.Type,
-                    Reward = pointReward.Reward
-                });
-            }
-
-            return result;
-
-        }
-
         public List<CDataQuestExp> ScaledExpRewards()
         {
             var result = new List<CDataQuestExp>();
@@ -147,7 +131,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 result.Add(new CDataQuestExp()
                 {
                     Type = pointReward.Type,
-                    Reward = amount.BasePoints
+                    Reward = amount.BasePoints,
                 });
             }
 
@@ -750,6 +734,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             return new CDataSetQuestOrderList()
             {
+                AreaId = QuestAreaId,
                 Param = ToCDataQuestOrderList(step),
                 Detail = new CDataSetQuestDetail()
                 {

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -579,23 +579,6 @@ namespace Arrowgene.Ddon.GameServer.Quests
         public abstract PacketQueue DistributeQuestRewards(uint questScheduleId, DbConnection? connectionIn = null);
         public abstract PacketQueue UpdatePriorityQuestList(GameClient requestingClient, DbConnection? connectionIn = null);
 
-        private (uint BasePoints, uint BonusPoints) CalculateTotalPointAmount(DdonGameServer server, GameClient client, CDataQuestExp point, QuestType questType)
-        {
-            (uint BasePoints, uint BonusPoints) amount = (point.Reward, 0);
-            switch (point.Type)
-            {
-                case PointType.ExperiencePoints:
-                    amount = server.ExpManager.GetAdjustedPoints(client, RewardSource.Quest, client.Character, null, PointType.ExperiencePoints, point.Reward, null, questType);
-                    break;
-                case PointType.AreaPoints:
-                    amount = server.ExpManager.GetAdjustedPointsForQuest(PointType.AreaPoints, point.Reward, questType);
-                    break;
-                default:
-                    break;
-            }
-            return amount;
-        }
-
         protected PacketQueue SendWalletRewards(DdonGameServer server, GameClient client, Quest quest, DbConnection? connectionIn = null)
         {
             PacketQueue packets = new();
@@ -620,16 +603,16 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 client.Enqueue(updateCharacterItemNtc, packets);
             }
 
-            var scaledRewards = quest.BaseExpRewards();
-            foreach (var point in scaledRewards)
+            var scaledRewards = quest.ScaledExpRewards();
+            foreach (var pointReward in scaledRewards)
             {
-                var amount = CalculateTotalPointAmount(server, client, point, quest.QuestType);
-                if (amount.BasePoints == 0)
+                if (pointReward.Reward == 0)
                 {
                     continue;
                 }
 
-                switch (point.Type)
+                (uint BasePoints, uint BonusPoints) amount = (pointReward.Reward, 0);
+                switch (pointReward.Type)
                 {
                     case PointType.ExperiencePoints:
                         packets.AddRange(server.ExpManager.AddExp(client, client.Character, amount, RewardSource.Quest, quest.QuestType, connectionIn));

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000058.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000058.csx
@@ -16,8 +16,7 @@ public class ScriptedQuest : IQuest
 
     public override bool AcceptRequirementsMet(GameClient client)
     {
-        return client.Character.ActiveCharacterJobData.Job == JobId.Alchemist &&
-               client.Character.HasQuestCompleted(QuestId.AlchemistTacticsTrialAlchemy);
+        return client.Character.ActiveCharacterJobData.Job == JobId.Alchemist;
     }
 
     protected override void InitializeState()

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200051.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200051.csx
@@ -16,8 +16,7 @@ public class ScriptedQuest : IQuest
 
     public override bool AcceptRequirementsMet(GameClient client)
     {
-        return client.Character.ActiveCharacterJobData.Job == JobId.SpiritLancer &&
-               client.Character.HasQuestCompleted(QuestId.SpiritLancerTacticsTrialASpiritLance);
+        return client.Character.ActiveCharacterJobData.Job == JobId.SpiritLancer;
     }
 
     protected override void InitializeState()

--- a/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
@@ -20,8 +20,8 @@ namespace Arrowgene.Ddon.Shared.AssetReader
 
         private static readonly ILogger Logger = LogProvider.Logger(typeof(EnemySpawnAssetDeserializer));
 
-        private static readonly string[] ENEMY_HEADERS = new string[]{"StageId", "LayerNo", "GroupId", "SubGroupId", "EnemyId", "NamedEnemyParamsId", "RaidBossId", "Scale", "Lv", "HmPresetNo", "StartThinkTblNo", "RepopNum", "RepopCount", "EnemyTargetTypesId", "MontageFixNo", "SetType", "InfectionType", "IsBossGauge", "IsBossBGM", "IsManualSet", "IsAreaBoss", "IsBloodOrbEnemy", "BloodOrbs", "IsHighOrbEnemy", "HighOrbs", "Experience", "DropsTableId", "SpawnTime", "PPDrop"};
-        private static readonly string[] DROPS_TABLE_HEADERS = new string[]{"ItemId", "ItemNum", "MaxItemNum", "Quality", "IsHidden", "DropChance"};
+        private static readonly string[] ENEMY_HEADERS = {"StageId", "LayerNo", "GroupId", "SubGroupId", "EnemyId", "NamedEnemyParamsId", "RaidBossId", "Scale", "Lv", "HmPresetNo", "StartThinkTblNo", "RepopNum", "RepopCount", "EnemyTargetTypesId", "MontageFixNo", "SetType", "InfectionType", "IsBossGauge", "IsBossBGM", "IsManualSet", "IsAreaBoss", "IsBloodOrbEnemy", "BloodOrbs", "IsHighOrbEnemy", "HighOrbs", "Experience", "DropsTableId", "SpawnTime", "PPDrop"};
+        private static readonly string[] DROPS_TABLE_HEADERS = {"ItemId", "ItemNum", "MaxItemNum", "Quality", "IsHidden", "DropChance"};
 
         private Dictionary<uint, NamedParam> namedParams;
 
@@ -117,24 +117,18 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                     Subgroup = subGroupId,
                 };
 
+                // Fallback for old style schema
+                enemy.IsBloodOrbEnemy = enemy.BloodOrbs > 0;
                 if (enemySchemaIndexes.ContainsKey("IsBloodOrbEnemy"))
                 {
                     enemy.IsBloodOrbEnemy = row[enemySchemaIndexes["IsBloodOrbEnemy"]].GetBoolean();
                 }
-                else
-                {
-                    // Fallback for old style schema
-                    enemy.IsBloodOrbEnemy = enemy.BloodOrbs > 0;
-                }
 
+                // Fallback for old style schema
+                enemy.IsHighOrbEnemy = enemy.HighOrbs > 0;
                 if (enemySchemaIndexes.ContainsKey("IsHighOrbEnemy"))
                 {
-                    enemy.IsBloodOrbEnemy = row[enemySchemaIndexes["IsHighOrbEnemy"]].GetBoolean();
-                }
-                else
-                {
-                    // Fallback for old style schema
-                    enemy.IsHighOrbEnemy = enemy.HighOrbs > 0;
+                    enemy.IsHighOrbEnemy = row[enemySchemaIndexes["IsHighOrbEnemy"]].GetBoolean();
                 }
 
                 // checking if the file has spawntime, if yes we convert the time and pass it along to enemy.cs

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataSetQuestOrderList.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataSetQuestOrderList.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model.Quest;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure
 {
@@ -9,6 +10,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             Detail = new CDataSetQuestDetail();
         }
     
+        public QuestAreaId AreaId { get; set; }
         public CDataQuestOrderList Param { get; set; }
         public CDataSetQuestDetail Detail { get; set; }
     
@@ -16,6 +18,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         {
             public override void Write(IBuffer buffer, CDataSetQuestOrderList obj)
             {
+                WriteUInt32(buffer, (uint) obj.AreaId);
                 WriteEntity<CDataQuestOrderList>(buffer, obj.Param);
                 WriteEntity<CDataSetQuestDetail>(buffer, obj.Detail);
             }
@@ -23,6 +26,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             public override CDataSetQuestOrderList Read(IBuffer buffer)
             {
                 CDataSetQuestOrderList obj = new CDataSetQuestOrderList();
+                obj.AreaId = (QuestAreaId)ReadUInt32(buffer);
                 obj.Param = ReadEntity<CDataQuestOrderList>(buffer);
                 obj.Detail = ReadEntity<CDataSetQuestDetail>(buffer);
                 return obj;

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000.json
@@ -83,23 +83,23 @@
       "npc_id": "WearyHarpy",
       "message_id": 10800
     },
-    
+
     {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 1,
-        "group_id": 1,
-        "layer_no": 1
-      },
-      "npc_id": "WearyHarpy",
-      "announce_type": "Accept",
-      "items": [
-        {
-          "id": 7968,
-          "amount": 1
-        }
-      ],
-      "message_id": 10737
+        "type": "NewDeliverItems",
+        "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+        },
+        "npc_id": "WearyHarpy",
+        "announce_type": "Accept",
+        "items": [
+            {
+                "id": 7968,
+                "amount": 1
+            }
+        ],
+        "message_id": 10737
     },
 
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065003.json
@@ -59,9 +59,7 @@
           "is_boss": true,
           "is_manual_set": false,
           "index": 4
-        }
-        
-        
+        } 
       ]
     }
   ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014000.json
@@ -52,20 +52,20 @@
                     "level": 70,
                     "exp": 3000,
                     "is_boss": false
-    },
-    {
+                },
+                {
                     "enemy_id": "0x010430",
                     "level": 70,
                     "exp": 3000,
                     "is_boss": false
-    },
-    {
+                },
+                {
                     "enemy_id": "0x010430",
                     "level": 70,
                     "exp": 3000,
                     "is_boss": false
-    },
-    {
+                },
+                {
                     "enemy_id": "0x010430",
                     "level": 70,
                     "exp": 3000,
@@ -119,8 +119,8 @@
                 }
             ]
         }
-    ],		
-    "blocks": [
+    ],
+  "blocks": [
     {
       "type": "NpcTalkAndOrder",
       "stage_id": {
@@ -130,45 +130,48 @@
       "message_id": 10800
     },
     {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Accept",
-            "groups": [0]
-        },
-        {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "groups": [0]
-        },
-        {			
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Update",
-            "groups": [1]			
-        },
-        {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "groups": [1]
-        },
-        {			
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Update",
-            "groups": [2]
-        },
-        {				
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "groups": [2]			
-        },
-        {		
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 339,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Dirith0",
-            "message_id": 11842			
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 2 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 2 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 339,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Dirith1",
+      "message_id": 11842
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
@@ -52,20 +52,20 @@
                     "level": 70,
                     "exp": 3000,
                     "is_boss": false
-    },
-    {
+                },
+                {
                     "enemy_id": "0x010430",
                     "level": 70,
                     "exp": 3000,
                     "is_boss": false
-    },
-    {
+                },
+                {
                     "enemy_id": "0x010430",
                     "level": 70,
                     "exp": 3000,
                     "is_boss": false
-    },
-    {
+                },
+                {
                     "enemy_id": "0x010430",
                     "level": 70,
                     "exp": 3000,
@@ -163,7 +163,7 @@
                 "layer_no": 1
             },
             "announce_type": "Update",
-            "npc_id": "Dirith0",
+            "npc_id": "Dirith1",
             "message_id": 11842			
     }
   ]

--- a/Arrowgene.Ddon.Shared/Model/Enemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/Enemy.cs
@@ -39,6 +39,8 @@ namespace Arrowgene.Ddon.Shared.Model
             DropsTable = enemy.DropsTable;
             Subgroup = enemy.Subgroup;
             PPDrop = enemy.PPDrop;
+            IsBloodOrbEnemy = enemy.IsBloodOrbEnemy;
+            IsHighOrbEnemy = enemy.IsHighOrbEnemy;
         }
 
         public uint Id { get; set; }


### PR DESCRIPTION
- Fixed enemy spawn blood orb enemies not showing with purple names
- Fixed the following world quests
  - q20030000.json
  - q20065003.json
  - q21014000.json
  - q21014009.json
- Adjusted the following personal quests
  - q60000058.csx
  - q60200051.csx
- Fixed an issue where the AP rewards didn't print the Area ID
- Fixed an issue where the adventure guide packet for world quests was
  missing a field.
- Added stricter checks for distributing world quests.
- Adjusted the scaled reward code to include JP for quests.
- Temporarily removed world quests from the adventure guide.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
