### PR TITLE
PSQL-related fixes

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -11,7 +11,7 @@ public partial class DdonSqlDb : SqlDb
         "DELETE FROM \"ddon_character_common\" WHERE EXISTS (SELECT 1 FROM \"ddon_pawn\" WHERE \"ddon_character_common\".\"character_common_id\"=\"ddon_pawn\".\"character_common_id\" AND \"ddon_pawn\".\"pawn_id\"=@pawn_id)";
 
     private const string SqlSelectOfficialPawns =
-        @"SELECT * FROM ddon_pawn WHERE is_official_pawn=1;";
+        @"SELECT * FROM ddon_pawn WHERE is_official_pawn=true;";
 
     private const string SqlSelectAllPlayerPawns =
         @"SELECT * FROM ddon_pawn WHERE is_official_pawn=false LIMIT @limit;";

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -72,7 +72,8 @@ public partial class DdonPostgresDb : DdonSqlDb
             NoResetOnClose = resetOnClose,
             SocketReceiveBufferSize = (int)bufferSize,
             SocketSendBufferSize = (int)bufferSize,
-            Pooling = true
+            Pooling = true,
+            IncludeErrorDetail = true
         };
         string connectionString = builder.ToString();
         Logger.Info($"Connection String: {connectionString}");


### PR DESCRIPTION
- Fix C2S_PAWN_GET_OFFICIAL_PAWN_LIST_REQ using an integer to query a boolean column (now works for both PSQL & SQLite)
- Fix C2S_ITEM_GET_DEFAULT_STORAGE_EMPTY_SLOT_NUM_REQ re-using a single connection in a nested loop which causes `Npgsql.NpgsqlOperationInProgressException (0x80004005): A command is already in progress`

# Checklist:
- [ ] The project compiles
- [x] The PR targets `develop` branch
