### PR TITLE
Update EventDropAssetDeserializer

### DIFF
--- a/Arrowgene.Ddon.Shared/AssetReader/EventDropAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EventDropAssetDeserializer.cs
@@ -43,11 +43,11 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 {
                     if (jEnemyId.ValueKind == JsonValueKind.String)
                     {
-                        eventItem.QuestIds.Add(Convert.ToUInt32(jEnemyId.GetString(), 16));
+                        eventItem.EnemyIds.Add(Convert.ToUInt32(jEnemyId.GetString(), 16));
                     }
                     else
                     {
-                        eventItem.QuestIds.Add(jEnemyId.GetUInt32());
+                        eventItem.EnemyIds.Add(jEnemyId.GetUInt32());
                     }
                 }
 

--- a/Arrowgene.Ddon.Shared/AssetReader/EventDropAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EventDropAssetDeserializer.cs
@@ -36,7 +36,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
 
                 foreach (var jStageId in jEventItem.GetProperty("stage_ids").EnumerateArray())
                 {
-                    eventItem.QuestIds.Add(jStageId.GetUInt32());
+                    eventItem.StageIds.Add(jStageId.GetUInt32());
                 }
 
                 foreach (var jEnemyId in jEventItem.GetProperty("enemy_ids").EnumerateArray())


### PR DESCRIPTION
Small bug fix to properly assign EnemyIds in the EventDropAssetDeserializer.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
