### PR TITLE
Explicitly order result lists by ID to avoid jumbling data

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -109,7 +109,8 @@ public partial class DdonSqlDb : SqlDb
         + "LEFT JOIN \"ddon_character_matching_profile\" ON \"ddon_character_matching_profile\".\"character_id\" = \"ddon_character\".\"character_id\" "
         + "LEFT JOIN \"ddon_character_arisen_profile\" ON \"ddon_character_arisen_profile\".\"character_id\" = \"ddon_character\".\"character_id\" "
         + "LEFT JOIN \"ddon_binary_data\" ON \"ddon_binary_data\".\"character_id\" = \"ddon_character\".\"character_id\" "
-        + "WHERE \"account_id\" = @account_id AND \"game_mode\" = @game_mode;";
+        + "WHERE \"account_id\" = @account_id AND \"game_mode\" = @game_mode "
+        + "ORDER BY \"ddon_character\".\"character_id\";";
 
     private readonly string SqlUpdateCharacterBinaryData =
         $"UPDATE \"ddon_binary_data\" SET {BuildQueryUpdate(CharacterBinaryDataFields)} WHERE \"character_id\" = @character_id;";

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -140,7 +140,8 @@ public partial class DdonSqlDb : SqlDb
         + "LEFT JOIN \"ddon_character_common\" ON \"ddon_character_common\".\"character_common_id\" = \"ddon_pawn\".\"character_common_id\" "
         + "LEFT JOIN \"ddon_edit_info\" ON \"ddon_edit_info\".\"character_common_id\" = \"ddon_pawn\".\"character_common_id\" "
         + "LEFT JOIN \"ddon_status_info\" ON \"ddon_status_info\".\"character_common_id\" = \"ddon_pawn\".\"character_common_id\" "
-        + "WHERE \"character_id\" = @character_id";
+        + "WHERE \"character_id\" = @character_id "
+        + "ORDER BY \"pawn_id\"";
 
     public override bool CreatePawn(Pawn pawn)
     {


### PR DESCRIPTION
- Fixes a bug in Postgres where the character association gets jumbled up upon log in when you have multiple characters
- Fixes a bug in Postgres where the pawn<->slot association gets jumbled up and the longer the user plays in that setup the more the pawns data will switch around.

Generic cause for these issues: In Postgres there is no guarantee whatsoever on the ordering of result rows.
Generic resolution: Force an order by on character/pawn ID which works for both SQLite and Postgres.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
