### PR TITLE
Ensure pawns don't additionally trigger training tasks.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -396,7 +396,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     lowerLevelSkill.SkillLv = skillLv;
                     database.UpdateLearnedCustomSkill(character.CommonId, lowerLevelSkill, connection);
 
-                    _Server.JobMasterManager.ScheduleCustomSkillTrainingTask(client, job, lowerLevelSkill, connection);
+                    if (character is Character)
+                    {
+                        _Server.JobMasterManager.ScheduleCustomSkillTrainingTask(client, job, lowerLevelSkill, connection);
+                    }
                 }
 
                 // EX Skills
@@ -725,7 +728,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     lowerLevelAbility.AbilityLv = abilityLv;
                     database.UpdateLearnedAbility(character.CommonId, lowerLevelAbility, connection);
 
-                    _Server.JobMasterManager.ScheduleAbilityTrainingTask(client, job, lowerLevelAbility, connection);
+                    if (character is Character)
+                    {
+                        _Server.JobMasterManager.ScheduleAbilityTrainingTask(client, job, lowerLevelAbility, connection);
+                    }
                 }
 
                 uint jpCost = abilityData.Params.Where(x => x.Lv == abilityLv).Single().RequireJobPoint;


### PR DESCRIPTION
Fixes duplicate key errors of the following kind:

```
Client #031920 (19.8.1) C2S_SKILL_LEARN_PAWN_ABILITY_REQ
2025-04-27 05:20:32 - Debug - JobManager: Unlocking/upgrading ability Sorcerer: 129
2025-04-27 05:20:32 - Error - DdonSqlDb: Npgsql.PostgresException (0x80004005): 23505: duplicate primary key violation of Unique-Constraint »pk_ddon_job_master_active_orders«

DETAIL: primary key »(character_id, job_id, release_type, release_id)=(34956, 6, 2, 129)« already exists.
   at Npgsql.Internal.NpgsqlConnector.ReadMessageLong(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications, Boolean isReadingPrependedMessage)
   at System.Runtime.CompilerServices.PoolingAsyncValueTaskMethodBuilder`1.StateMachineBox`1.System.Threading.Tasks.Sources.IValueTaskSource<TResult>.GetResult(Int16 token)
   at Npgsql.NpgsqlDataReader.NextResult(Boolean async, Boolean isConsuming, CancellationToken cancellationToken)
   at Npgsql.NpgsqlDataReader.NextResult(Boolean async, Boolean isConsuming, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteReader(Boolean async, CommandBehavior behavior, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteReader(Boolean async, CommandBehavior behavior, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteNonQuery(Boolean async, CancellationToken cancellationToken)
   at Arrowgene.Ddon.Database.Sql.SqlDb.ExecuteNonQuery(DbConnection conn, String query, Action`1 nonQueryAction) in 
[...]
```

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
