### PR TITLE
Replace RNG uint-based Item UID with UUIDv7

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 38;
+    public const uint Version = 39;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/item_uid_type_to_text_migration_postgresql.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/item_uid_type_to_text_migration_postgresql.sql
@@ -1,0 +1,5 @@
+﻿ALTER TABLE "ddon_storage_item" ALTER COLUMN "item_uid" TYPE text;
+ALTER TABLE "ddon_equip_item" ALTER COLUMN "item_uid" TYPE text;
+ALTER TABLE "ddon_equip_job_item" ALTER COLUMN "item_uid" TYPE text;
+ALTER TABLE "ddon_crests" ALTER COLUMN "item_uid" TYPE text;
+ALTER TABLE "ddon_equipment_limit_break" ALTER COLUMN "item_uid" TYPE text;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/item_uid_type_to_text_migration_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/item_uid_type_to_text_migration_sqlite.sql
@@ -1,0 +1,84 @@
+﻿PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "ddon_storage_item_new"
+(
+    "item_uid"     TEXT PRIMARY KEY NOT NULL,
+    "character_id" INTEGER                NOT NULL,
+    "storage_type" SMALLINT               NOT NULL,
+    "slot_no"      SMALLINT               NOT NULL,
+    "item_id"      INTEGER                NOT NULL,
+    "item_num"     INTEGER                NOT NULL,
+    "safety"       SMALLINT               NOT NULL,
+    "color"        SMALLINT               NOT NULL,
+    "plus_value"   SMALLINT               NOT NULL,
+    "equip_points" INTEGER                NOT NULL,
+    CONSTRAINT "uq_ddon_storage_item_character_id_storage_type_slot_no" UNIQUE ("character_id", "storage_type", "slot_no"),
+    CONSTRAINT "fk_ddon_storage_item_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_storage_item_new" SELECT * FROM "ddon_storage_item";
+DROP TABLE "ddon_storage_item";
+ALTER TABLE "ddon_storage_item_new" RENAME TO "ddon_storage_item";
+
+CREATE TABLE "ddon_equip_item_new"
+(
+    "item_uid"            TEXT NOT NULL,
+    "character_common_id" INTEGER    NOT NULL,
+    "job"                 SMALLINT   NOT NULL,
+    "equip_type"          SMALLINT   NOT NULL,
+    "equip_slot"          SMALLINT   NOT NULL,
+    CONSTRAINT "pk_ddon_equip_item" PRIMARY KEY ("character_common_id", "job", "equip_type", "equip_slot"),
+    CONSTRAINT "fk_ddon_equip_item_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_equip_item_new" SELECT * FROM "ddon_equip_item";
+DROP TABLE "ddon_equip_item";
+ALTER TABLE "ddon_equip_item_new" RENAME TO "ddon_equip_item";
+
+CREATE TABLE "ddon_equip_job_item_new"
+(
+    "item_uid"            TEXT NOT NULL,
+    "character_common_id" INTEGER    NOT NULL,
+    "job"                 SMALLINT   NOT NULL,
+    "equip_slot"          SMALLINT   NOT NULL,
+    CONSTRAINT "pk_ddon_equip_job_item" PRIMARY KEY ("character_common_id", "job", "equip_slot"),
+    CONSTRAINT "fk_ddon_equip_job_item_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_equip_job_item_new" SELECT * FROM "ddon_equip_job_item";
+DROP TABLE "ddon_equip_job_item";
+ALTER TABLE "ddon_equip_job_item_new" RENAME TO "ddon_equip_job_item";
+
+CREATE TABLE "ddon_crests_new"
+(
+    "character_common_id" INTEGER    NOT NULL,
+    "item_uid"            TEXT NOT NULL,
+    "slot"                INTEGER    NOT NULL,
+    "crest_id"            INTEGER    NOT NULL,
+    "crest_amount"        INTEGER    NOT NULL,
+    CONSTRAINT "fk_ddon_crests_item_uid" FOREIGN KEY ("item_uid") REFERENCES "ddon_storage_item" ("item_uid") ON DELETE CASCADE,
+    CONSTRAINT "fk_ddon_crests_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_crests_new" SELECT * FROM "ddon_crests";
+DROP TABLE "ddon_crests";
+ALTER TABLE "ddon_crests_new" RENAME TO "ddon_crests";
+
+CREATE INDEX IF NOT EXISTS "idx_ddon_crests_item_uid" ON "ddon_crests" ("item_uid");
+CREATE INDEX IF NOT EXISTS "idx_ddon_crests_character_item" ON "ddon_crests" ("character_common_id", "item_uid");
+
+CREATE TABLE "ddon_equipment_limit_break_new"
+(
+    "character_id"     INTEGER    NOT NULL,
+    "item_uid"         TEXT NOT NULL,
+    "effect_1"         INTEGER    NOT NULL,
+    "effect_2"         INTEGER    NOT NULL,
+    "is_effect1_valid" BOOLEAN    NOT NULL,
+    "is_effect2_valid" BOOLEAN    NOT NULL,
+    CONSTRAINT "pk_ddon_equipment_limit_break" PRIMARY KEY ("character_id", "item_uid"),
+    CONSTRAINT "fk_ddon_equipment_limit_break_item_uid" FOREIGN KEY ("item_uid") REFERENCES "ddon_storage_item" ("item_uid") ON DELETE CASCADE,
+    CONSTRAINT "fk_ddon_equipment_limit_break_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_equipment_limit_break_new" SELECT * FROM "ddon_equipment_limit_break";
+DROP TABLE "ddon_equipment_limit_break";
+ALTER TABLE "ddon_equipment_limit_break_new" RENAME TO "ddon_equipment_limit_break";
+
+CREATE INDEX IF NOT EXISTS "idx_ddon_equipment_limit_break_item_uid" ON "ddon_equipment_limit_break" ("item_uid");
+
+PRAGMA foreign_keys=ON;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -293,7 +293,7 @@ CREATE TABLE IF NOT EXISTS ddon_wallet_point
 
 CREATE TABLE IF NOT EXISTS "ddon_storage_item"
 (
-    "item_uid"     VARCHAR(8) PRIMARY KEY NOT NULL,
+    "item_uid"     TEXT PRIMARY KEY NOT NULL,
     "character_id" INTEGER                NOT NULL,
     "storage_type" SMALLINT               NOT NULL,
     "slot_no"      SMALLINT               NOT NULL,
@@ -309,7 +309,7 @@ CREATE TABLE IF NOT EXISTS "ddon_storage_item"
 
 -- CREATE TABLE IF NOT EXISTS ddon_additional_status
 -- (
---     "item_uid"          VARCHAR(8) NOT NULL,
+--     "item_uid"          TEXT NOT NULL,
 --     "character_id"      INTEGER NOT NULL,
 --     "is_add_stat1"      TINYINT NOT NULL,
 --     "is_add_stat2"      TINYINT NOT NULL,
@@ -324,7 +324,7 @@ CREATE TABLE IF NOT EXISTS "ddon_storage_item"
 
 CREATE TABLE IF NOT EXISTS "ddon_equip_item"
 (
-    "item_uid"            VARCHAR(8) NOT NULL,
+    "item_uid"            TEXT NOT NULL,
     "character_common_id" INTEGER    NOT NULL,
     "job"                 SMALLINT   NOT NULL,
     "equip_type"          SMALLINT   NOT NULL,
@@ -335,7 +335,7 @@ CREATE TABLE IF NOT EXISTS "ddon_equip_item"
 
 CREATE TABLE IF NOT EXISTS "ddon_equip_job_item"
 (
-    "item_uid"            VARCHAR(8) NOT NULL,
+    "item_uid"            TEXT NOT NULL,
     "character_common_id" INTEGER    NOT NULL,
     "job"                 SMALLINT   NOT NULL,
     "equip_slot"          SMALLINT   NOT NULL,
@@ -633,7 +633,7 @@ CREATE TABLE IF NOT EXISTS "ddon_stamp_bonus"
 CREATE TABLE IF NOT EXISTS "ddon_crests"
 (
     "character_common_id" INTEGER    NOT NULL,
-    "item_uid"            VARCHAR(8) NOT NULL,
+    "item_uid"            TEXT NOT NULL,
     "slot"                INTEGER    NOT NULL,
     "crest_id"            INTEGER    NOT NULL,
     "crest_amount"        INTEGER    NOT NULL,
@@ -938,7 +938,7 @@ VALUES (24, 0);
 CREATE TABLE IF NOT EXISTS "ddon_equipment_limit_break"
 (
     "character_id"     INTEGER    NOT NULL,
-    "item_uid"         VARCHAR(8) NOT NULL,
+    "item_uid"         TEXT NOT NULL,
     "effect_1"         INTEGER    NOT NULL,
     "effect_2"         INTEGER    NOT NULL,
     "is_effect1_valid" BOOLEAN    NOT NULL,

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000039_ItemUidTypeToTextMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000039_ItemUidTypeToTextMigration.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Data.Common;
+using System.IO;
+using System.Text;
+using Arrowgene.Ddon.Database.Model;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class ItemUidTypeToTextMigration : IMigrationStrategy
+    {
+        public uint From => 38;
+        public uint To => 39;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public ItemUidTypeToTextMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+        
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            Enum.TryParse(DatabaseSetting.Type, true, out DatabaseType dbType);
+            db.Execute(conn, File.ReadAllText(Path.Combine(DatabaseSetting.DatabaseFolder, $"Script/item_uid_type_to_text_migration_{dbType.ToString().ToLowerInvariant()}.sql"), Encoding.UTF8));
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -270,10 +270,14 @@ public abstract class SqlDb : IDatabase
         uint currentVersion = GetMeta().DatabaseVersion;
         bool result = migrator.MigrateDatabase(this, currentVersion, toVersion);
         if (result)
+        {
             SetMeta(new DatabaseMeta
             {
                 DatabaseVersion = DdonDatabaseBuilder.Version
             });
+            ExecuteNonQuery(OpenNewConnection(),"VACUUM;", _ => {});
+            ExecuteNonQuery(OpenNewConnection(),"ANALYZE;", _ => {});
+        }
         return result;
     }
 

--- a/Arrowgene.Ddon.Shared/Model/Item.cs
+++ b/Arrowgene.Ddon.Shared/Model/Item.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 
 namespace Arrowgene.Ddon.Shared.Model
 {
     public class Item
     {
-        public const int UIdLength = 8;
-
         public string UId
         {
             get
@@ -57,11 +54,7 @@ namespace Arrowgene.Ddon.Shared.Model
 
         private string UpdateUId()
         {
-            // The max value that can be represented in hex in 8 characters is 0xFFFF_FFFF which is equal to uint.MaxValue,
-            //  unfortunately there is no built-in uint support, so we force cast the random full range int -> uint instead.
-            int rnd = Random.Shared.Next(int.MinValue, int.MaxValue);
-            uint urnd = Unsafe.As<int, uint>(ref rnd);
-            _uid = urnd.ToString($"X{UIdLength}");
+            _uid = Guid.CreateVersion7(DateTimeOffset.UtcNow).ToString();
             return _uid;
         }
     }


### PR DESCRIPTION
Goals:

- Reduce the amount of collisions for item creation.

Changes:

- Migrates DB from v38 -> v39 -> there is a PSQL & SQLite appropriate migration.
- Replaces the RNG-based approach with a max. length of 8 chars with a UUIDv7-based Guid approach.
- Ensure VACUUM & ANALYZE are run after every migration.

Tests:

- Created a new char
- Moved items from/to storage
- Buying items from a shop to bag/storage
- Buying items from bazaar
- Item limit break

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
