### PR TITLE
Avoid duplicates in job training log

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 39;
+    public const uint Version = 40;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/ddon_job_master_active_orders_progress_primary_key_migration.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/ddon_job_master_active_orders_progress_primary_key_migration.sql
@@ -1,0 +1,31 @@
+﻿-- Note: This migration will fail if you have duplicates in your DB!
+-- What follows are no-warranty duplicate cleaners that delete one of the duplicate rows without applying any criteria:
+
+-- PostgreSQL
+-- with marked as (select ctid, row_number() over ( partition by character_id, job_id, release_type, release_id, target_idorder by ctid ) as rn from ddon_job_master_active_orders_progress)
+-- delete from ddon_job_master_active_orders_progress q using marked m
+-- where q.ctid = m.ctid and m.rn > 1;
+
+-- SQLite
+-- WITH marked AS (SELECT rowid AS rid, ROW_NUMBER() OVER ( PARTITION BY character_id, job_id, release_type, release_id, target_idORDER BY rowid ) AS rn FROM ddon_job_master_active_orders_progress)
+-- DELETE FROM ddon_job_master_active_orders_progress
+-- WHERE rowid IN ( SELECT rid FROM marked WHERE rn > 1);
+
+CREATE TABLE IF NOT EXISTS "ddon_job_master_active_orders_progress_new"
+(
+    "character_id" INTEGER NOT NULL,
+    "job_id"       INTEGER NOT NULL,
+    "release_type" INTEGER NOT NULL,
+    "release_id"   INTEGER NOT NULL,
+    "target_id"    INTEGER NOT NULL,
+    "condition"    INTEGER NOT NULL,
+    "target_rank"  INTEGER NOT NULL,
+    "target_num"   INTEGER NOT NULL,
+    "current_num"  INTEGER NOT NULL,
+    CONSTRAINT "pk_ddon_job_master_active_orders_progress" PRIMARY KEY ("character_id", "job_id", "release_type", "release_id", "target_id"),
+    CONSTRAINT "fk_ddon_job_master_active_orders_progress" FOREIGN KEY ("character_id", "job_id", "release_type", "release_id") REFERENCES "ddon_job_master_active_orders" ("character_id", "job_id", "release_type", "release_id") ON DELETE CASCADE,
+    CONSTRAINT "fk_ddon_job_master_active_orders_progress_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_job_master_active_orders_progress_new" SELECT "character_id", "job_id", "release_type", "release_id", "target_id", "condition", "target_rank", "target_num", "current_num" FROM "ddon_job_master_active_orders_progress";
+DROP TABLE "ddon_job_master_active_orders_progress";
+ALTER TABLE "ddon_job_master_active_orders_progress_new" RENAME TO "ddon_job_master_active_orders_progress";

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -979,11 +979,12 @@ CREATE TABLE IF NOT EXISTS "ddon_job_master_active_orders_progress"
     "job_id"       INTEGER NOT NULL,
     "release_type" INTEGER NOT NULL,
     "release_id"   INTEGER NOT NULL,
-    "condition"    INTEGER NOT NULL,
     "target_id"    INTEGER NOT NULL,
+    "condition"    INTEGER NOT NULL,
     "target_rank"  INTEGER NOT NULL,
     "target_num"   INTEGER NOT NULL,
     "current_num"  INTEGER NOT NULL,
+    CONSTRAINT "pk_ddon_job_master_active_orders_progress" PRIMARY KEY ("character_id", "job_id", "release_type", "release_id", "target_id"),
     CONSTRAINT "fk_ddon_job_master_active_orders_progress" FOREIGN KEY ("character_id", "job_id", "release_type", "release_id") REFERENCES "ddon_job_master_active_orders" ("character_id", "job_id", "release_type", "release_id") ON DELETE CASCADE,
     CONSTRAINT "fk_ddon_job_master_active_orders_progress_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000040_DdonJobMasterActiveOrdersProgressPrimaryKeyMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000040_DdonJobMasterActiveOrdersProgressPrimaryKeyMigration.cs
@@ -1,0 +1,24 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class DdonJobMasterActiveOrdersProgressPrimaryKeyMigration : IMigrationStrategy
+    {
+        public uint From => 39;
+        public uint To => 40;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public DdonJobMasterActiveOrdersProgressPrimaryKeyMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+        
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(DatabaseSetting, "Script/ddon_job_master_active_orders_progress_primary_key_migration.sql");
+            db.Execute(conn, adaptedSchema);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This also restricts the job training orders to only mention the target_id only once as this is now part of the primary key.

Tests:
- Tested opening training log
- Tested finishing training log with pawns in party
- Tested upgrading skill to level 7
- Tested reopening training log afterward

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
