### PR TITLE
fix: Add Manun Village questboard unlock

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
@@ -12,7 +12,8 @@
         {"type": "MainQuestCompleted", "Param1": 20200}
     ],
     "contents_release": [
-        {"flag_info": "TowerOfIvanos.QuestBoard"}
+        { "flag_info": "ManunVillage.QuestBoard" },
+        { "flag_info": "TowerOfIvanos.QuestBoard" }
     ],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
@@ -432,6 +432,16 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             public static QuestFlagInfo VegasaCorridorEast { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2400, QuestId.Q70023001);
         }
 
+        public static class ManunVillage
+        {
+            private static StageInfo StageInfo = Stage.ManunVillage;
+
+            /// <summary>
+            /// Unlocks the quest board in Manun Village when set.
+            /// </summary>
+            public static QuestFlagInfo QuestBoard { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2245, QuestId.Q70023001);
+        }
+
         public static class TowerOfIvanos
         {
             private static StageInfo StageInfo = Stage.TowerofIvanos;


### PR DESCRIPTION
Fixed an issue where the Manun Village questboard was not unlocked at the same time as the Tower of Ivanos.
- q00020210.json

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
