### PR TITLE
Throw an exception if there's more than one result in ArcArchive.GetFile search

### DIFF
--- a/Arrowgene.Ddon.Client/ArcArchive.cs
+++ b/Arrowgene.Ddon.Client/ArcArchive.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Linq;
 using Arrowgene.Buffers;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Crypto;
@@ -227,11 +228,11 @@ namespace Arrowgene.Ddon.Client
         }
 
         /// <summary>
-        /// Returns the first file that matches the search criteria.
+        /// Returns the only file that matches the search criteria, raises an exception if none or more than one file is found.
         /// </summary>
         public ArcFile GetFile(FileIndexSearch search)
         {
-            return GetFiles(search)[0];
+            return GetFiles(search).Single();
         }
 
         public ArcFile PutFile(string path, byte[] fileData)


### PR DESCRIPTION
Since it's possible for a search in GetFile to obtain multiple files that match the filters, in order to avoid mistakes reading the wrong files, the GetFile function will now throw an exception if more than one file matches the filters.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
