### PR TITLE
Handle Postgres-specific autoincrement failures.

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/ddon_job_master_active_orders_progress_primary_key_migration.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/ddon_job_master_active_orders_progress_primary_key_migration.sql
@@ -2,14 +2,13 @@
 -- What follows are no-warranty duplicate cleaners that delete one of the duplicate rows without applying any criteria:
 
 -- PostgreSQL
--- with marked as (select ctid, row_number() over ( partition by character_id, job_id, release_type, release_id, target_idorder by ctid ) as rn from ddon_job_master_active_orders_progress)
--- delete from ddon_job_master_active_orders_progress q using marked m
--- where q.ctid = m.ctid and m.rn > 1;
-
+--WITH marked AS (SELECT ctid, row_number() over (partition by character_id, job_id, release_type, release_id, target_id ORDER BY ctid) AS rn FROM ddon_job_master_active_orders_progress)
+--delete FROM ddon_job_master_active_orders_progress q using marked m
+--WHERE q.ctid = m.ctid and m.rn > 1;
 -- SQLite
--- WITH marked AS (SELECT rowid AS rid, ROW_NUMBER() OVER ( PARTITION BY character_id, job_id, release_type, release_id, target_idORDER BY rowid ) AS rn FROM ddon_job_master_active_orders_progress)
--- DELETE FROM ddon_job_master_active_orders_progress
--- WHERE rowid IN ( SELECT rid FROM marked WHERE rn > 1);
+--WITH marked AS (SELECT rowid AS rid, ROW_NUMBER() OVER (PARTITION BY character_id, job_id, release_type, release_id, target_id ORDER BY rowid) AS rn FROM ddon_job_master_active_orders_progress)
+--DELETE FROM ddon_job_master_active_orders_progress
+--WHERE rowid IN (SELECT rid FROM marked WHERE rn > 1);
 
 CREATE TABLE IF NOT EXISTS "ddon_job_master_active_orders_progress_new"
 (

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -65,10 +65,10 @@ public interface IDatabase
     DatabaseMeta GetMeta();
 
     // Account
-    Account CreateAccount(string name, string mail, string hash);
+    Account? CreateAccount(string name, string mail, string hash);
     Account SelectAccountById(int accountId);
-    Account SelectAccountByName(string accountName);
-    Account SelectAccountByLoginToken(string loginToken);
+    Account? SelectAccountByName(string accountName);
+    Account? SelectAccountByLoginToken(string loginToken);
     bool UpdateAccount(Account account);
     bool DeleteAccount(int accountId);
     Storages SelectAllStoragesByCharacterId(uint characterId);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
@@ -36,7 +36,7 @@ public partial class DdonSqlDb : SqlDb
                 for (i = 0; i < rewards.NumRandomRewards; i++) AddParameter(command, $"random_reward{i}_index", rewards.RandomRewardIndices[i]);
 
                 for (; i < MAX_RANDOM_REWARDS; i++) AddParameter(command, $"random_reward{i}_index", 0);
-            }, out long autoIncrement) == 1;
+            }) == 1;
         });
     }
 

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -294,10 +294,10 @@ public abstract class SqlDb : IDatabase
     public abstract bool CreateMeta(DatabaseMeta meta);
 
     public abstract DatabaseMeta GetMeta();
-    public abstract Account CreateAccount(string name, string mail, string hash);
+    public abstract Account? CreateAccount(string name, string mail, string hash);
     public abstract Account SelectAccountById(int accountId);
-    public abstract Account SelectAccountByName(string accountName);
-    public abstract Account SelectAccountByLoginToken(string loginToken);
+    public abstract Account? SelectAccountByName(string accountName);
+    public abstract Account? SelectAccountByLoginToken(string loginToken);
     public abstract bool UpdateAccount(Account account);
     public abstract bool DeleteAccount(int accountId);
     public abstract Storages SelectAllStoragesByCharacterId(uint characterId);


### PR DESCRIPTION
If a schema-only change was made or a maintenance-only task was executed, Postgres could throw an error on "ExecuteNonQuery" as "LASTVAL" was not initialized as the method always checks on the auto increment value.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
