### PR TITLE
fixes: Fix issues found with S2 BO implementation

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
@@ -95,11 +95,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     {
                         if (element.IsAbility())
                         {
-                            character.UnlockedAbilities[jobId].Add((uint) element.Ability);
+                            character.UnlockedAbilities[jobId].Add((uint) element.AbilityId);
                         }
                         else if (element.IsCustomSkill())
                         {
-                            character.UnlockedCustomSkills[jobId].Add(element.CustomSkill.ReleaseId());
+                            character.UnlockedCustomSkills[jobId].Add(element.CustomSkillId.ReleaseId());
                         }
                         else
                         {
@@ -157,11 +157,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             if (upgrade.IsAbility())
             {
-                Server.CharacterManager.UnlockAbility(client.Character, jobId, (uint)upgrade.Ability, 1);
+                Server.CharacterManager.UnlockAbility(client.Character, jobId, (uint)upgrade.AbilityId, 1);
 
                 // Handle players who had existing abilities blocked by addition of S2 tree
-                var existing = client.Character.LearnedAbilities.Where(x => x.AbilityId == (uint) upgrade.Ability).FirstOrDefault();
-                Server.JobManager.UnlockAbility(client, client.Character, jobId, (uint)upgrade.Ability, existing?.AbilityLv ?? 1, connectionIn);
+                var existing = client.Character.LearnedAbilities.Where(x => x.AbilityId == (uint) upgrade.AbilityId).FirstOrDefault();
+                if (existing == null)
+                {
+                    Server.JobManager.UnlockAbility(client, client.Character, jobId, (uint)upgrade.AbilityId, 1, connectionIn);
+                }
 
                 packets.Enqueue(client, new S2CSkillAcquirementLearnNtc()
                 {
@@ -169,7 +172,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     {
                        new CDataAbilityLevelBaseParam()
                        {
-                           AbilityNo = (uint) upgrade.Ability,
+                           AbilityNo = (uint) upgrade.AbilityId,
                            AbilityLv = existing?.AbilityLv ?? 1,
                        }
                     }
@@ -177,11 +180,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
             else if (upgrade.IsCustomSkill())
             {
-                Server.CharacterManager.UnlockCustomSkill(client.Character, jobId, upgrade.CustomSkill.ReleaseId(), 1);
+                Server.CharacterManager.UnlockCustomSkill(client.Character, jobId, upgrade.CustomSkillId.ReleaseId(), 1);
 
                 // Handle players who had existing skills blocked by addition of S2 tree
-                var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == upgrade.CustomSkill.ReleaseId()).FirstOrDefault();
-                Server.JobManager.UnlockSkill(client, client.Character, jobId, upgrade.CustomSkill.ReleaseId(), existing?.SkillLv ?? 1, connectionIn);
+                var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == upgrade.CustomSkillId.ReleaseId()).FirstOrDefault();
+                if (existing == null)
+                {
+                    Server.JobManager.UnlockSkill(client, client.Character, jobId, upgrade.CustomSkillId.ReleaseId(), 1, connectionIn);
+                }
 
                 packets.Enqueue(client, new S2CSkillAcquirementLearnNtc()
                 {
@@ -190,7 +196,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                        new CDataSkillLevelBaseParam()
                        {
                            Job = jobId,
-                           SkillNo = upgrade.CustomSkill.ReleaseId(),
+                           SkillNo = upgrade.CustomSkillId.ReleaseId(),
                            SkillLv = existing?.SkillLv ?? 1,
                        }
                     }

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartCraftHandler.cs
@@ -101,7 +101,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 bool canPlusValue = !itemInfo.SubCategory.HasValue || !NoQualitySubCategories.Contains(itemInfo.SubCategory.Value);
                 if (canPlusValue && !string.IsNullOrEmpty(request.RefineMaterialUID))
                 {
-                    Item refineMaterialItem = Server.Database.SelectStorageItemByUId(request.RefineMaterialUID);
+                    Item refineMaterialItem = Server.Database.SelectStorageItemByUId(request.RefineMaterialUID, connection);
                     CraftCalculationResult craftCalculationResult = CraftManager.CalculateEquipmentQuality(refineMaterialItem, (uint)calculatedOdds);
                     plusValue = craftCalculationResult.CalculatedValue;
                     isGreatSuccessEquipmentQuality = craftCalculationResult.IsGreatSuccess;

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartEquipGradeUpHandler.cs
@@ -219,7 +219,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     if (CraftManager.CanPawnRankUp(leadPawn))
                     {
                         client.Enqueue(CraftManager.HandlePawnRankUpNtc(client, leadPawn), queue);
-                        queue.AddRange(Server.AchievementManager.HandlePawnCrafting(client, leadPawn));
+                        queue.AddRange(Server.AchievementManager.HandlePawnCrafting(client, leadPawn, connection));
                     }
                 }
                 else

--- a/Arrowgene.Ddon.GameServer/Handler/RecycleStartExchangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/RecycleStartExchangeHandler.cs
@@ -34,7 +34,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     throw new ResponseErrorException(ErrorCode.ERROR_CODE_CLIENT_ITEM_INFO_MISSING, $"Unable to find item information for '{request.ItemUID}'");
 
                 var recycleRewards = equipmentRecycleMixin.GetRecycleRewards(Server.AssetRepository, itemInfo, item);
-                for (var i = 0; i < recycleRewards.NumRewards; i++)
+                for (var i = 0; i < Math.Min(recycleRewards.ItemRewards.Count, recycleRewards.NumRewards); i++)
                 {
                     var rolledSlot = Random.Shared.Next(0, recycleRewards.ItemRewards.Count);
                     var item = recycleRewards.ItemRewards[rolledSlot];

--- a/Arrowgene.Ddon.Scripts/scripts/quests/vocation/04_priest/q60200104.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/vocation/04_priest/q60200104.csx
@@ -49,14 +49,14 @@ public class ScriptedQuest : IQuest
 
     private class QstLayoutFlag
     {
-        public const uint Camus = 3587;
+        public const uint Camus = 3585;
     }
 
     private class MyQstFlag
     {
-        public const uint CamusFSM0 = 1358;
-        public const uint CamusFSM1 = 1359;
-        public const uint CamusFSM2 = 1360;
+        public const uint CamusFSM0 = 1352;
+        public const uint CamusFSM1 = 1353;
+        public const uint CamusFSM2 = 1354;
     }
 
     protected override void InitializeEnemyGroups()

--- a/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200112.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200112.csx
@@ -85,7 +85,7 @@ public class ScriptedQuest : IQuest
                 .SetNamedEnemyParams(NamedParamId.SecondTest),
         });
 
-        AddEnemies(EnemyGroupId.Encounter + 2, Stage.BetlandCemetery, 4, QuestEnemyPlacementType.Manual, new()
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.BetlandCemetery, 6, QuestEnemyPlacementType.Manual, new()
         {
             LibDdon.Enemy.CreateAuto(EnemyId.CaptainOrc0, 40, 3)
                 .SetNamedEnemyParams(NamedParamId.FinalTest),

--- a/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200113.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200113.csx
@@ -74,7 +74,7 @@ public class ScriptedQuest : IQuest
                 .SetNamedEnemyParams(NamedParamId.SecondTest),
             LibDdon.Enemy.CreateAuto(EnemyId.OrcTrooper, 42, 1)
                 .SetNamedEnemyParams(NamedParamId.SecondTest),
-            LibDdon.Enemy.CreateAuto(EnemyId.CaptainOrc0, 43, 3)
+            LibDdon.Enemy.CreateAuto(EnemyId.CaptainOrc0, 43, 2)
                 .SetNamedEnemyParams(NamedParamId.SecondTest),
         });
 
@@ -102,8 +102,6 @@ public class ScriptedQuest : IQuest
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2);
         process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2, resetGroup: false);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LighthouseKeepersHouse, NpcId.Rudolfo, 17653);
-        process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.LighthouseKeepersHouse)
-           .AddResultCmdReleaseAnnounce(ContentsRelease.ShieldSageWarSkillAugmentation, TutorialId.InheritanceSkillsOfBattleTechniques);
         process0.AddProcessEndBlock(true);
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200114.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200114.csx
@@ -114,8 +114,6 @@ public class ScriptedQuest : IQuest
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2);
         process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2, resetGroup: false);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LighthouseKeepersHouse, NpcId.Rudolfo, 17653);
-        process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.LighthouseKeepersHouse)
-           .AddResultCmdReleaseAnnounce(ContentsRelease.ShieldSageWarSkillAugmentation, TutorialId.InheritanceSkillsOfBattleTechniques);
         process0.AddProcessEndBlock(true);
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200115.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/vocation/05_shield_sage/q60200115.csx
@@ -102,7 +102,7 @@ public class ScriptedQuest : IQuest
             .AddCheckCmdPlJobEq(JobId.ShieldSage)
             .AddCheckCmdIsTutorialQuestClear(QuestId.SkillAugmentationShieldSageTrialIII);
         process0.AddNpcTalkAndOrderBlock(Stage.LighthouseKeepersHouse, NpcId.Rudolfo, 18833);
-        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.MoltovaRuins, 1, 1, NpcId.Rudolfo, 18835)
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.CesspoolofFilth, 1, 1, NpcId.Rudolfo, 18835)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.Rudolfo);
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0)
             .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, MyQstFlag.RudolfoFSM0);
@@ -112,8 +112,6 @@ public class ScriptedQuest : IQuest
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2);
         process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2, resetGroup: false);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LighthouseKeepersHouse, NpcId.Rudolfo, 18837);
-        process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.LighthouseKeepersHouse)
-           .AddResultCmdReleaseAnnounce(ContentsRelease.ShieldSageWarSkillAugmentation, TutorialId.InheritanceSkillsOfBattleTechniques);
         process0.AddProcessEndBlock(true);
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/skill_augmentation/seeker.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/skill_augmentation/seeker.csx
@@ -13,7 +13,7 @@ skillAugmentation.AddNode(1)
     .Location(4, 1)
     .BloodOrbCost(500)
     .Unlocks(OrbGainParamType.JobMagicalDefence, 1)
-    .HasQuestDependency(60200116);
+    .HasQuestDependency(QuestId.SkillAugmentationSeekerTrialI);
 
 // 2nd Tier
 skillAugmentation.AddNode(2)
@@ -171,7 +171,7 @@ skillAugmentation.AddNode(28)
     .BloodOrbCost(500)
     .Unlocks(OrbGainParamType.JobPhysicalAttack, 1)
     .HasUnlockDependency(27)
-    .HasQuestDependency(60200117);
+    .HasQuestDependency(QuestId.SkillAugmentationSeekerTrialII);
 
 // 12th Tier
 skillAugmentation.AddNode(29)
@@ -352,21 +352,21 @@ skillAugmentation.AddNode(56)
     .BloodOrbCost(1400)
     .Unlocks(OrbGainParamType.JobPhysicalAttack, 1)
     .HasUnlockDependency(55)
-    .HasQuestDependency(60200118);
+    .HasQuestDependency(QuestId.SkillAugmentationSeekerTrialIII);
 
 skillAugmentation.AddNode(57)
     .Location(4, 21)
     .BloodOrbCost(1200)
     .Unlocks(OrbGainParamType.JobHpMax, 25)
     .HasUnlockDependency(55)
-    .HasQuestDependency(60200102);
+    .HasQuestDependency(QuestId.SkillAugmentationSeekerTrialIII);
 
 skillAugmentation.AddNode(58)
     .Location(6, 21)
     .BloodOrbCost(1000)
     .Unlocks(OrbGainParamType.JobPhysicalDefence, 1)
     .HasUnlockDependency(55)
-    .HasQuestDependency(60200102);
+    .HasQuestDependency(QuestId.SkillAugmentationSeekerTrialIII);
 
 // 22nd Tier
 skillAugmentation.AddNode(59)
@@ -533,7 +533,7 @@ skillAugmentation.AddNode(86)
     .BloodOrbCost(1400)
     .Unlocks(OrbGainParamType.JobStaminaMax, 10)
     .HasUnlockDependencies(85)
-    .HasQuestDependency(60200119);
+    .HasQuestDependency(QuestId.SkillAugmentationSeekerTrialIV);
 
 // 32nd Tier
 skillAugmentation.AddNode(87)

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016014.json
@@ -1,90 +1,97 @@
 {
-    "state_machine": "GenericStateMachine",
-    "type": "World",
-    "comment": "Assault of Demons",
-    "quest_id": 21016014,
-    "base_level": 75,
-    "minimum_item_rank": 0,
-    "discoverable": false,
-	"area_id": "MorrowForest",	
-    "rewards": [
-        {
-            "type": "wallet",
-            "wallet_type": "Gold",
-            "amount": 4493
-        },
-        {
-            "type": "wallet",
-            "wallet_type": "RiftPoints",
-            "amount": 665
-        },
-        {
-            "type": "exp",
-            "amount": 21915
-        },
-        {
-            "type": "select",
-            "loot_pool": [
-                {
-                    "item_id": 15927,
-                    "num": 1
-                },
-                {					
-                    "item_id": 15963,
-                    "num": 1
-                },
-                {				
-                    "item_id": 7555,
-                    "num": 3					
-                }
-            ]
-        }
-    ],
-    "enemy_groups" : [
-        {
-            "stage_id": {
-                "id": 378,
-                "group_id": 4
-            },
-            "enemies": [
-                {
-                    "enemy_id": "0x015017",
-                    "level": 75,
-                    "exp": 92000,				
-                    "is_boss": true,
-					"infection_type": 2	
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Assault of Demons",
+  "quest_id": 21016014,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MorrowForest",
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4493
     },
     {
-                    "enemy_id": "0x011062",
-                    "level": 75,
-                    "exp": 3700,				
-                    "is_boss": false	
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 665
     },
     {
-                    "enemy_id": "0x011062",
-                    "level": 75,
-                    "exp": 3700,				
-                    "is_boss": false		
+      "type": "exp",
+      "amount": 21915
     },
     {
-                    "enemy_id": "0x011063",
-                    "level": 75,
-                    "exp": 3700,				
-                    "is_boss": false					
-                }
-            ]
-        }
-    ],		
-    "blocks": [
+      "type": "select",
+      "loot_pool": [
         {
-            "type": "DiscoverEnemy",
-            "groups": [0]
+          "item_id": 15927,
+          "num": 1
         },
         {
-            "type": "KillGroup",
-            "announce_type": "Accept",
-            "reset_group": true,
-            "groups": [0]
+          "item_id": 15963,
+          "num": 1
+        },
+        {
+          "item_id": 7555,
+          "num": 3
         }
-    ]
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 378,
+        "group_id": 4
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015017",
+          "level": 75,
+          "exp": 92000,
+          "is_boss": true,
+          "infection_type": 2
+        },
+        {
+          "comment": "Phindymian Hunter",
+          "enemy_id": "0x011062",
+          "level": 75,
+          "exp": 3700,
+          "hm_present_no": 96
+        },
+        {
+          "comment": "Phindymian Hunter",
+          "enemy_id": "0x011062",
+          "level": 75,
+          "exp": 3700,
+          "hm_present_no": 96
+        },
+        {
+          "comment": "Phindymian Hunter",
+          "enemy_id": "0x011063",
+          "level": 75,
+          "exp": 3700,
+          "hm_present_no": 96
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [
+        0
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": true,
+      "groups": [
+        0
+      ]
+    }
+  ]
 }

--- a/Arrowgene.Ddon.Shared/Model/JobOrbUpgrade.cs
+++ b/Arrowgene.Ddon.Shared/Model/JobOrbUpgrade.cs
@@ -15,8 +15,8 @@ namespace Arrowgene.Ddon.Shared.Model
         public uint ElementId { get; private set; }
         public uint Amount { get; private set; }
         public OrbGainParamType GainType { get; private set; }
-        public CustomSkillId CustomSkill { get; private set; }
-        public AbilityId Ability { get; private set; }
+        public CustomSkillId CustomSkillId { get; private set; }
+        public AbilityId AbilityId { get; private set; }
         public uint PosX { get; private set; }
         public uint PosY { get; private set; }
         public uint Cost { get; private set; }
@@ -75,14 +75,14 @@ namespace Arrowgene.Ddon.Shared.Model
         public JobOrbUpgrade Unlocks(CustomSkillId customSkill)
         {
             this.GainType = OrbGainParamType.JobCustomSkill;
-            this.CustomSkill = customSkill;
+            this.CustomSkillId = customSkill;
             return this;
         }
 
         public JobOrbUpgrade Unlocks(AbilityId ability)
         {
             this.GainType = OrbGainParamType.JobAbility;
-            this.Ability = ability;
+            this.AbilityId = ability;
             return this;
         }
 
@@ -165,12 +165,12 @@ namespace Arrowgene.Ddon.Shared.Model
 
             if (IsCustomSkill())
             {
-                result.ParamId = this.CustomSkill.ReleaseId();
+                result.ParamId = this.CustomSkillId.ReleaseId();
                 result.ParamValue = 0;
             }
             else if (IsAbility())
             {
-                result.ParamId = (uint)this.Ability;
+                result.ParamId = (uint)this.AbilityId;
                 result.ParamValue = 0;
             }
             else


### PR DESCRIPTION
- Fixed a DB issue where a skill fails to be unlocked if it was leveled
  high enough to have a skill training task scheduled.
- Updated Encounter + 2 group id from 4 to 6 in the quest
  "Augmentation Shield Sage Trial: I".
- Updated Encounter + 1 third enemy position from 3 to 2 in the quest
  "Skill Augmentation Shield Sage Trial: II"
- Fixed issue in the quest "Skill Augmentation Shield Sage Trial: IV"
  where Rudolfo was assigned the wrong stage.
- Added Phindymian Hunter preset id to the enemies in the quest
  21016014.json.
- Fixed an issue with the seeker skill tree where it required fighter
  quests.
- Fixed an issue with the quest "Skill Augmentation Priest Trial: I"
  which used the wrong quest layout flags.
- Fixed a bug which causes an null pointer exception during equipment
  recycling.
- Fixed a bug which causes a DB hang during crafting.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
