### PR TITLE
fix: Fix issue with spirit lancer tree

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/skill_augmentation/spirit_lancer.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/skill_augmentation/spirit_lancer.csx
@@ -143,7 +143,7 @@ skillAugmentation.AddNode(25)
 skillAugmentation.AddNode(26)
     .Location(5, 10)
     .BloodOrbCost(2000)
-    .Unlocks(AbilityId.Active)
+    .Unlocks(AbilityId.EnhancedVitality)
     .HasUnlockDependencies(23);
 #endregion
 


### PR DESCRIPTION
Fixed an issue where active was unlocked when it should be enhanced vitality.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
