### PR TITLE
fix: Add S2 BO tree stats to pawns

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/JobOrbTreeReleaseJobOrbElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobOrbTreeReleaseJobOrbElementHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -26,6 +27,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             // Notify all players of the upgrade
             packets.AddRange(Server.CharacterManager.UpdateCharacterExtendedParamsNtc(client, client.Character));
+
+            foreach (var member in client.Party.Members)
+            {
+                if (member is PawnPartyMember pawnMember && pawnMember.Pawn.CharacterId == client.Character.CharacterId)
+                {
+                    packets.AddRange(Server.CharacterManager.UpdateCharacterExtendedParamsNtc(client, pawnMember.Pawn));
+                }
+            }
 
             packets.Send();
 

--- a/Arrowgene.Ddon.GameServer/Handler/PawnCreatePawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnCreatePawnHandler.cs
@@ -113,13 +113,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             };
             PopulateNewPawnData(client.Character, pawn, request.SlotNo - 1);
-            Server.CharacterManager.UpdateCharacterExtendedParams(pawn, true);
+            Server.CharacterManager.UpdateCharacterExtendedParams(pawn, true, client.Character);
 
             Database.CreatePawn(pawn);
             Database.InsertGainExtendParam(pawn.CommonId, pawn.ExtendedParams);
 
             pawn = Server.Database.SelectPawnsByCharacterId(client.Character.CharacterId).Find(x => x.PawnId == pawn.PawnId);
-            Server.CharacterManager.UpdateCharacterExtendedParams(pawn, true);
+            Server.CharacterManager.UpdateCharacterExtendedParams(pawn, true, client.Character);
             pawn.Server = client.Character.Server;
 
             pawn.Equipment = client.Character.Storage.GetPawnEquipment(request.SlotNo - 1);


### PR DESCRIPTION
Updated Pawn logic to inherit stats from the players S2 and S3 orb enhancemenets.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
