### PR TITLE
Send HTTP status code 200 on register/login operations

### DIFF
--- a/Arrowgene.Ddon.WebServer/AccountRoute.cs
+++ b/Arrowgene.Ddon.WebServer/AccountRoute.cs
@@ -130,6 +130,7 @@ namespace Arrowgene.Ddon.WebServer
             }
 
             WebResponse response = new WebResponse();
+            response.StatusCode = 200;
             await response.WriteJsonAsync(res);
             return response;
         }


### PR DESCRIPTION
Added the HTTP status code 200 as return of valid login/register operations to avoid the "manual" construction of http request done on launcher and it's possible problems. It also improve the track of problems on launcher itself as HttpResponseMessage fields will be used for it.

# Checklist:
- [ x ] The project compiles
- [ x ] The PR targets `develop` branch
