### PR TITLE
Partner Pawn Job Training Bonus Setting

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -55,6 +56,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new();
             }
 
+            //Kill count multiplier for having a partner pawn present
+            uint killMulti = (uint)((client.Character.PartnerPawnId != 0 && client.Party.Members.Any(x => x.PawnId == client.Character.PartnerPawnId)) ? 2 : 1);
+
             foreach (var matchingOrder in matchingOrders)
             {
                 bool updatedRecord = false;
@@ -68,7 +72,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 foreach (var orderProgress in matchingProgress)
                 {
                     updatedRecord = true;
-                    orderProgress.CurrentNum += 1;
+                    orderProgress.CurrentNum += (1 * killMulti);
 
                     if (!Server.Database.UpsertJobMasterActiveOrdersProgress(client.Character.CharacterId, jobId, matchingOrder.ReleaseType, matchingOrder.ReleaseId, orderProgress, connectionIn))
                     {

--- a/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
@@ -57,8 +57,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
 
             //Kill count bonus for having a partner pawn present
-            uint partnerKillBonus = (uint)((client.Character.PartnerPawnId != 0 &&
-                client.Party.Members.Any(x => x.PawnId == client.Character.PartnerPawnId)) ? Server.GameSettings.GameServerSettings.JobTrainingPartnerBonus : 0);
+            uint partnerKillBonus = Server.PartnerPawnManager.IsPartnerPawnInParty(client) ? Server.GameSettings.GameServerSettings.JobTrainingPartnerBonus : 0;
 
             foreach (var matchingOrder in matchingOrders)
             {

--- a/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
@@ -56,8 +56,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new();
             }
 
-            //Kill count multiplier for having a partner pawn present
-            uint killMulti = (uint)((client.Character.PartnerPawnId != 0 && client.Party.Members.Any(x => x.PawnId == client.Character.PartnerPawnId)) ? 2 : 1);
+            //Kill count bonus for having a partner pawn present
+            uint partnerKillBonus = (uint)((client.Character.PartnerPawnId != 0 &&
+                client.Party.Members.Any(x => x.PawnId == client.Character.PartnerPawnId)) ? Server.GameSettings.GameServerSettings.JobTrainingPartnerBonus : 1);
 
             foreach (var matchingOrder in matchingOrders)
             {
@@ -72,7 +73,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 foreach (var orderProgress in matchingProgress)
                 {
                     updatedRecord = true;
-                    orderProgress.CurrentNum += (1 * killMulti);
+                    orderProgress.CurrentNum += 1 + partnerKillBonus;
 
                     if (!Server.Database.UpsertJobMasterActiveOrdersProgress(client.Character.CharacterId, jobId, matchingOrder.ReleaseType, matchingOrder.ReleaseId, orderProgress, connectionIn))
                     {

--- a/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
@@ -58,7 +58,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             //Kill count bonus for having a partner pawn present
             uint partnerKillBonus = (uint)((client.Character.PartnerPawnId != 0 &&
-                client.Party.Members.Any(x => x.PawnId == client.Character.PartnerPawnId)) ? Server.GameSettings.GameServerSettings.JobTrainingPartnerBonus : 1);
+                client.Party.Members.Any(x => x.PawnId == client.Character.PartnerPawnId)) ? Server.GameSettings.GameServerSettings.JobTrainingPartnerBonus : 0);
 
             foreach (var matchingOrder in matchingOrders)
             {

--- a/Arrowgene.Ddon.GameServer/Characters/PartnerPawnManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/PartnerPawnManager.cs
@@ -118,6 +118,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return Server.Database.HasPartnerPawnLastAffectionIncreaseRecord(client.Character.CharacterId, client.Character.PartnerPawnId, action, connectionIn);
         }
 
+        public bool IsPartnerPawnInParty(GameClient client)
+        {
+            return client.Party.Members.Where(x => x.IsPawn).Any(x => x.PawnId == client.Character.PartnerPawnId);
+        }
+
         public uint GetLikabilityForCurrentPartnerPawn(GameClient client, DbConnection? connectionIn = null)
         {
             var partnerPawnData = GetPartnerPawnData(client, connectionIn);

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1397,5 +1397,23 @@ namespace Arrowgene.Ddon.Server.Settings
             }
         }
         private const uint _RandomPawnMaxSample = 10000;
+
+        /// <summary>
+        /// The bonus for Job Training kills with a Partner Pawn present.
+        /// Setting this to 0 effectively disables bonus kills with a Partner Pawn.
+        /// </summary>
+        [DefaultValue(_JobTrainingPartnerBonus)]
+        public uint JobTrainingPartnerBonus
+        {
+            set
+            {
+                SetSetting("JobTrainingPartnerBonus", value);
+            }
+            get
+            {
+                return TryGetSetting("JobTrainingPartnerBonus", _JobTrainingPartnerBonus);
+            }
+        }
+        private const uint _JobTrainingPartnerBonus = 1;
     }
 }


### PR DESCRIPTION
* Adds extra credit on Job Training kills when the player's partner pawn is present.

Based on a changelog/Tweet from April 3rd, 2018, and exposed as a game setting for server admins to change/disable as desired.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
