### PR TITLE
Automatically reset pawns stuck in crafting state whenever progress is checked.

### DIFF
--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -594,7 +594,7 @@ public interface IDatabase
     bool InsertPawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null);
     bool UpdatePawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null);
     bool DeletePawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null);
-    CraftProgress SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null);
+    CraftProgress? SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null);
 
     #endregion
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawnCraftProgress.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawnCraftProgress.cs
@@ -73,11 +73,11 @@ public partial class DdonSqlDb : SqlDb
         });
     }
 
-    public override CraftProgress SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null)
+    public override CraftProgress? SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null)
     {
         return ExecuteQuerySafe(connectionIn, connection =>
         {
-            CraftProgress craftProgress = null;
+            CraftProgress? craftProgress = null;
             ExecuteReader(connection, SqlSelectPawnCraftProgress,
                 command =>
                 {

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -342,7 +342,7 @@ public abstract class SqlDb : IDatabase
     public abstract bool InsertPawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null);
     public abstract bool UpdatePawnCraftProgress(CraftProgress craftProgress, DbConnection? connectionIn = null);
     public abstract bool DeletePawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null);
-    public abstract CraftProgress SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null);
+    public abstract CraftProgress? SelectPawnCraftProgress(uint craftCharacterId, uint craftLeadPawnId, DbConnection? connectionIn = null);
     public abstract bool InsertSpSkill(uint pawnId, JobId job, CDataSpSkill spSkill);
     public abstract bool DeleteSpSkill(uint pawnId, JobId job, byte spSkillId);
     public abstract bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData, DbConnection? connectionIn = null);


### PR DESCRIPTION
Unclear how exactly this happens (outside of manually deleting crafting progress?), but it has been reported by users before. Theoretically speaking upon retrieving a crafted item the pawn state should have been reset already.

Report:
> My pawn cant be summoned says its crafting but nothing shows on the production list and its almost been 24 hours RL and things are usually instantly crafted any sugguestions?

Changes:
- Add a sanity check whenever crafting progress is checked (e.g. whenever the crafting room is entered)

Tests:
- Manually set pawn state to 2 in DB and entered crafting room => successfully reset
- Crafted an item with pawn, left crafting room and re-entered => successfully did not erroneously reset

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
