### PR TITLE
Fix stamp bonus last_stamp_time

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 42;
+    public const uint Version = 43;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/ddon_stamp_bonus_minimum_date_migration.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/ddon_stamp_bonus_minimum_date_migration.sql
@@ -1,0 +1,3 @@
+﻿UPDATE ddon_stamp_bonus
+SET last_stamp_time = '1900-01-01 00:00:00+00'
+WHERE last_stamp_time < '1900-01-01';

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000043_DdonStampBonusMinimumDateMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000043_DdonStampBonusMinimumDateMigration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class DdonStampBonusMinimumDateMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 42;
+        public uint To => 43;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/ddon_stamp_bonus_minimum_date_migration.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/CharacterStampBonus.cs
+++ b/Arrowgene.Ddon.Shared/Model/CharacterStampBonus.cs
@@ -1,16 +1,19 @@
 using System;
 
-namespace Arrowgene.Ddon.Shared.Model
+namespace Arrowgene.Ddon.Shared.Model;
+
+public class CharacterStampBonus
 {
-    public class CharacterStampBonus
+    private static readonly DateTime DateTimeSafeMinValue = new(1900, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    public CharacterStampBonus()
     {
-        public CharacterStampBonus() {
-            LastStamp = DateTime.MinValue;
-            ConsecutiveStamp = 0;
-            TotalStamp = 0;
-        }
-        public DateTime LastStamp { get; set; }
-        public ushort ConsecutiveStamp {  get; set; }
-        public ushort TotalStamp { get; set; }
+        LastStamp = DateTimeSafeMinValue;
+        ConsecutiveStamp = 0;
+        TotalStamp = 0;
     }
+
+    public DateTime LastStamp { get; set; }
+    public ushort ConsecutiveStamp { get; set; }
+    public ushort TotalStamp { get; set; }
 }


### PR DESCRIPTION
Merge #843 first.

Fix ddon_bonus_stamp last_stamp_time column parsing errors.

Stack trace:
```
Error - DdonSqlDb: System.InvalidCastException: Out of range of DateTime (year must be between 1 and 9999).
 ---> System.ArgumentOutOfRangeException: Ticks must be between DateTime.MinValue.Ticks and DateTime.MaxValue.Ticks. (Parameter 'ticks')
   at System.DateTime.ThrowTicksOutOfRange()
   at Npgsql.Internal.Converters.PgTimestamp.Decode(Int64 value, DateTimeKind kind, Boolean dateTimeInfinityConversions)
   --- End of inner exception stack trace ---
   at Npgsql.Internal.Converters.PgTimestamp.Decode(Int64 value, DateTimeKind kind, Boolean dateTimeInfinityConversions)
   at Npgsql.NpgsqlDataReader.GetFieldValueCore[T](Int32 ordinal)
   at Arrowgene.Ddon.Database.Sql.Core.DdonSqlDb.<>c__DisplayClass198_0.<QueryCharacterData>b__15(DbDataReader reader) in \Arrowgene.Ddon.Database\Sql\Core\DdonSqlDbCharacter.cs:line 373
   at Arrowgene.Ddon.Database.Sql.SqlDb.ExecuteReader(DbConnection conn, String query, Action`1 nonQueryAction, Action`1 readAction, Boolean rethrowException) in \Arrowgene.Ddon.Database\Sql\SqlDb.cs:line 104
Error - DdonSqlDb: Exception during query: SELECT "character_id", "last_stamp_time", "consecutive_stamp", "total_stamp" FROM "ddon_stamp_bonus" WHERE "character_id" = @character_id;
```

Cause:
- The default DateTime.MinValue reproducibly creates '-infinity' values in PSQL

Changes:
- Migrates DB from 42 -> 43
- Resets all "bad" ddon_bonus_stamp dates (incl. '-infinity') less than 1900-01-01
- Introduces a new manually defined safe minimum date '1900-01-01 00:00:00+00' (as defined in the sqlite schema)

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
