### PR TITLE
Improvements when reading and writing arc files

### DIFF
--- a/Arrowgene.Ddon.Client/ArcArchive.cs
+++ b/Arrowgene.Ddon.Client/ArcArchive.cs
@@ -235,29 +235,12 @@ namespace Arrowgene.Ddon.Client
             return GetFiles(search).Single();
         }
 
-        public ArcFile PutFile(string path, byte[] fileData)
+        public ArcFile PutFile(string arcPath, string ext, byte[] fileData)
         {
-            ArcFile existingFile = null;
-            foreach (ArcFile file in _files)
-            {
-                if (path == file.Index.Path)
-                {
-                    existingFile = file;
-                    break;
-                }
-            }
-
-            if (existingFile != null)
-            {
-                DeleteFile(existingFile);
-            }
-
             FileIndex newFileIndex = new FileIndex();
             newFileIndex.IsCyphered = IsCypheredArc(MagicTag);
-            newFileIndex.Path = path;
-            string ext = Path.GetExtension(path);
-            newFileIndex.ArcPath = path.Substring(0, path.Length - ext.Length);
-            ext = ext.TrimStart('.');
+
+            newFileIndex.ArcPath = arcPath;
 
             foreach (uint jamCrc in JamCrcLookup.Keys)
             {
@@ -276,6 +259,8 @@ namespace Arrowgene.Ddon.Client
                 // todo calculate jamcrc?
                 newFileIndex.Extension = $"{newFileIndex.JamCrc:X8}";
             }
+
+            newFileIndex.Path = arcPath+"."+ newFileIndex.Extension;
 
             newFileIndex.Directory = Path.GetDirectoryName(newFileIndex.ArcPath);
             if (newFileIndex.Directory == null)

--- a/Arrowgene.Ddon.Client/ArcArchive.cs
+++ b/Arrowgene.Ddon.Client/ArcArchive.cs
@@ -540,15 +540,15 @@ namespace Arrowgene.Ddon.Client
                 {
                     if (decompressor.IsNeedingDictionary)
                     {
-                        Logger.Error("ecompressor.IsNeedingDictionary");
+                        throw new Exception("Corrupted Arc file. decompressor.IsNeedingDictionary");
                     }
                     else if (decompressor.IsNeedingInput)
                     {
-                        Logger.Error("decompressor.IsNeedingInput");
+                        throw new Exception("Corrupted Arc file. decompressor.IsNeedingInput");
                     }
                     else
                     {
-                        Logger.Error("Unknown Decompression Error");
+                        throw new Exception("Corrupted Arc file. Unknown Decompression Error");
                     }
                 }
             }

--- a/Arrowgene.Ddon.Client/ArcArchive.cs
+++ b/Arrowgene.Ddon.Client/ArcArchive.cs
@@ -253,6 +253,7 @@ namespace Arrowgene.Ddon.Client
             }
 
             FileIndex newFileIndex = new FileIndex();
+            newFileIndex.IsCyphered = IsCypheredArc(MagicTag);
             newFileIndex.Path = path;
             string ext = Path.GetExtension(path);
             newFileIndex.ArcPath = path.Substring(0, path.Length - ext.Length);


### PR DESCRIPTION
Fixes memory leak in an infinite loop when opening a corrupted arc file and ensures that new files are ciphered when writing them into ciphered arc files

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
