### PR TITLE
Better progress report when packing GMD files

### DIFF
--- a/Arrowgene.Ddon.Cli/Command/ClientCommand.cs
+++ b/Arrowgene.Ddon.Cli/Command/ClientCommand.cs
@@ -144,7 +144,9 @@ namespace Arrowgene.Ddon.Cli.Command
             {
                 try
                 {
-                    GmdActions.Pack(parameter.ArgumentMap["gmdCsv"], parameter.ArgumentMap["romDir"], parameter.ArgumentMap["romLang"]);
+                    GmdCsv gmdCsvReader = new GmdCsv();
+                    List<GmdCsv.Entry> gmdCsvEntries = gmdCsvReader.ReadPath(parameter.ArgumentMap["gmdCsv"]);
+                    GmdActions.Pack(gmdCsvEntries, parameter.ArgumentMap["romDir"], parameter.ArgumentMap["romLang"]);
                 } 
                 catch (Exception ex)
                 {

--- a/Arrowgene.Ddon.Client/GmdPackActions.cs
+++ b/Arrowgene.Ddon.Client/GmdPackActions.cs
@@ -14,23 +14,20 @@ namespace Arrowgene.Ddon.Client
         private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(GmdActions));
 
         // pack gmd.csv into all .arc files of rom
-        public static void Pack(string gmdCsvArg, string romDirArg, string romLangArg, IProgress<PackProgressReport> progress = null) {
-        
+        public static void Pack(List<GmdCsv.Entry> csvEntries, string romDirArg, string romLangArg, IProgress<PackProgressReport> progress = null)
+        {
             if (!Enum.TryParse<GuiMessage.Language>(romLangArg, out GuiMessage.Language romLanguage))
             {
                 throw new Exception($"Provided romLang:{romLangArg} is invalid");
             }
 
             DirectoryInfo romDir = new DirectoryInfo(romDirArg);
-            FileInfo gmdCsvFile = new FileInfo(gmdCsvArg);
             if (!romDir.Exists)
             {
                 throw new Exception($"Provided romDir:{romDirArg} does not exist");
             }
 
             int totalGmdEntries = 0;
-            GmdCsv gmdCsvReader = new GmdCsv();
-            List<GmdCsv.Entry> csvEntries = gmdCsvReader.ReadPath(gmdCsvFile.FullName);
             Dictionary<string, Dictionary<string, List<GmdCsv.Entry>>> csvArcLookup =
                 new Dictionary<string, Dictionary<string, List<GmdCsv.Entry>>>();
             foreach (GmdCsv.Entry csvEntry in csvEntries)

--- a/Arrowgene.Ddon.Client/GmdPackActions.cs
+++ b/Arrowgene.Ddon.Client/GmdPackActions.cs
@@ -28,6 +28,7 @@ namespace Arrowgene.Ddon.Client
                 throw new Exception($"Provided romDir:{romDirArg} does not exist");
             }
 
+            int totalGmdEntries = 0;
             GmdCsv gmdCsvReader = new GmdCsv();
             List<GmdCsv.Entry> csvEntries = gmdCsvReader.ReadPath(gmdCsvFile.FullName);
             Dictionary<string, Dictionary<string, List<GmdCsv.Entry>>> csvArcLookup =
@@ -59,12 +60,12 @@ namespace Arrowgene.Ddon.Client
                 }
 
                 gmdEntries.Add(csvEntry);
+                totalGmdEntries++;
             }
 
-            int current = 0;
+            int processedGmdEntries = 0;
             foreach (string arcPath in csvArcLookup.Keys)
             {
-                current++;
                 string fullPath = Path.Combine(romDir.FullName, Util.UnrootPath(arcPath));
                 Dictionary<string, List<GmdCsv.Entry>> gmdCsvLookup = csvArcLookup[arcPath];
                 ArcArchive archive = new ArcArchive();
@@ -84,6 +85,17 @@ namespace Arrowgene.Ddon.Client
                     gmd.Open(gmdFile.Data);
                     foreach (GuiMessage.Entry entry in gmd.Entries)
                     {
+                        Logger.Info($"Writing {processedGmdEntries}/{totalGmdEntries} {fullPath}");
+                        if (progress != null)
+                        {
+                            progress.Report(new PackProgressReport()
+                            {
+                                Current = processedGmdEntries++,
+                                Total = totalGmdEntries,
+                                Path = fullPath
+                            });
+                        }
+
                         GmdCsv.Entry matchCsvEntry = null;
                         List<GmdCsv.Entry> keyMatches = new();
                         List<GmdCsv.Entry> indexMatches = new();
@@ -144,16 +156,6 @@ namespace Arrowgene.Ddon.Client
 
                 byte[] savedArc = archive.Save();
                 File.WriteAllBytes(fullPath, savedArc);
-                Logger.Info($"Writing {current}/{csvArcLookup.Keys.Count} {fullPath}");
-                if(progress != null)
-                {
-                    progress.Report(new PackProgressReport()
-                    {
-                        Current = current,
-                        Total = csvArcLookup.Keys.Count,
-                        Path = fullPath
-                    });
-                }
             }
         }
 


### PR DESCRIPTION
Reports on each altered gmd file instead of arc file so theres less noticeable jumps when reporting progress and decoupled parsing of GMD file from the packing function

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
