### PR TITLE
refactor: Cleanup some emblem settings

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobEmblemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobEmblemManager.cs
@@ -114,19 +114,19 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return (float)chance / 100.0f;
         }
 
-        public ushort MaxEmblemPoints(ushort emblemLevel)
+        public ushort MaxEmblemPointsForLevel(JobEmblem jobEmblem)
         {
-            return (ushort) Server.GameSettings.EmblemSettings.LevelingData.Where(x => x.Level <= emblemLevel).Sum(x => x.EP);
-        }
-
-        public ushort MaxEmblemPoints(JobEmblem jobEmblem)
-        {
-            return MaxEmblemPoints(jobEmblem.EmblemLevel);
+            return (ushort)Server.GameSettings.EmblemSettings.LevelingData.Where(x => x.Level <= jobEmblem.EmblemLevel).Sum(x => x.EP);
         }
 
         public ushort GetAvailableEmblemPoints(JobEmblem jobEmblem)
         {
-            return (ushort)(MaxEmblemPoints(jobEmblem) - jobEmblem.EmblemPointsUsed);
+            return (ushort)(MaxEmblemPointsForLevel(jobEmblem) - jobEmblem.EmblemPointsUsed);
+        }
+
+        public ushort GetMaxTotalEmblemPoints()
+        {
+            return (ushort) Server.GameSettings.EmblemSettings.LevelingData.Where(x => x.Level <= Server.GameSettings.EmblemSettings.MaxEmblemLevel).Sum(x => x.EP);
         }
 
         public uint LevelUpPPCost(byte emblemLevel)

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemGetEmblemListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemGetEmblemListHandler.cs
@@ -37,7 +37,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     {
                         JobId = jobId,
                         Amount = Server.JobEmblemManager.GetAvailableEmblemPoints(emblemData),
-                        MaxAmount = Server.JobEmblemManager.MaxEmblemPoints(emblemData),
+                        MaxAmount = Server.JobEmblemManager.MaxEmblemPointsForLevel(emblemData),
                     });
                 }
             }
@@ -110,7 +110,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 Amount = Server.GameSettings.EmblemSettings.EmblemInheritanceEquipLossGGCost
             });
 
-            result.EmblemSettings.MaxEmblemPoints = Server.GameSettings.EmblemSettings.MaxEmblemPoints;
+            result.EmblemSettings.MaxEmblemPoints = Server.JobEmblemManager.GetMaxTotalEmblemPoints();
             result.EmblemSettings.MaxEmblemLevel = Server.GameSettings.EmblemSettings.MaxEmblemLevel;
             result.EmblemSettings.MaxInhertienceChanceIncrease = Server.GameSettings.EmblemSettings.MaxInheritanceChanceIncrease;
 

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemResetParamLevelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemResetParamLevelHandler.cs
@@ -77,7 +77,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     JobId = JobId.Fighter,
                     Amount = Server.JobEmblemManager.GetAvailableEmblemPoints(emblemData),
-                    MaxAmount = Server.JobEmblemManager.MaxEmblemPoints(emblemData)
+                    MaxAmount = Server.JobEmblemManager.MaxEmblemPointsForLevel(emblemData)
                 }
             }, packets);
 

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateLevelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateLevelHandler.cs
@@ -36,7 +36,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     JobId = request.JobId,
                     Amount = Server.JobEmblemManager.GetAvailableEmblemPoints(emblemData),
-                    MaxAmount = Server.JobEmblemManager.MaxEmblemPoints(emblemData)
+                    MaxAmount = Server.JobEmblemManager.MaxEmblemPointsForLevel(emblemData)
                 },
             }, packets);
 

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevel.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevel.cs
@@ -65,7 +65,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 {
                     JobId = JobId.Fighter,
                     Amount = Server.JobEmblemManager.GetAvailableEmblemPoints(emblemData),
-                    MaxAmount = Server.JobEmblemManager.MaxEmblemPoints(emblemData)
+                    MaxAmount = Server.JobEmblemManager.MaxEmblemPointsForLevel(emblemData)
                 }
             }, packets);
 

--- a/Arrowgene.Ddon.Server/Settings/EmblemSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/EmblemSettings.cs
@@ -36,23 +36,6 @@ namespace Arrowgene.Ddon.Server.Settings
         }
         private const byte _MaxEmblemLevel = 120;
 
-        /// <summary>
-        /// Defines the maximum number of emblem points that can be distributed at one time.
-        /// </summary>
-        [DefaultValue(_MaxEmblemPoints)]
-        public ushort MaxEmblemPoints
-        {
-            set
-            {
-                SetSetting("MaxEmblemPoints", value);
-            }
-            get
-            {
-                return TryGetSetting("MaxEmblemPoints", _MaxEmblemPoints);
-            }
-        }
-        private const ushort _MaxEmblemPoints = 350;
-
 
         /// <summary>
         /// Defines the maximum amount you can increase your odds when attaching crests to the job emblem.


### PR DESCRIPTION
- Removed option MaxEmblemPoints and instead derive this based on level data and maximum level.
- Renamed function which calculates the maximum emblem points for the current job emblem level.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
