### PR TITLE
Hotfix: Ping timeout

### DIFF
--- a/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
@@ -21,7 +21,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
         private readonly object _tokensInFlightLock;
         private readonly HashSet<string> _tokensInFlight;
 
-        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = new HttpClient() { Timeout = TimeSpan.FromSeconds(5) };
         private bool _httpReady = false;
 
         public ClientLoginHandler(DdonLoginServer server) : base(server)


### PR DESCRIPTION
Pings properly time out so they don't hold the client hostage trying to ping a stuck (but not dead) server.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
