### PR TITLE
fix: Fix issues reported

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
@@ -118,6 +118,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 }
             }
 
+            if (previousStageId == 0)
+            {
+                targetClients.Add(client);
+            }
+
             if (targetClients.Any())
             {
                 SendContext(client, targetClients);

--- a/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobManager.cs
@@ -372,7 +372,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return neededSlots <= availableSlots;
         }
 
-        public PacketQueue UnlockSkill(GameClient client, CharacterCommon character, JobId job, uint skillId, byte skillLv, DbConnection? connectionIn = null)
+        public PacketQueue UnlockCustomSkill(GameClient client, CharacterCommon character, JobId job, uint skillId, byte skillLv, DbConnection? connectionIn = null)
         {
             PacketQueue queue = new();
 

--- a/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
@@ -186,7 +186,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == upgrade.CustomSkillId.ReleaseId()).FirstOrDefault();
                 if (existing == null)
                 {
-                    Server.JobManager.UnlockSkill(client, client.Character, jobId, upgrade.CustomSkillId.ReleaseId(), 1, connectionIn);
+                    Server.JobManager.UnlockCustomSkill(client, client.Character, jobId, upgrade.CustomSkillId.ReleaseId(), 1, connectionIn);
                 }
 
                 packets.Enqueue(client, new S2CSkillAcquirementLearnNtc()

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -456,7 +456,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new JobEmblemDetachElementHandler(this));
             AddHandler(new JobEmblemGetEmblemListHandler(this));
             AddHandler(new JobEmblemUpdateLevelHandler(this));
-            AddHandler(new JobEmblemUpdateParamLevel(this));
+            AddHandler(new JobEmblemUpdateParamLevelHandler(this));
             AddHandler(new JobEmblemResetParamLevelHandler(this));
 
             AddHandler(new JobMasterReportJobOrderProgressHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemAttachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemAttachElementHandler.cs
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var packets = new PacketQueue();
             var itemUpdateNtc = new S2CItemUpdateCharacterItemNtc()
             {
-                UpdateType = ItemNoticeType.GatherEquipItem
+                UpdateType = ItemNoticeType.EmblemStartAttach
             };
 
             if (request.EmblemUIDs.Count == 0)

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemDetachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemDetachElementHandler.cs
@@ -32,7 +32,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             var updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
             {
-                UpdateType = ItemNoticeType.GatherEquipItem
+                UpdateType = ItemNoticeType.EmblemStartDetach
             };
             Server.Database.ExecuteInTransaction(connection =>
             {

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemResetParamLevelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemResetParamLevelHandler.cs
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             var updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
             {
-                UpdateType = ItemNoticeType.GatherEquipItem,
+                UpdateType = ItemNoticeType.EmblemStatUpdate,
             };
 
             var emblemData = client.Character.JobEmblems[request.JobId];
@@ -60,14 +60,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             client.Enqueue(updateCharacterItemNtc, packets);
 
-            S2CEquipChangeCharacterEquipNtc changeCharacterEquipNtc = new S2CEquipChangeCharacterEquipNtc()
-            {
-                CharacterId = client.Character.CharacterId,
-                EquipItemList = client.Character.Equipment.AsCDataEquipItemInfo(EquipType.Performance),
-                VisualEquipItemList = client.Character.Equipment.AsCDataEquipItemInfo(EquipType.Visual)
-            };
-            Server.ClientLookup.EnqueueToAll(changeCharacterEquipNtc, packets);
-
             client.Enqueue(new S2CJobEmblemResetParamLevelRes()
             {
                 JobId = request.JobId,
@@ -75,7 +67,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 EmblemStatParamList = emblemData.GetEmblemStatParamList(),
                 EmblemPoints = new CDataJobEmblemPoints()
                 {
-                    JobId = JobId.Fighter,
+                    JobId = request.JobId,
                     Amount = Server.JobEmblemManager.GetAvailableEmblemPoints(emblemData),
                     MaxAmount = Server.JobEmblemManager.MaxEmblemPointsForLevel(emblemData)
                 }

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevelHandler.cs
@@ -9,11 +9,11 @@ using System;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
-    public class JobEmblemUpdateParamLevel : GameRequestPacketQueueHandler<C2SJobEmblemUpdateParamLevelReq, S2CJobEmblemUpdateParamLevelRes>
+    public class JobEmblemUpdateParamLevelHandler : GameRequestPacketQueueHandler<C2SJobEmblemUpdateParamLevelReq, S2CJobEmblemUpdateParamLevelRes>
     {
-        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(JobEmblemUpdateParamLevel));
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(JobEmblemUpdateParamLevelHandler));
 
-        public JobEmblemUpdateParamLevel(DdonGameServer server) : base(server)
+        public JobEmblemUpdateParamLevelHandler(DdonGameServer server) : base(server)
         {
         }
 
@@ -22,7 +22,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var packets = new PacketQueue();
             var updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
             {
-                UpdateType = ItemNoticeType.GatherEquipItem,
+                UpdateType = ItemNoticeType.EmblemStatUpdate,
             };
 
             var emblemData = client.Character.JobEmblems[request.JobId];
@@ -47,14 +47,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(client.Character, item, storageType, slotNo, 1, 1));
             }
             client.Enqueue(updateCharacterItemNtc, packets);
-
-            S2CEquipChangeCharacterEquipNtc changeCharacterEquipNtc = new S2CEquipChangeCharacterEquipNtc()
-            {
-                CharacterId = client.Character.CharacterId,
-                EquipItemList = client.Character.Equipment.AsCDataEquipItemInfo(EquipType.Performance),
-                VisualEquipItemList = client.Character.Equipment.AsCDataEquipItemInfo(EquipType.Visual)
-            };
-            Server.ClientLookup.EnqueueToAll(changeCharacterEquipNtc, packets);
 
             client.Enqueue(new S2CJobEmblemUpdateParamLevelRes()
             {

--- a/Arrowgene.Ddon.GameServer/Handler/SkillLearnPawnSkillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillLearnPawnSkillHandler.cs
@@ -22,7 +22,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             Pawn pawn = client.Character.PawnById(request.PawnId, PawnType.Main);
             Server.Database.ExecuteInTransaction(connection =>
             {
-                packets = Server.JobManager.UnlockSkill(client, pawn, request.Job, request.SkillId, request.SkillLv, connection);
+                packets = Server.JobManager.UnlockCustomSkill(client, pawn, request.Job, request.SkillId, request.SkillLv, connection);
             });
 
             return packets;

--- a/Arrowgene.Ddon.GameServer/Handler/SkillLearnSkillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillLearnSkillHandler.cs
@@ -19,7 +19,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Server.Database.ExecuteInTransaction(connection =>
             {
-                packets = Server.JobManager.UnlockSkill(client, client.Character, request.Job, request.SkillId, request.SkillLv, connection);
+                packets = Server.JobManager.UnlockCustomSkill(client, client.Character, request.Job, request.SkillId, request.SkillLv, connection);
             });
 
             return packets;

--- a/Arrowgene.Ddon.Server/Settings/EmblemSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/EmblemSettings.cs
@@ -2,7 +2,6 @@ using Arrowgene.Ddon.Server.Scripting.utils;
 using Arrowgene.Ddon.Shared.Model;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Threading;
 
 namespace Arrowgene.Ddon.Server.Settings
 {
@@ -11,7 +10,6 @@ namespace Arrowgene.Ddon.Server.Settings
         public EmblemSettings(ScriptableSettings settingsData) : base(settingsData, typeof(EmblemSettings).Name)
         {
         }
-
 
         /// <summary>
         /// Sets the maximum level the emblem can be upgraded to.

--- a/Arrowgene.Ddon.Shared/Model/ItemNoticeType.cs
+++ b/Arrowgene.Ddon.Shared/Model/ItemNoticeType.cs
@@ -55,7 +55,28 @@ namespace Arrowgene.Ddon.Shared.Model
         ReleaseTreeElement = 0x32,
         PawnExpeditionDrop = 0x33,
         StorePostItemBoxGacha = 0x34,
+        // 0x35
+        // 0x36
+        // 0x37
         SoulOrdealReward = 0x38,
+        // 0x39
+        // 0x3a
+        // 0x3b
+        // 0x3c
+        // 0x3d
+        // 0x3e
+        // 0x3f
+        // 0x40
+        // 0x41
+        // 0x42
+        // 0x43
+        // 0x44
+        // 0x45
+        EmblemStartAttach = 0x46,
+        EmblemStartDetach = 0x47,
+        // 0x48
+        // 0x49
+        EmblemStatUpdate = 0x4a,
         GatherEquipItem = 0x4b,
         Debug = 0x64,
         DebugAdd = 0x64,


### PR DESCRIPTION
- Fixed an issue where the player context is not sent to the player on login, which causes emblem stats to not be calculated.
- Renamed JobEmblemUpdateParamLevel.cs to JobEmblemUpdateParamLevelHandler.cs
- Renamed UnlockSkill to UnlockCustomSkill.
- Found new item update notices which seem to be designed for the emblem.
- Fixed an issue where a field in one of the emblem packets was hard coded to figter job id.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
