### PR TITLE
Clan Requests

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 43;
+    public const uint Version = 44;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_clan_requests.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_clan_requests.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "ddon_clan_requests"
+(
+    "requester_character_id"    INTEGER PRIMARY KEY NOT NULL,
+    "clan_id"                   INTEGER  NOT NULL,
+    "created"                   DATETIME NOT NULL,
+    "approved"                  SMALLINT NOT NULL,
+    CONSTRAINT "fk_ddon_clan_requests_clan_id" FOREIGN KEY ("clan_id") REFERENCES "ddon_clan_param" ("clan_id") ON DELETE CASCADE,
+    CONSTRAINT "fk_ddon_clan_requests_requester_character_id" FOREIGN KEY ("requester_character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+
+INSERT INTO "ddon_schedule_next" ("type", "timestamp")
+VALUES (25, 0);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -1022,3 +1022,14 @@ CREATE TABLE IF NOT EXISTS "ddon_job_emblem" (
     CONSTRAINT pk_ddon_job_emblem PRIMARY KEY ("character_id", "job_id"),
     CONSTRAINT fk_ddon_job_emblem_character_id FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS "ddon_clan_requests" (
+    "requester_character_id"    INTEGER PRIMARY KEY NOT NULL,
+    "clan_id"                   INTEGER  NOT NULL,
+    "created"                   DATETIME NOT NULL,
+    "approved"                  SMALLINT NOT NULL,
+    CONSTRAINT "fk_ddon_clan_requests_clan_id" FOREIGN KEY ("clan_id") REFERENCES "ddon_clan_param" ("clan_id") ON DELETE CASCADE,
+    CONSTRAINT "fk_ddon_clan_requests_requester_character_id" FOREIGN KEY ("requester_character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+INSERT INTO "ddon_schedule_next" ("type", "timestamp")
+VALUES (25, 0);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -476,6 +476,13 @@ public interface IDatabase
     bool InsertOrUpdateClanBaseCustomization(uint clanId, byte type, uint furnitureId, DbConnection? connectionIn = null);
     bool DeleteClanBaseCustomization(uint clanId, byte type, DbConnection? connectionIn = null);
     List<CDataClanSearchResult> SearchClans(CDataClanSearchParam param, DbConnection? connectionIn = null);
+    bool InsertClanRequest(uint clanId, uint characterId, DbConnection? connectionIn = null);
+    List<CDataClanJoinRequest> GetClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null);
+    List<CDataClanJoinRequest> GetApprovedClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null);
+    List<CDataClanJoinRequest> GetClanRequestsByClan(uint clanId, DbConnection? connectionIn = null);
+    bool SetClanRequestApproved(uint characterId, DbConnection? connectionIn = null);
+    bool DeleteClanRequestByCharacter(uint characterId, DbConnection? connectionIn = null);
+    bool DeleteOldClanRequests(uint minDays = 30, DbConnection? connectionIn = null);
 
     // Epitaph Road
     bool InsertEpitaphRoadUnlock(uint characterId, uint epitaphId, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbClan.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbClan.cs
@@ -88,6 +88,7 @@ public partial class DdonSqlDb : SqlDb
         + "AND (@dont_filter_by_active_days OR active_days & @active_days > 0) "
         + "AND (@dont_filter_by_active_time OR active_time & @active_time > 0) "
         + "AND (@dont_filter_by_characteristic OR characteristic & @characteristic > 0) "
+        + "AND is_publish = 1 "
         + "LIMIT 256;"; // limit imposed by client
 
     private readonly string SqlSelectClanShopPurchases = $"SELECT {BuildQueryField(ClanShopFields)} FROM \"ddon_clan_shop_purchases\" WHERE \"clan_id\" = @clan_id;";

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbClanRequests.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbClanRequests.cs
@@ -1,0 +1,196 @@
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using System.Collections.Generic;
+using System.Data.Common;
+using System;
+
+namespace Arrowgene.Ddon.Database.Sql.Core
+{
+    public partial class DdonSqlDb : SqlDb
+    {
+        /* ddon_clan_requests */
+        protected static readonly string[] ClanRequestFields = new[]
+        {
+            "clan_id", "requester_character_id", "created", "approved"
+        };
+        
+        private readonly string SqlInsertClanRequest = $"""
+            INSERT INTO ddon_clan_requests ({BuildQueryField(ClanRequestFields)})
+            VALUES ({BuildQueryInsert(ClanRequestFields)});
+        """;
+
+        private readonly string SqlSelectClanRequestsByCharacter = $"""
+            SELECT req."clan_id", req."requester_character_id", req."created", req."approved", chara."first_name", chara."last_name", param."name"
+            FROM ddon_clan_requests AS req
+            INNER JOIN ddon_character AS chara ON req.requester_character_id = chara.character_id
+            INNER JOIN ddon_clan_param AS param ON param.clan_id = req.clan_id
+            WHERE req.requester_character_id = @requester_character_id
+            AND req.approved = 0;
+        """;
+
+        private readonly string SqlSelectApprovedClanRequestsByCharacter = $"""
+            SELECT req."clan_id", req."requester_character_id", req."created", req."approved", chara."first_name", chara."last_name", param."name"
+            FROM ddon_clan_requests AS req
+            INNER JOIN ddon_character AS chara ON req.requester_character_id = chara.character_id
+            INNER JOIN ddon_clan_param AS param ON param.clan_id = req.clan_id
+            WHERE req.requester_character_id = @requester_character_id
+            AND req.approved = 1;
+        """;
+            
+        private readonly string SqlSelectClanRequestsByClan = $"""
+            SELECT req."clan_id", req."requester_character_id", req."created", req."approved", chara."first_name", chara."last_name", param."name"
+            FROM ddon_clan_requests AS req
+            INNER JOIN ddon_character AS chara ON req.requester_character_id = chara.character_id
+            INNER JOIN ddon_clan_param AS param ON param.clan_id = req.clan_id
+            WHERE req.clan_id = @clan_id
+            AND req.approved = 0;
+        """;
+
+        private readonly string SqlSetClanRequestApproved = $"""
+            UPDATE ddon_clan_requests
+            SET approved = 1
+            WHERE requester_character_id = @requester_character_id;
+        """;
+
+        private readonly string SqlDeleteClanRequestByCharacter = $"""
+            DELETE FROM ddon_clan_requests
+            WHERE requester_character_id = @requester_character_id;
+        """;
+
+        private readonly string SqlDeleteOldClanRequests = $"""
+            DELETE FROM ddon_clan_requests
+            WHERE created < @date_filter;
+        """;
+
+
+        public override bool InsertClanRequest(uint clanId, uint characterId, DbConnection connectionIn = null)
+        {
+            return ExecuteQuerySafe(connectionIn, connection =>
+            {
+                return ExecuteNonQuery(connection, SqlInsertClanRequest, command =>
+                {
+                    AddParameter(command, "clan_id", clanId);
+                    AddParameter(command, "requester_character_id", characterId);
+                    AddParameter(command, "created", DateTime.Now);
+                    AddParameter(command, "approved", 0);
+                }) == 1;
+            });
+        }
+
+        public override List<CDataClanJoinRequest> GetClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null)
+        {
+            List<CDataClanJoinRequest> results = new();
+            ExecuteQuerySafe(connectionIn, connection =>
+            {
+                ExecuteReader(connection, SqlSelectClanRequestsByCharacter, command =>
+                {
+                    AddParameter(command, "requester_character_id", characterId);
+                },
+                reader =>
+                { 
+                    while (reader.Read())
+                    {
+                        results.Add(ReadClanRequestData(reader));
+                    }
+                });
+            });
+
+            return results;
+        }
+        public override List<CDataClanJoinRequest> GetApprovedClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null)
+        {
+            List<CDataClanJoinRequest> results = new();
+            ExecuteQuerySafe(connectionIn, connection =>
+            {
+                ExecuteReader(connection, SqlSelectApprovedClanRequestsByCharacter, command =>
+                {
+                    AddParameter(command, "requester_character_id", characterId);
+                },
+                reader =>
+                { 
+                    while (reader.Read())
+                    {
+                        results.Add(ReadClanRequestData(reader));
+                    }
+                });
+            });
+
+            return results;
+        }
+
+        public override List<CDataClanJoinRequest> GetClanRequestsByClan(uint clanId, DbConnection? connectionIn = null)
+        {
+            List<CDataClanJoinRequest> results = new();
+            ExecuteQuerySafe(connectionIn, connection =>
+            {
+                ExecuteReader(connection, SqlSelectClanRequestsByClan, command =>
+                {
+                    AddParameter(command, "clan_id", clanId);
+                },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        results.Add(ReadClanRequestData(reader));
+                    }
+                });
+            });
+
+            return results;
+        }
+
+        public override bool SetClanRequestApproved(uint characterId, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe(connectionIn, connection =>
+            {
+                return ExecuteNonQuery(connection, SqlSetClanRequestApproved, command =>
+                {
+                    AddParameter(command, "requester_character_id", characterId);
+                }) == 1;
+            });
+        }
+
+        public override bool DeleteClanRequestByCharacter(uint characterId, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe(connectionIn, connection =>
+            {
+                return ExecuteNonQuery(connection, SqlDeleteClanRequestByCharacter, command =>
+                {
+                    AddParameter(command, "requester_character_id", characterId);
+                }) == 1;
+            });
+        }
+
+        public override bool DeleteOldClanRequests(uint minDays = 30, DbConnection? connectionIn = null)
+        {
+            return ExecuteQuerySafe(connectionIn, connection =>
+            {
+                return ExecuteNonQuery(connection, SqlDeleteOldClanRequests, command =>
+                {
+                    AddParameter(command, "date_filter", DateTime.Now.AddDays(-minDays));
+                }) == 1;
+            });
+        }
+
+        private CDataClanJoinRequest ReadClanRequestData(DbDataReader reader)
+        {
+            CDataClanJoinRequest result = new()
+            {
+                ClanId = GetUInt32(reader, "clan_id"),
+                ClanName = GetString(reader, "name"),
+                BaseInfo = new CDataCommunityCharacterBaseInfo()
+                {
+                    CharacterId = GetUInt32(reader, "requester_character_id"),
+                    CharacterName = new CDataCharacterName
+                    {
+                        FirstName = GetString(reader, "first_name"),
+                        LastName = GetString(reader, "last_name")
+                    }
+                },
+                CreateTime = GetDateTime(reader, "created")
+            };
+
+            return result;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000044_ClanRequestMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000044_ClanRequestMigration.cs
@@ -1,0 +1,24 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class ClanRequestMigration : IMigrationStrategy
+    {
+        public uint From => 43;
+        public uint To => 44;
+
+        private readonly DatabaseSetting DatabaseSetting;
+
+        public ClanRequestMigration(DatabaseSetting databaseSetting)
+        {
+            DatabaseSetting = databaseSetting;
+        }
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(DatabaseSetting, "Script/migration_clan_requests.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -513,6 +513,13 @@ public abstract class SqlDb : IDatabase
     public abstract List<CDataClanMemberInfo> GetClanMemberList(uint clanId, DbConnection? connectionIn = null);
     public abstract CDataClanMemberInfo GetClanMember(uint characterId, DbConnection? connectionIn = null);
     public abstract bool UpdateClanMember(CDataClanMemberInfo memberInfo, uint clanId, DbConnection? connectionIn = null);
+    public abstract bool InsertClanRequest(uint clanId, uint characterId, DbConnection? connectionIn = null);
+    public abstract List<CDataClanJoinRequest> GetClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null);
+    public abstract List<CDataClanJoinRequest> GetApprovedClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null);
+    public abstract List<CDataClanJoinRequest> GetClanRequestsByClan(uint clanId, DbConnection? connectionIn = null);
+    public abstract bool SetClanRequestApproved(uint characterId, DbConnection? connectionIn = null);
+    public abstract bool DeleteClanRequestByCharacter(uint characterId, DbConnection? connectionIn = null);
+    public abstract bool DeleteOldClanRequests(uint minDays = 30, DbConnection? connectionIn = null);
     public abstract List<uint> SelectClanShopPurchases(uint clanId, DbConnection? connectionIn = null);
     public abstract bool InsertClanShopPurchase(uint clanId, uint lineupId, DbConnection? connectionIn = null);
     public abstract List<(byte Type, uint Id)> SelectClanBaseCustomizations(uint clanId, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -276,10 +276,10 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new CharacterPawnGoldenReviveHandler(this));
             AddHandler(new CharacterPawnPointReviveHandler(this));
             AddHandler(new CharacterSetOnlineStatusHandler(this));
-			AddHandler(new CharacterEditGetShopPriceHandler(this));
-			AddHandler(new CharacterEditUpdateCharacterEditParamHandler(this));
+            AddHandler(new CharacterEditGetShopPriceHandler(this));
+            AddHandler(new CharacterEditUpdateCharacterEditParamHandler(this));
             AddHandler(new CharacterEditUpdateCharacterEditParamExHandler(this));
-			AddHandler(new CharacterEditUpdatePawnEditParamHandler(this));
+            AddHandler(new CharacterEditUpdatePawnEditParamHandler(this));
             AddHandler(new CharacterEditUpdatePawnEditParamExHandler(this));
             AddHandler(new CharacterCharacterDeadHandler(this));
             AddHandler(new CharacterCharacterDownCancelHandler(this));
@@ -311,6 +311,9 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new ClanClanInviteAcceptHandler(this));
             AddHandler(new ClanClanScoutEntrySearchHandler(this));
             AddHandler(new ClanClanSearchHandler(this));
+            AddHandler(new ClanClanJoinRequestHandler(this));
+            AddHandler(new ClanClanCancelJoinRequestHandler(this));
+            AddHandler(new ClanClanApproveJoinRequestHandler(this));
             AddHandler(new ClanClanScoutEntryGetInviteListHandler(this));
             AddHandler(new ClanClanLeaveMemberHandler(this));
             AddHandler(new ClanClanGetMemberListHandler(this));
@@ -584,9 +587,9 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new QuestGetAdventureGuideQuestNoticeHandler(this));
             AddHandler(new QuestGetAreaBonusListHandler(this));
             AddHandler(new QuestGetAreaInfoListHandler(this));
-			AddHandler(new QuestGetCycleContentsNewsListHandler(this));
+            AddHandler(new QuestGetCycleContentsNewsListHandler(this));
             AddHandler(new QuestGetCycleContentsStateListHandler(this));
-			AddHandler(new QuestGetEndContentsGroupHandler(this));
+            AddHandler(new QuestGetEndContentsGroupHandler(this));
             AddHandler(new QuestGetEndContentsRecruitListHandler(this));
             AddHandler(new QuestGetLevelBonusListHandler(this));
             AddHandler(new QuestGetLightQuestList(this));
@@ -627,10 +630,10 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new RankingRankListHandler(this));
             AddHandler(new RankingRankListByCharacterIdHandler(this));
 
-			AddHandler(new EntryBoardEntryBoardListHandler(this));
-			AddHandler(new EntryBoardEntryBoardItemCreateHandler(this));
-			AddHandler(new EntryBoardEntryBoardItemForceStartHandler(this));
-			AddHandler(new EntryBoardEntryBoardItemInfoMyselfHandler(this));
+            AddHandler(new EntryBoardEntryBoardListHandler(this));
+            AddHandler(new EntryBoardEntryBoardItemCreateHandler(this));
+            AddHandler(new EntryBoardEntryBoardItemForceStartHandler(this));
+            AddHandler(new EntryBoardEntryBoardItemInfoMyselfHandler(this));
             AddHandler(new EntryBoardEntryBoardItemReadyHandler(this));
             AddHandler(new EntryBoardEntryBoardItemLeaveHandler(this));
             AddHandler(new EntryBoardEntryItemInfoChangeHandler(this));
@@ -730,8 +733,8 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new StageGetSpAreaChangeInfoHandler(this));
 
             AddHandler(new StampBonusCheckHandler(this));
-			AddHandler(new StampBonusGetListHandler(this));
-			AddHandler(new StampBonusReceiveDailyHandler(this));
+            AddHandler(new StampBonusGetListHandler(this));
+            AddHandler(new StampBonusReceiveDailyHandler(this));
             AddHandler(new StampBonusReceiveTotalHandler(this));
 
             AddHandler(new WarpAreaWarpHandler(this));

--- a/Arrowgene.Ddon.GameServer/Handler/ClanClanApproveJoinRequestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClanClanApproveJoinRequestHandler.cs
@@ -1,0 +1,62 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model.Clan;
+using Arrowgene.Logging;
+using System;
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class ClanClanApproveJoinRequestHandler : GameRequestPacketHandler<C2SClanClanApproveJoinReq, S2CClanClanApproveJoinRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ClanClanApproveJoinRequestHandler));
+
+        public ClanClanApproveJoinRequestHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CClanClanApproveJoinRes Handle(GameClient client, C2SClanClanApproveJoinReq request)
+        {
+            bool shouldDelete = false;
+
+            if (request.IsApproved && Server.ClanManager.CheckAnyPermissions(client.Character.CharacterId,
+                [
+                    ClanPermission.GuildMaster,
+                    ClanPermission.JoinRequestApprove
+                ]))
+            {
+                shouldDelete = true;
+
+                Server.Database.ExecuteInTransaction(conn =>
+                {
+                    UInt32 clanId = Server.Database.GetClanRequestsByCharacter(request.CharacterId, conn).First().ClanId;
+                    Server.ClanManager.JoinClan(request.CharacterId, clanId, conn);
+
+                    if (Server.ClientLookup.GetClientByCharacterId(request.CharacterId) == null)
+                    {
+                        Server.Database.SetClanRequestApproved(request.CharacterId, conn);
+                        shouldDelete = false;
+                    }
+                });
+            }
+            else if (!request.IsApproved && Server.ClanManager.CheckAnyPermissions(client.Character.CharacterId,
+                [
+                    ClanPermission.GuildMaster,
+                    ClanPermission.JoinRequestDeny
+                ]))
+            {
+                shouldDelete = true;
+            }
+
+            if (shouldDelete)
+            {
+                Server.Database.ExecuteInTransaction(conn =>
+                {
+                    Server.Database.DeleteClanRequestByCharacter(request.CharacterId, conn);
+                });
+            }
+
+            return new S2CClanClanApproveJoinRes();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/ClanClanCancelJoinRequestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClanClanCancelJoinRequestHandler.cs
@@ -1,0 +1,24 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class ClanClanCancelJoinRequestHandler : GameRequestPacketHandler<C2SClanClanCancelJoinReq, S2CClanClanCancelJoinRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ClanClanCancelJoinRequestHandler));
+
+        public ClanClanCancelJoinRequestHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CClanClanCancelJoinRes Handle(GameClient client, C2SClanClanCancelJoinReq request)
+        {
+            Server.Database.ExecuteInTransaction(conn =>
+            {
+                Server.Database.DeleteClanRequestByCharacter(client.Character.CharacterId, conn);
+            });
+            return new S2CClanClanCancelJoinRes();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/ClanClanGetJoinRequestedListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClanClanGetJoinRequestedListHandler.cs
@@ -1,5 +1,7 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model.Clan;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -14,9 +16,22 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CClanClanGetJoinRequestedListRes Handle(GameClient client, C2SClanClanGetJoinRequestedListReq request)
         {
-            // TODO: Implement.
-            // client.Send(InGameDump.Dump_69);
-            return new();
+            S2CClanClanGetJoinRequestedListRes res = new S2CClanClanGetJoinRequestedListRes();
+
+            if (Server.ClanManager.CheckAnyPermissions(client.Character.CharacterId,
+                [
+                    ClanPermission.GuildMaster,
+                    ClanPermission.JoinRequestApprove,
+                    ClanPermission.JoinRequestDeny
+                ]))
+            {
+                Server.Database.ExecuteInTransaction(conn =>
+                {
+                    res.JoinReqList = Server.Database.GetClanRequestsByClan(client.Character.ClanId, conn);
+                });
+            }
+
+            return res;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/ClanClanGetMyJoinRequestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClanClanGetMyJoinRequestListHandler.cs
@@ -14,8 +14,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CClanClanGetMyJoinRequestListRes Handle(GameClient client, C2SClanClanGetMyJoinRequestListReq request)
         {
-            // TODO: Implement.
-            return new S2CClanClanGetMyJoinRequestListRes();
+            S2CClanClanGetMyJoinRequestListRes res = new S2CClanClanGetMyJoinRequestListRes();
+            Server.Database.ExecuteInTransaction(conn =>
+            {
+                res.JoinInfo = Server.Database.GetClanRequestsByCharacter(client.Character.CharacterId, conn);
+            });
+            return res;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/ClanClanJoinRequestHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClanClanJoinRequestHandler.cs
@@ -1,0 +1,24 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Logging;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    public class ClanClanJoinRequestHandler : GameRequestPacketHandler<C2SClanClanJoinRequest, S2CClanClanJoinRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ClanClanJoinRequestHandler));
+
+        public ClanClanJoinRequestHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CClanClanJoinRes Handle(GameClient client, C2SClanClanJoinRequest request)
+        {
+            Server.Database.ExecuteInTransaction(conn =>
+            {
+                Server.Database.InsertClanRequest(request.ClanId, client.Character.CharacterId, conn);
+            });
+            return new S2CClanClanJoinRes();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyJoinHandler.cs
@@ -73,6 +73,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             Server.BazaarManager.NotifySoldExhibitions(client);
+            Server.ClanManager.NotifyClanJoins(client);
 
             var allUsers = newUserNtc.UserList.Concat(alreadyPresentUsersNtc.UserList).ToList();
             return new S2CLobbyJoinRes()

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -35,6 +35,7 @@ namespace Arrowgene.Ddon.GameServer
                 new RankingBoardResetTask(DayOfWeek.Monday, 5, 0),
                 new PawnLikabilityIncreaseResetTask(5, 0),
                 new EquipmentRecycleResetTask(5, 0),
+                new ClanRequestCleanupTask(DayOfWeek.Monday, 5, 0),
             };
         }
 

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/ClanRequestCleanupTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/ClanRequestCleanupTask.cs
@@ -1,0 +1,27 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Logging;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
+{
+    public class ClanRequestCleanupTask : WeeklyTask
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ClanRequestCleanupTask));
+
+        public ClanRequestCleanupTask(DayOfWeek day, uint hour, uint minute) : base(TaskType.ClanRequestCleanup, day, hour, minute)
+        {
+        }
+
+        public override bool IsEnabled(DdonGameServer server)
+        {
+            return true;
+        }
+
+        public override void RunTask(DdonGameServer server)
+        {
+            Logger.Info("Performing weekly clan request cleanup");
+            server.Database.DeleteOldClanRequests();
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -618,6 +618,9 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SClanClanScoutEntryGetMyReq.Serializer());
             Create(new C2SClanClanScoutEntrySearchReq.Serializer());
             Create(new C2SClanClanSearchReq.Serializer());
+            Create(new C2SClanClanJoinRequest.Serializer());
+            Create(new C2SClanClanCancelJoinReq.Serializer());
+            Create(new C2SClanClanApproveJoinReq.Serializer());
             Create(new C2SClanClanSetMemberRankReq.Serializer());
             Create(new C2SClanClanSettingUpdateReq.Serializer());
             Create(new C2SClanClanShopBuyBuffItemReq.Serializer());
@@ -1179,6 +1182,9 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CClanClanScoutEntryGetMyRes.Serializer());
             Create(new S2CClanClanScoutEntrySearchRes.Serializer());
             Create(new S2CClanClanSearchRes.Serializer());
+            Create(new S2CClanClanJoinRes.Serializer());
+            Create(new S2CClanClanCancelJoinRes.Serializer());
+            Create(new S2CClanClanApproveJoinRes.Serializer());
             Create(new S2CClanClanSetMemberRankNtc.Serializer());
             Create(new S2CClanClanSetMemberRankRes.Serializer());
             Create(new S2CClanClanSettingUpdateRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SClanClanApproveJoinReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SClanClanApproveJoinReq.cs
@@ -1,0 +1,31 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SClanClanApproveJoinReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CLAN_CLAN_APPROVE_JOIN_REQ;
+
+        public UInt32 CharacterId { get; set; }
+        public bool IsApproved { get; set; }
+
+        public class Serializer : PacketEntitySerializer<C2SClanClanApproveJoinReq>
+        {
+            public override void Write(IBuffer buffer, C2SClanClanApproveJoinReq obj)
+            {
+                WriteUInt32(buffer, obj.CharacterId);
+                WriteBool(buffer, obj.IsApproved);
+            }
+
+            public override C2SClanClanApproveJoinReq Read(IBuffer buffer)
+            {
+                C2SClanClanApproveJoinReq obj = new();
+                obj.CharacterId = ReadUInt32(buffer);
+                obj.IsApproved = ReadBool(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SClanClanCancelJoinReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SClanClanCancelJoinReq.cs
@@ -1,0 +1,23 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SClanClanCancelJoinReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CLAN_CLAN_CANCEL_JOIN_REQ;
+
+        public class Serializer : PacketEntitySerializer<C2SClanClanCancelJoinReq>
+        {
+            public override void Write(IBuffer buffer, C2SClanClanCancelJoinReq obj)
+            {
+            }
+
+            public override C2SClanClanCancelJoinReq Read(IBuffer buffer)
+            {
+                return new C2SClanClanCancelJoinReq();
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SClanClanJoinRequest.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SClanClanJoinRequest.cs
@@ -1,0 +1,32 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SClanClanJoinRequest : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CLAN_CLAN_REGISTER_JOIN_REQ;
+
+        public UInt32 ClanId { get; set; }
+
+        public C2SClanClanJoinRequest()
+        {
+        }
+
+        public class Serializer : PacketEntitySerializer<C2SClanClanJoinRequest>
+        {
+            public override void Write(IBuffer buffer, C2SClanClanJoinRequest obj)
+            {
+                WriteUInt32(buffer, obj.ClanId);
+            }
+
+            public override C2SClanClanJoinRequest Read(IBuffer buffer)
+            {
+                C2SClanClanJoinRequest obj = new C2SClanClanJoinRequest();
+                obj.ClanId = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CClanClanApproveJoinRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CClanClanApproveJoinRes.cs
@@ -1,0 +1,26 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+using System;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CClanClanApproveJoinRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CLAN_CLAN_APPROVE_JOIN_RES;
+
+        public class Serializer : PacketEntitySerializer<S2CClanClanApproveJoinRes>
+        {
+            public override void Write(IBuffer buffer, S2CClanClanApproveJoinRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CClanClanApproveJoinRes Read(IBuffer buffer)
+            {
+                S2CClanClanApproveJoinRes obj = new();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CClanClanCancelJoinRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CClanClanCancelJoinRes.cs
@@ -1,0 +1,26 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CClanClanCancelJoinRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CLAN_CLAN_CANCEL_JOIN_RES;
+
+        public class Serializer : PacketEntitySerializer<S2CClanClanCancelJoinRes>
+        {
+            public override void Write(IBuffer buffer, S2CClanClanCancelJoinRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CClanClanCancelJoinRes Read(IBuffer buffer)
+            {
+                S2CClanClanCancelJoinRes obj = new S2CClanClanCancelJoinRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CClanClanJoinRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CClanClanJoinRes.cs
@@ -1,0 +1,26 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CClanClanJoinRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CLAN_CLAN_REGISTER_JOIN_RES;
+
+        public class Serializer : PacketEntitySerializer<S2CClanClanJoinRes>
+        {
+            public override void Write(IBuffer buffer, S2CClanClanJoinRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CClanClanJoinRes Read(IBuffer buffer)
+            {
+                S2CClanClanJoinRes obj = new S2CClanClanJoinRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataClanJoinRequest.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataClanJoinRequest.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Buffers;
+using System;
 
 namespace Arrowgene.Ddon.Shared.Entity.Structure
 {
@@ -13,7 +14,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         public uint ClanId { get; set; }
         public string ClanName { get; set; }
         public CDataCommunityCharacterBaseInfo BaseInfo { get; set; }
-        public long CreateTime { get; set; }
+        public DateTimeOffset CreateTime { get; set; }
 
         public class Serializer : EntitySerializer<CDataClanJoinRequest>
         {
@@ -22,7 +23,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 WriteUInt32(buffer, obj.ClanId);
                 WriteMtString(buffer, obj.ClanName);
                 WriteEntity<CDataCommunityCharacterBaseInfo>(buffer, obj.BaseInfo);
-                WriteInt64(buffer, obj.CreateTime);
+                WriteInt64(buffer, obj.CreateTime.ToUnixTimeSeconds());
             }
 
             public override CDataClanJoinRequest Read(IBuffer buffer)
@@ -31,7 +32,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
                 obj.ClanId = ReadUInt32(buffer);
                 obj.ClanName = ReadMtString(buffer);
                 obj.BaseInfo = ReadEntity<CDataCommunityCharacterBaseInfo>(buffer);
-                obj.CreateTime = ReadInt64(buffer);
+                obj.CreateTime = DateTimeOffset.FromUnixTimeSeconds(ReadInt64(buffer));
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Model/Scheduler/TaskType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Scheduler/TaskType.cs
@@ -32,5 +32,6 @@ namespace Arrowgene.Ddon.Shared.Model.Scheduler
         SeasonalEventSchedule = 22,
         RankingBoardReset = 23,
         EquipmentRecycleReset = 24,
+        ClanRequestCleanup = 25,
     }
 }

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -427,6 +427,13 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertOrUpdateClanBaseCustomization(uint clanId, byte type, uint furnitureId, DbConnection? connectionIn = null) { return true; }
         public bool DeleteClanBaseCustomization(uint clanId, byte type, DbConnection? connectionIn = null) { return true; }
         public List<CDataClanSearchResult> SearchClans(CDataClanSearchParam param, DbConnection? connectionIn = null) { return new(); }
+        public bool InsertClanRequest(uint clanId, uint characterId, DbConnection? connectionIn = null) { return true; }
+        public List<CDataClanJoinRequest> GetClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null) { return new(); }
+        public List<CDataClanJoinRequest> GetApprovedClanRequestsByCharacter(uint characterId, DbConnection? connectionIn = null) { return new(); }
+        public List<CDataClanJoinRequest> GetClanRequestsByClan(uint clanId, DbConnection? connectionIn = null) { return new(); }
+        public bool SetClanRequestApproved(uint characterId, DbConnection? connectionIn = null) { return true; }
+        public bool DeleteClanRequestByCharacter(uint characterId, DbConnection? connectionIn = null) { return true; }
+        public bool DeleteOldClanRequests(uint minDays = 30, DbConnection? connectionIn = null) { return true; }
 
         public bool InsertEpitaphRoadUnlock(uint characterId, uint epitaphId, DbConnection? connectionIn = null) { return true; }
         public HashSet<uint> GetEpitaphRoadUnlocks(uint characterId, DbConnection? connectionIn = null) { return new(); }


### PR DESCRIPTION
Continues work on Clan Search by implementing the Clan Request feature. This allows characters to request access to a clan, with approval performed by clan owners or clan members with appropriate permissions set. The scouting system remains unimplemented.

### Changes:
- New table "ddon_clan_requests" added to the db schema. Version incremented and migration strategy written.
- Handlers and related packet structures added for registering, cancelling, approving/rejecting, and listing clan join requests.
- Clan permissions are respected (+ minor fix to clan search so that non-public clans are not listed).
- New scheduled weekly task to remove stale requests older than 30 days (as suggested in-game(.
- Changes to ClanManager's JoinClan so that offline characters can be added to a clan, and notified on next login.

### Quirks / potential issues:
- One character may only have up to one clan request at a time. This is slightly non-intuitive but the client provides feedback to that effect. The limitation here is in the client, not the server implementation (my original approach was to allow arbitrary numbers of requests per character).
- Testing has been performed with sqlite and pgsql but only using various configurations of 2 test characters. A larger test environment (with more characters + clan members) may be beneficial to ensure there are no undesired behaviours.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
