### PR TITLE
fix: Fix another emblem bug

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevelHandler.cs
@@ -55,7 +55,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 EmblemStatParamList = emblemData.GetEmblemStatParamList(),
                 EmblemPoints = new CDataJobEmblemPoints()
                 {
-                    JobId = JobId.Fighter,
+                    JobId = request.JobId,
                     Amount = Server.JobEmblemManager.GetAvailableEmblemPoints(emblemData),
                     MaxAmount = Server.JobEmblemManager.MaxEmblemPointsForLevel(emblemData)
                 }


### PR DESCRIPTION
Fixed another spot where the wrong jobid is used.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
