### PR TITLE
fix: Properly update skills after EM4 first completion

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
@@ -183,7 +183,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 Server.CharacterManager.UnlockCustomSkill(client.Character, jobId, upgrade.CustomSkillId.ReleaseId(), 1);
 
                 // Handle players who had existing skills blocked by addition of S2 tree
-                var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == upgrade.CustomSkillId.ReleaseId()).FirstOrDefault();
+                var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == upgrade.CustomSkillId.ReleaseId() && x.Job == jobId).FirstOrDefault();
                 if (existing == null)
                 {
                     Server.JobManager.UnlockCustomSkill(client, client.Character, jobId, upgrade.CustomSkillId.ReleaseId(), 1, connectionIn);

--- a/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
@@ -1,9 +1,14 @@
 using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Characters
 {
@@ -11,10 +16,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(RewardManager));
 
-        private readonly DdonGameServer _Server;
+        private readonly DdonGameServer Server;
         public RewardManager(DdonGameServer server)
         {
-            _Server = server;
+            Server = server;
         }
 
         public bool AddQuestRewards(GameClient client, Quest quest, DbConnection? connectionIn = null)
@@ -22,22 +27,51 @@ namespace Arrowgene.Ddon.GameServer.Characters
             var rewards = quest.GenerateBoxRewards();
 
             var currentRewards = GetQuestBoxRewards(client, connectionIn);
-            if (currentRewards.Count >= _Server.GameSettings.GameServerSettings.RewardBoxMax)
+            if (currentRewards.Count >= Server.GameSettings.GameServerSettings.RewardBoxMax)
             {
                 return false;
             }
 
-            return _Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards, connectionIn);
+            return Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards, connectionIn);
         }
 
         public List<QuestBoxRewards> GetQuestBoxRewards(GameClient client, DbConnection? connectionIn = null)
         {
-            return _Server.Database.SelectBoxRewardItems(client.Character.CommonId, connectionIn);
+            return Server.Database.SelectBoxRewardItems(client.Character.CommonId, connectionIn);
         }
 
         public bool DeleteQuestBoxReward(GameClient client, uint uniqId, DbConnection? connectionIn = null)
         {
-            return _Server.Database.DeleteBoxRewardItem(client.Character.CommonId, uniqId, connectionIn);
+            return Server.Database.DeleteBoxRewardItem(client.Character.CommonId, uniqId, connectionIn);
+        }
+
+        public PacketQueue UnlockEM4Skills(GameClient client, DbConnection? connectionIn = null)
+        {
+            var packets = new PacketQueue();
+
+            var unlockedSkills = new S2CSkillAcquirementLearnNtc();
+            // TODO: Track quest completion on per job instead of unlocking all
+            foreach (var (jobId, releaseId) in SkillData.Em4CustomSkills)
+            {
+                Server.CharacterManager.UnlockCustomSkill(client.Character, jobId, releaseId, 1);
+
+                // Handle players who had existing skills before they were locked
+                var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == releaseId && x.Job == jobId).FirstOrDefault();
+                if (existing == null)
+                {
+                    Server.JobManager.UnlockCustomSkill(client, client.Character, jobId, releaseId, 1, connectionIn);
+                }
+
+                unlockedSkills.SkillParamList.Add(new CDataSkillLevelBaseParam()
+                {
+                    Job = jobId,
+                    SkillNo = releaseId,
+                    SkillLv = existing?.SkillLv ?? 1,
+                });
+            }
+            packets.Enqueue(client, unlockedSkills);
+
+            return packets;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -909,6 +909,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     Server.RewardManager.AddQuestRewards(memberClient, quest, connectionIn);
                 }
 
+                if (quest.QuestId == QuestId.TheShiningGate && !memberClient.Character.HasQuestCompleted(QuestId.TheShiningGate))
+                {
+                    packets.AddRange(Server.RewardManager.UnlockEM4Skills(memberClient, connectionIn));
+                }
+
                 // Check for Exp, Rift and Gold Rewards
                 var ntcs = SendWalletRewards(Server, memberClient, quest, connectionIn);
                 packets.AddRange(ntcs);


### PR DESCRIPTION
Fixed an issue where the skills were not properly unlocked when completing EM4.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
