### PR TITLE
fix: Fix Lestania equip in BBM

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
@@ -84,7 +84,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             client.Send(new S2CItemUpdateCharacterItemNtc()
             {
                 UpdateType = ItemNoticeType.SwitchingStorage,
-                UpdateItemList = SwapCharacterInventories(client.Character, previousStorage, ItemManager.ItemBagStorageTypes)
+                UpdateItemList = SwapCharacterInventories(client.Character, previousStorage, ItemManager.ItemBagStorageTypes.Concat([StorageType.CharacterEquipment]).ToList())
             });
 
             client.Send(new S2CEquipChangeCharacterEquipLobbyNtc()


### PR DESCRIPTION
Fixed an issue where the players equipment from Lestania shows up in the BBM equipment takeaway.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
