### PR TITLE
fix: Fix world quests which reset groups improperly

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007.json
@@ -109,6 +109,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {
@@ -119,6 +120,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 1 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005.json
@@ -99,6 +99,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030007.json
@@ -79,6 +79,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040001.json
@@ -97,6 +97,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004.json
@@ -86,6 +86,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006.json
@@ -116,6 +116,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007.json
@@ -87,6 +87,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050002.json
@@ -115,6 +115,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005.json
@@ -106,6 +106,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050007.json
@@ -110,6 +110,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060001.json
@@ -87,6 +87,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003.json
@@ -97,6 +97,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070005.json
@@ -131,6 +131,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080001.json
@@ -6,7 +6,7 @@
     "base_level": 48,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "EasternZandora",		
+    "area_id": "EasternZandora",		
     "rewards": [
         {
             "type": "exp",
@@ -78,7 +78,8 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
-            "groups": [0]
+            "reset_group": false,
+            "groups": [ 0 ]
         },
         {			
             "type": "CollectItem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080002.json
@@ -103,7 +103,8 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
-            "groups": [0]
+            "reset_group": false,
+            "groups": [ 0 ]
         },
         {
             "type": "TalkToNpc",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
@@ -103,6 +103,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000.json
@@ -88,6 +88,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001.json
@@ -78,6 +78,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002.json
@@ -84,6 +84,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004.json
@@ -88,6 +88,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010.json
@@ -106,6 +106,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000.json
@@ -108,6 +108,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003.json
@@ -102,6 +102,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Update",
+      "reset_group": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
@@ -75,6 +75,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
@@ -75,6 +75,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000006.json
@@ -101,6 +101,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000007.json
@@ -79,6 +79,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000008.json
@@ -79,6 +79,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000023.json
@@ -107,6 +107,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000036.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000036.json
@@ -79,6 +79,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000048.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000048.json
@@ -113,6 +113,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000073.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000073.json
@@ -90,6 +90,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000085.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000085.json
@@ -107,6 +107,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000096.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000096.json
@@ -103,6 +103,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000097.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000097.json
@@ -107,6 +107,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014001.json
@@ -78,6 +78,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014007.json
@@ -82,7 +82,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Accept",
-            "reset_group": true,
+            "reset_group": false,
             "groups": [0]
         }
     ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014008.json
@@ -149,6 +149,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {			
@@ -159,6 +160,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]
         },
         {			
@@ -169,6 +171,7 @@
         {				
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]			
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
@@ -133,6 +133,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {			
@@ -143,6 +144,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]
         },
         {			
@@ -153,6 +155,7 @@
         {				
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]			
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015000.json
@@ -205,6 +205,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {			
@@ -215,6 +216,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]
         },
         {			
@@ -225,6 +227,7 @@
         {				
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]			
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015007.json
@@ -107,7 +107,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Accept",
-            "reset_group": true,
+            "reset_group": false,
             "groups": [0]
         }
     ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015008.json
@@ -193,6 +193,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {			
@@ -203,6 +204,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]
         },
         {			
@@ -213,6 +215,7 @@
         {				
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]			
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016000.json
@@ -193,6 +193,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]				
         },
         {				
@@ -203,6 +204,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]				
         },
         {			
@@ -213,6 +215,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]				
         },
         {				

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016010.json
@@ -100,7 +100,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Accept",
-            "reset_group": true,
+            "reset_group": false,
             "groups": [0]
         }
     ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016012.json
@@ -125,6 +125,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]					
         },
         {		

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016014.json
@@ -88,7 +88,7 @@
     {
       "type": "KillGroup",
       "announce_type": "Accept",
-      "reset_group": true,
+      "reset_group": false,
       "groups": [
         0
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017000.json
@@ -187,6 +187,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {				
@@ -197,6 +198,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]
         },
         {				
@@ -207,6 +209,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]			
         },
         {				

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017007.json
@@ -100,7 +100,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Accept",
-            "reset_group": true,
+            "reset_group": false,
             "groups": [0]
         }
     ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017011.json
@@ -211,6 +211,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]		
         },
         {			
@@ -221,6 +222,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [1]		
         },
         {				
@@ -231,6 +233,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [2]		
         },
         {							

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017014.json
@@ -125,6 +125,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017015.json
@@ -111,6 +111,7 @@
         {
             "type": "KillGroup",
             "announce_type": "Update",
+            "reset_group": false,
             "groups": [0]		
         },
         {				


### PR DESCRIPTION
Fixed an issue where some world quests reset the enemy group improperly, causing the group to flash once reaching them.

Fixed the following world quest files:
- q20000007.json
- q20010005.json
- q20030007.json
- q20040001.json
- q20040004.json
- q20040006.json
- q20040007.json
- q20050002.json
- q20050005.json
- q20050007.json
- q20060001.json
- q20060003.json
- q20070005.json
- q20080001.json
- q20080002.json
- q20080006.json
- q20095000.json
- q20095001.json
- q20095002.json
- q20095004.json
- q20095010.json
- q20100000.json
- q20100003.json
- q20990004.json
- q20995002.json
- q21000006.json
- q21000007.json
- q21000008.json
- q21000023.json
- q21000036.json
- q21000048.json
- q21000073.json
- q21000085.json
- q21000096.json
- q21000097.json
- q21014001.json
- q21014007.json
- q21014008.json
- q21014009.json
- q21015000.json
- q21015007.json
- q21015008.json
- q21016000.json
- q21016010.json
- q21016012.json
- q21016014.json
- q21017000.json
- q21017007.json
- q21017011.json
- q21017014.json
- q21017015.json

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
