### PR TITLE
Fix: Hotfixes 06/01

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/EquipManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/EquipManager.cs
@@ -179,7 +179,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     );
 
                     //Check for ensemble requirements
-                    ClientItemInfo itemInfo = server.ItemManager.LookupInfoByUID(server, itemUId);
+                    ClientItemInfo itemInfo = server.ItemManager.LookupInfoByItem(server, result.Item2.Item2);
                     if (itemInfo.SubCategory == ItemSubCategory.EquipEnsemble)
                     {
                         foreach (EquipSlot slot in EnsembleSlots)

--- a/Arrowgene.Ddon.GameServer/Handler/CraftStartAttachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftStartAttachElementHandler.cs
@@ -63,7 +63,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 foreach (var element in request.CraftElementList)
                 {
-                    uint crestId = Server.ItemManager.LookupItemByUID(Server, element.ItemUId);
+                    var crestId = client.Character.Storage.FindItemByUIdInStorage(ItemManager.AllItemStorages, element.ItemUId)?.Item2.Item2.ItemId
+                        ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_NOT_FOUND, $"Could not find item {element.ItemUId}.");
 
                     Server.Database.InsertCrest(client.Character.CommonId, request.EquipItemUId, element.SlotNo, crestId, 0, connection);
                     result.EquipElementParamList.Add(new CDataEquipElementParam()

--- a/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPresentForPartnerPawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartnerPawnPresentForPartnerPawnHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
 using System.Collections.Generic;
+using System.Xml.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -27,7 +28,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 foreach (var item in request.ItemUIDList)
                 {
-                    uint itemId = Server.ItemManager.LookupItemByUID(Server, item.ItemUID);
+                    uint itemId = client.Character.Storage.FindItemByUIdInStorage(ItemManager.AllItemStorages, item.ItemUID)?.Item2.Item2.ItemId
+                        ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_NOT_FOUND, $"Could not find item {item.ItemUID}.");
                     var searchResult = client.Character.Storage.FindItemByUIdInStorage(ItemManager.BothStorageTypes, item.ItemUID);
                     var itemUpdate = Server.ItemManager.ConsumeItemByUId(Server, client.Character, searchResult.Item1, item.ItemUID, item.Num, connectionIn: connection)
                         ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_DONT_HAVE_DELIVERY_ITEM);

--- a/Arrowgene.Ddon.GameServer/Handler/PawnSpSkillDeleteStockSkillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnSpSkillDeleteStockSkillHandler.cs
@@ -16,7 +16,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CPawnSpSkillDeleteStockSkillRes Handle(GameClient client, C2SPawnSpSkillDeleteStockSkillReq request)
         {
             // TODO: Implement
-            throw new ResponseErrorException(ErrorCode.ERROR_CODE_NOT_IMPLEMENTED);
+            return new();
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
@@ -35,7 +35,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 foreach (var item in request.ItemUIDList)
                 {
-                    uint itemId = Server.ItemManager.LookupItemByUID(Server, item.ItemUID);
+                    uint itemId = client.Character.Storage.FindItemByUIdInStorage(ItemManager.AllItemStorages, item.ItemUID)?.Item2.Item2.ItemId
+                        ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_NOT_FOUND, $"Could not find item {item.ItemUID}.");
                     var searchResult = client.Character.Storage.FindItemByUIdInStorage(ItemManager.BothStorageTypes, item.ItemUID);
                     var itemUpdate = Server.ItemManager.ConsumeItemByUId(Server, client.Character, searchResult.Item1, item.ItemUID, item.Num, connectionIn: connection)
                         ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_DONT_HAVE_DELIVERY_ITEM);

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
@@ -12,13 +12,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
     {
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(SkillGetAcquirableAbilityListHandler));
 
-
         public static CDataAbilityParam GetAbilityFromId(uint abilityId)
         {
             var abilities = SkillData.AllAbilities.Concat(SkillData.AllSecretAbilities);
             return abilities.Where(x => x.AbilityNo == abilityId).FirstOrDefault();
         }
-
 
         public SkillGetAcquirableAbilityListHandler(DdonGameServer server) : base(server)
         {
@@ -26,6 +24,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CSkillGetAcquirableAbilityListRes Handle(GameClient client, C2SSkillGetAcquirableAbilityListReq request)
         {
+            // This list probably shouldn't be filtered because of caching,
+            // but its fine to return the normal gamemode result no matter what because the BBM character can't interact with abilities/augments.
+
             S2CSkillGetAcquirableAbilityListRes response = new S2CSkillGetAcquirableAbilityListRes();
             if (request.Job != 0)
             {

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
@@ -15,17 +15,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CSkillGetAcquirableSkillListRes Handle(GameClient client, C2SSkillGetAcquirableSkillListReq request)
         {
-            var skillList = client.Character.AcquirableSkills[request.Job];
-
+            // This list can't be filtered based on progress because it's cached between BBM and normal gameplay.
             return new S2CSkillGetAcquirableSkillListRes()
             {
-                SkillParamList = skillList
+                SkillParamList = client.Character.AcquirableSkills[request.Job]
             };
-        }
-
-        private bool IsSkillUnlocked(Character character, JobId jobId, uint skillNo)
-        {
-            return character.UnlockedCustomSkills[jobId].Contains(skillNo);
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetLearnedAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetLearnedAbilityListHandler.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
 using System.Linq;
 
@@ -17,10 +18,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             return new S2CSkillGetLearnedAbilityListRes()
             {
-                SetAcquierementParam = client.Character.LearnedAbilities
-                    .Select(x => x?.AsCDataLearnedSetAcquirementParam())
-                    .Where(x => x != null)
-                    .ToList()
+                SetAcquirementParam = [.. client.Character.LearnedAbilities.Select(x => x.AsCDataLearnedSetAcquirementParam())]
             };            
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetLearnedSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetLearnedSkillListHandler.cs
@@ -16,18 +16,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CSkillGetLearnedSkillListRes Handle(GameClient client, C2SSkillGetLearnedSkillListReq request)
         {
-            var skills = client.GameMode == GameMode.Normal ?
-                client.Character.LearnedCustomSkills
-                    .Where(x => !SkillData.IsS3HoSkill(x.Job, x.SkillId, x.SkillLv))
-                    .Select(x => x.AsCDataLearnedSetAcquirementParam())
-                    .ToList()
-                : client.Character.LearnedCustomSkills
-                    .Select(x => x.AsCDataLearnedSetAcquirementParam())
-                    .ToList();
-
             return new S2CSkillGetLearnedSkillListRes()
             {
-                SetAcquirementParam = skills
+                SetAcquirementParam = [.. client.Character.LearnedCustomSkills.Select(x => x.AsCDataLearnedSetAcquirementParam())]
             };
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetPawnLearnedAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetPawnLearnedAbilityListHandler.cs
@@ -20,7 +20,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             return new S2CSkillGetPawnLearnedAbilityListRes()
             {
                 PawnId = pawn.PawnId,
-                SetAcquierementParam = pawn.LearnedAbilities.Select(x => x.AsCDataLearnedSetAcquirementParam()).ToList()
+                SetAcquirementParam = pawn.LearnedAbilities
+                    .Select(x => x.AsCDataLearnedSetAcquirementParam())
+                    .ToList()
             };
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetPawnLearnedSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetPawnLearnedSkillListHandler.cs
@@ -18,10 +18,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CSkillGetPawnLearnedSkillListRes Handle(GameClient client, C2SSkillGetPawnLearnedSkillListReq request)
         {
             Pawn pawn = client.Character.PawnById(request.PawnId, PawnType.Main);
+
             return new S2CSkillGetPawnLearnedSkillListRes()
             {
                 PawnId = pawn.PawnId,
-                LearnedAcquierementParamList = pawn.LearnedCustomSkills.Select(x => x.AsCDataLearnedSetAcquirementParam()).ToList()
+                LearnedAcquirementParamList = pawn.LearnedCustomSkills
+                .Select(x => x.AsCDataLearnedSetAcquirementParam())
+                .ToList()
             };
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetReleaseSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetReleaseSkillListHandler.cs
@@ -19,7 +19,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CSkillGetReleaseSkillListRes Handle(GameClient client, C2SSkillGetReleaseSkillListReq request)
         {
             List<CDataReleaseAcquirementParam> releaseParamList = new();
-            foreach (var jobId in ((JobId[])JobId.GetValues(typeof(JobId))))
+            foreach (var jobId in System.Enum.GetValues<JobId>())
             {
                 var matches = Server.JobMasterManager.GetReleasedElements(client, jobId)
                     .Where(x => x.ReleaseType == ReleaseType.CustomSkill)

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -223,6 +223,12 @@ namespace Arrowgene.Ddon.GameServer.Party
                         $"[PartyId:{Id}][Accept] invitation expired");
                 }
 
+                if (Leader is null)
+                {
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_INVITE_FAIL_REASON_NO_LEADER,
+                        $"[PartyId:{Id}][Accept] has no leader");
+                }
+
                 PlayerPartyMember partyMember = GetPlayerPartyMember(client);
                 if (partyMember == null)
                 {

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/GameServerScriptModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/GameServerScriptModule.cs
@@ -4,6 +4,7 @@ using Arrowgene.Ddon.Shared;
 using Arrowgene.Logging;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Scripting;
+using System.Data.Common;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -22,10 +23,13 @@ namespace Arrowgene.Ddon.GameServer.Scripting
                 .AddReferences(MetadataReference.CreateFromFile(typeof(LibDdon).Assembly.Location))
                 .AddReferences(MetadataReference.CreateFromFile(typeof(LibUtils).Assembly.Location))
                 .AddReferences(MetadataReference.CreateFromFile(typeof(LogProvider).Assembly.Location))
+                .AddReferences(MetadataReference.CreateFromFile(typeof(DbConnection).Assembly.Location))
                 .AddImports("System", "System.Linq")
                 .AddImports("System.Collections")
                 .AddImports("System.Collections.Generic")
                 .AddImports("System.Collections.ObjectModel")
+                .AddImports("System.Data")
+                .AddImports("System.Data.Common")
                 .AddImports("System.Runtime.CompilerServices")
                 .AddImports("Arrowgene.Logging")
                 .AddImports("Arrowgene.Ddon.Database")

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetLearnedAbilityListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetLearnedAbilityListRes.cs
@@ -11,24 +11,24 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 
         public S2CSkillGetLearnedAbilityListRes()
         {
-            SetAcquierementParam=new List<CDataLearnedSetAcquirementParam>();
+            SetAcquirementParam=new List<CDataLearnedSetAcquirementParam>();
         }
 
-        public List<CDataLearnedSetAcquirementParam> SetAcquierementParam { get; set; }
+        public List<CDataLearnedSetAcquirementParam> SetAcquirementParam { get; set; }
 
         public class Serializer : PacketEntitySerializer<S2CSkillGetLearnedAbilityListRes>
         {
             public override void Write(IBuffer buffer, S2CSkillGetLearnedAbilityListRes obj)
             {
                 WriteServerResponse(buffer, obj);
-                WriteEntityList<CDataLearnedSetAcquirementParam>(buffer, obj.SetAcquierementParam);
+                WriteEntityList<CDataLearnedSetAcquirementParam>(buffer, obj.SetAcquirementParam);
             }
 
             public override S2CSkillGetLearnedAbilityListRes Read(IBuffer buffer)
             {
                 S2CSkillGetLearnedAbilityListRes obj = new S2CSkillGetLearnedAbilityListRes();
                 ReadServerResponse(buffer, obj);
-                obj.SetAcquierementParam = ReadEntityList<CDataLearnedSetAcquirementParam>(buffer);
+                obj.SetAcquirementParam = ReadEntityList<CDataLearnedSetAcquirementParam>(buffer);
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetPawnLearnedAbilityListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetPawnLearnedAbilityListRes.cs
@@ -11,11 +11,11 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 
         public S2CSkillGetPawnLearnedAbilityListRes()
         {
-            SetAcquierementParam=new List<CDataLearnedSetAcquirementParam>();
+            SetAcquirementParam=new List<CDataLearnedSetAcquirementParam>();
         }
 
         public uint PawnId { get; set; }
-        public List<CDataLearnedSetAcquirementParam> SetAcquierementParam { get; set; }
+        public List<CDataLearnedSetAcquirementParam> SetAcquirementParam { get; set; }
 
         public class Serializer : PacketEntitySerializer<S2CSkillGetPawnLearnedAbilityListRes>
         {
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             {
                 WriteServerResponse(buffer, obj);
                 WriteUInt32(buffer, obj.PawnId);
-                WriteEntityList<CDataLearnedSetAcquirementParam>(buffer, obj.SetAcquierementParam);
+                WriteEntityList<CDataLearnedSetAcquirementParam>(buffer, obj.SetAcquirementParam);
             }
 
             public override S2CSkillGetPawnLearnedAbilityListRes Read(IBuffer buffer)
@@ -31,7 +31,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 S2CSkillGetPawnLearnedAbilityListRes obj = new S2CSkillGetPawnLearnedAbilityListRes();
                 ReadServerResponse(buffer, obj);
                 obj.PawnId = ReadUInt32(buffer);
-                obj.SetAcquierementParam = ReadEntityList<CDataLearnedSetAcquirementParam>(buffer);
+                obj.SetAcquirementParam = ReadEntityList<CDataLearnedSetAcquirementParam>(buffer);
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetPawnLearnedSkillListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CSkillGetPawnLearnedSkillListRes.cs
@@ -11,11 +11,11 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 
         public S2CSkillGetPawnLearnedSkillListRes()
         {
-            LearnedAcquierementParamList = new List<CDataLearnedSetAcquirementParam>();
+            LearnedAcquirementParamList = new List<CDataLearnedSetAcquirementParam>();
         }
 
         public uint PawnId { get; set; }
-        public List<CDataLearnedSetAcquirementParam> LearnedAcquierementParamList { get; set; }
+        public List<CDataLearnedSetAcquirementParam> LearnedAcquirementParamList { get; set; }
 
         public class Serializer : PacketEntitySerializer<S2CSkillGetPawnLearnedSkillListRes>
         {
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             {
                 WriteServerResponse(buffer, obj);
                 WriteUInt32(buffer, obj.PawnId);
-                WriteEntityList<CDataLearnedSetAcquirementParam>(buffer, obj.LearnedAcquierementParamList);
+                WriteEntityList<CDataLearnedSetAcquirementParam>(buffer, obj.LearnedAcquirementParamList);
             }
 
             public override S2CSkillGetPawnLearnedSkillListRes Read(IBuffer buffer)
@@ -31,7 +31,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
                 S2CSkillGetPawnLearnedSkillListRes obj = new S2CSkillGetPawnLearnedSkillListRes();
                 ReadServerResponse(buffer, obj);
                 obj.PawnId = ReadUInt32(buffer);
-                obj.LearnedAcquierementParamList = ReadEntityList<CDataLearnedSetAcquirementParam>(buffer);
+                obj.LearnedAcquirementParamList = ReadEntityList<CDataLearnedSetAcquirementParam>(buffer);
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataLearnedSetAcquirementParam.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataLearnedSetAcquirementParam.cs
@@ -15,7 +15,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
         }
 
         public JobId Job { get; set; }
-        public byte Type { get; set; }
+        public ReleaseType Type { get; set; }
         public uint AcquirementNo { get; set; }
         public byte AcquirementLv { get; set; }
         public uint AcquirementParamId { get; set; }
@@ -25,7 +25,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             public override void Write(IBuffer buffer, CDataLearnedSetAcquirementParam obj)
             {
                 WriteByte(buffer, (byte) obj.Job);
-                WriteByte(buffer, obj.Type);
+                WriteByte(buffer, (byte) obj.Type);
                 WriteUInt32(buffer, obj.AcquirementNo);
                 WriteByte(buffer, obj.AcquirementLv);
                 WriteUInt32(buffer, obj.AcquirementParamId);
@@ -35,7 +35,7 @@ namespace Arrowgene.Ddon.Shared.Entity.Structure
             {
                 CDataLearnedSetAcquirementParam obj = new CDataLearnedSetAcquirementParam();
                 obj.Job = (JobId) ReadByte(buffer);
-                obj.Type = ReadByte(buffer);
+                obj.Type = (ReleaseType) ReadByte(buffer);
                 obj.AcquirementNo = ReadUInt32(buffer);
                 obj.AcquirementLv = ReadByte(buffer);
                 obj.AcquirementParamId = ReadUInt32(buffer);

--- a/Arrowgene.Ddon.Shared/Model/Ability.cs
+++ b/Arrowgene.Ddon.Shared/Model/Ability.cs
@@ -34,7 +34,7 @@ namespace Arrowgene.Ddon.Shared.Model
             return new CDataLearnedSetAcquirementParam()
             {
                 Job = this.Job,
-                Type = 0,
+                Type = ReleaseType.Augment,
                 AcquirementNo = this.AbilityId,
                 AcquirementLv = this.AbilityLv,
                 AcquirementParamId = 0

--- a/Arrowgene.Ddon.Shared/Model/CustomSkill.cs
+++ b/Arrowgene.Ddon.Shared/Model/CustomSkill.cs
@@ -34,7 +34,7 @@ namespace Arrowgene.Ddon.Shared.Model
             return new CDataLearnedSetAcquirementParam()
             {
                 Job = this.Job,
-                Type = (byte)ReleaseType.CustomSkill,
+                Type = ReleaseType.CustomSkill,
                 AcquirementNo = this.SkillId,
                 AcquirementLv = this.SkillLv,
                 AcquirementParamId = 0

--- a/Arrowgene.Ddon.Shared/Model/Storages.cs
+++ b/Arrowgene.Ddon.Shared/Model/Storages.cs
@@ -66,7 +66,9 @@ namespace Arrowgene.Ddon.Shared.Model
 
         public Storage GetStorage(StorageType storageType)
         {
-            return storages[storageType];
+            return storages.GetValueOrDefault(storageType)
+                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_STORAGE_TYPE, 
+                $"Invalid storage type {storageType}");
         }
 
         public bool HasStorage(StorageType storageType)


### PR DESCRIPTION
- Fix possible DB lock when changing equipment. Could not reproduce ensembles smooshing equipment out of existence, but this is likely related.
- Guards against accepting invites to leaderless parties, which could cause other issues.
- Consistency pass for behavior between players/pawns regarding S3 skills.
- Awkward semi-fix for deleting pawn SP skills; returning an error seemed to cause another pawn-related error, so do nothing and return the expected empty response.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
