### PR TITLE
fix: Quick fix for MSQ and EXM errors

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -268,6 +268,17 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
             foreach (var item in questBlock.ConsumePlayerItems)
             {
+                ItemId itemId = (ItemId) item.ItemId;
+                if (itemId.IsKeyItem())
+                {
+                    var items = client.Character.Storage.GetStorage(StorageType.KeyItems).FindItemsById(item.ItemId);
+                    if (items.Count == 0)
+                    {
+                        Logger.Error(client, $"The quest {QuestId} was expecting the key item '{itemId}' to be present, but it doesn't exist in the players inventory. Skipping.");
+                        continue;
+                    }
+                }
+
                 var result = server.ItemManager.ConsumeItemByIdFromItemBag(server, client.Character, item.ItemId, item.Amount);
                 if (result != null)
                 {

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -909,10 +909,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     Server.RewardManager.AddQuestRewards(memberClient, quest, connectionIn);
                 }
 
+#if false
                 if (quest.QuestId == QuestId.TheShiningGate && !memberClient.Character.HasQuestCompleted(QuestId.TheShiningGate))
                 {
                     packets.AddRange(Server.RewardManager.UnlockEM4Skills(memberClient, connectionIn));
                 }
+#endif
 
                 // Check for Exp, Rift and Gold Rewards
                 var ntcs = SendWalletRewards(Server, memberClient, quest, connectionIn);

--- a/Arrowgene.Ddon.Shared/Model/ItemId.cs
+++ b/Arrowgene.Ddon.Shared/Model/ItemId.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Arrowgene.Ddon.Shared.Model
 {
     public enum ItemId : uint
@@ -21507,5 +21509,35 @@ namespace Arrowgene.Ddon.Shared.Model
         _1207JpObtain10 = 13357,
         _1207JpObtained06 = 13353,
         _1207JpObtained07 = 13354,
+    }
+
+    public static class ItemIdExtension
+    {
+        private static List<ItemId> KeyItems = new List<ItemId>()
+        {
+            ItemId.AlchemyResearchBuildingKey,
+            ItemId.AncientDeenanKey,
+            ItemId.BrokenKeyOfTheSealedPalace,
+            ItemId.DreedChapelKey,
+            ItemId.DiamantesVesselOfLife,
+            ItemId.FullyBlockedDoorKey,
+            ItemId.KeyToGardnoxFortressFrontGate,
+            ItemId.KieshildtsVesselOfLife,
+            ItemId.LeadersRoomKey,
+            ItemId.LakeCeraDetachedPavillionKey,
+            ItemId.MysteriousAncientTexts,
+            ItemId.RiftstoneOre,
+            ItemId.SpecialResearchAreaGoldKey,
+            ItemId.SuppliesForTheFort,
+            ItemId.VesselOfLife0,
+            ItemId.VesselOfLife1,
+            ItemId.WaterFlowControlRoomKey,
+            ItemId.ZuhlsVesselOfLife,
+        };
+
+        public static bool IsKeyItem(this ItemId itemId)
+        {
+            return KeyItems.Contains(itemId);
+        }
     }
 }


### PR DESCRIPTION
- Added a check in quest step handling to ignore if a keyitem is missing when consuming.
- Commented out EXM4 rewards temporarily. Players will need to log out to see their new skills be unlocked.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
