### PR TITLE
fix: Indicate password is on in recruitment

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/BoardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/BoardManager.cs
@@ -73,6 +73,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 PartyLeaderCharacterId = leaderCharacterId,
             };
             data.EntryItem.Param = createParam;
+            data.EntryItem.Param.PasswordOn = password.Length > 0;
             data.EntryItem.Id = _EntryItemIdPool.GenerateId();
 
             // TODO: Quest Manager look up min/max


### PR DESCRIPTION
Fixed an issue where the UI doesn't show there was a board set.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
