### PR TITLE
Add Account Banning

### DIFF
--- a/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
@@ -77,6 +77,13 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                     }
                 }
 
+                if (account.State == AccountStateType.Banned)
+                {
+                    L2CEjectionNtc message = new L2CEjectionNtc { Message = "This account has been banned" };
+                    client.Send(message);
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_AUTH_LOGIN_FAILED, "This account is banned");
+                }
+
                 if (!account.LoginTokenCreated.HasValue)
                 {
                     throw new ResponseErrorException(ErrorCode.ERROR_CODE_AUTH_LOGIN_FAILED, "No login token exists");


### PR DESCRIPTION
There is an unused AccountStateType of Banned, so this checks if the account is in a banned state during the login process, (immediately after it is instantiated from the database) and throws an error if so. Server admins will be able to ban an account by setting its state to 0 in the database.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
