### PR TITLE
fix: Remove local path from scripts

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200033.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200033.csx
@@ -8,7 +8,7 @@
  *   /giveitem 8708
  */
 
-#load "C:\Users\Paul\Git\Arrowgene.DragonsDogmaOnline\Arrowgene.Ddon.Cli\bin\Debug\net9.0\Files\Assets\scripts\libs.csx"
+#load "libs.csx"
 
 public class ScriptedQuest : IQuest
 {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200034.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200034.csx
@@ -8,7 +8,7 @@
  *   /giveitem 8708
  */
 
-#load "C:\Users\Paul\Git\Arrowgene.DragonsDogmaOnline\Arrowgene.Ddon.Cli\bin\Debug\net9.0\Files\Assets\scripts\libs.csx"
+#load "libs.csx"
 
 public class ScriptedQuest : IQuest
 {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200035.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200035.csx
@@ -6,7 +6,7 @@
  *   - SummerEventYear : uint
  */
 
-#load "C:\Users\Paul\Git\Arrowgene.DragonsDogmaOnline\Arrowgene.Ddon.Cli\bin\Debug\net9.0\Files\Assets\scripts\libs.csx"
+#load "libs.csx"
 
 public class ScriptedQuest : IQuest
 {


### PR DESCRIPTION
Accidently checked in scripts with my local path in it.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
