### PR TITLE
fix: Fix issue due to quest schedule changes

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/mixins/enemy_exp.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/mixins/enemy_exp.csx
@@ -48,18 +48,22 @@
 
 public class Mixin : IExpMixin
 {
-    private HashSet<uint> AutomaticExpQuestExceptions = new HashSet<uint>()
+    private HashSet<QuestId> AutomaticExpQuestExceptions = new HashSet<QuestId>()
     {
-        (uint) QuestId.ResolutionsAndOmens
+        QuestId.ResolutionsAndOmens
     };
 
     public override uint GetExpValue(CharacterCommon characterCommon, InstancedEnemy enemy)
     {
         uint result = 0;
 
-        if (AutomaticExpQuestExceptions.Contains(enemy.QuestScheduleId))
+        if (enemy.QuestScheduleId != 0)
         {
-            return 0;
+            var quest = QuestManager.GetQuestByScheduleId(enemy.QuestScheduleId);
+            if (AutomaticExpQuestExceptions.Contains(quest.QuestId))
+            {
+                return 0;
+            }
         }
 
         var scheme = enemy.ExpScheme;


### PR DESCRIPTION
Fixed an issue where the automatic exp script didn't ignore the 1st MSQ.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
