### PR TITLE
refactor: Move solo quest state from party to client

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -266,7 +266,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             questScheduleIds.UnionWith(client.Party.QuestState.StageQuests(stageId));
             if (client.Party.Leader is not null)
             {
-                questScheduleIds.UnionWith(client.Party.Leader.QuestState.StageQuests(stageId));
+                questScheduleIds.UnionWith(client.Party.Leader.Client.QuestState.StageQuests(stageId));
             }
 
             return questScheduleIds;

--- a/Arrowgene.Ddon.GameServer/GameClient.cs
+++ b/Arrowgene.Ddon.GameServer/GameClient.cs
@@ -19,6 +19,7 @@ namespace Arrowgene.Ddon.GameServer
             InstanceDropItemManager = new(this, server);
             InstanceShopManager = new InstanceShopManager(server.ShopManager);
             GameMode = GameMode.Normal;
+            QuestState = new SoloQuestStateManager(this, server);
         }
 
         public void UpdateIdentity()
@@ -47,12 +48,7 @@ namespace Arrowgene.Ddon.GameServer
         public InstanceDropItemManager InstanceDropItemManager { get; }
 
         public GameMode GameMode { get; set; }
-
-        public QuestStateManager QuestState { get
-            {
-                return ((PlayerPartyMember)Party?.GetPartyMemberByCharacter(Character))?.QuestState;
-            } 
-        }
+        public SoloQuestStateManager QuestState { get; private set; }
 
         public bool IsPartyLeader()
         {

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -161,11 +161,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         }
                     }
 
-                    // TODO: This will be revisited so we can properly handle EXP assigned by tool and
-                    // TODO: EXP determined by the mixin. For now, the default behavior of the mixin
-                    // TODO: is the same as the original server behavior.
                     var enemyExpMixin = Server.ScriptManager.MixinModule.Get<IExpMixin>("enemy_exp");
-
                     foreach (PartyMember member in client.Party.Members)
                     {
                         if (member.JoinState != JoinState.On) continue; // Only fully joined members get rewards.
@@ -191,7 +187,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                                 gainedExp = (0, 0);
                             }
 
-                            var huntPackets = playerMember.QuestState.HandleEnemyHuntRequests(enemyKilled, connectionIn);
+                            var huntPackets = playerMember.Client.QuestState.HandleEnemyHuntRequests(enemyKilled, connectionIn);
                             queuedPackets.AddRange(huntPackets);
 
                             S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc();

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
@@ -49,7 +49,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
                 if (quest != null && quest.IsPersonal)
                 { 
-                    join.QuestState.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+                    client.QuestState.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/Party/PlayerPartyMember.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PlayerPartyMember.cs
@@ -10,12 +10,9 @@ public class PlayerPartyMember : PartyMember
     public PlayerPartyMember(GameClient client, DdonGameServer server)
     {
         Client = client;
-        QuestState = new SoloQuestStateManager(this, server);
     }
 
     public GameClient Client { get; set; }
-
-    public SoloQuestStateManager QuestState { get; set; }
 
     public override CDataPartyMember GetCDataPartyMember()
     {


### PR DESCRIPTION
Due to party invite oddities, we need to relocate the solo quest state so when players join EXM and Party Finder parties, the solo quest state will be available during the area transitions.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
