### PR TITLE
fix: Clean up duplicate NPCs

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetPartyQuestProgressInfoHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetPartyQuestProgressInfoHandler.cs
@@ -45,6 +45,24 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 quest.QuestFlagList = leaderClient.Character.GetWorldManageQuestUnlocks((QuestId)quest.QuestId);
                 // TODO: This will probably break everything currently if cleared as all doors in the world will be closed
                 // TODO: Need to go track down all quests
+
+                // TODO: Don't add these flags since they mess up with the cutscene state
+                // TODO: in some S2 and S3 cutscenes. Add them back properly when the story requires it.
+                if ((QuestId)quest.QuestId == QuestId.Q70033001)
+                {
+                    quest.QuestLayoutFlagList = new();
+                }
+                else if ((QuestId)quest.QuestId == QuestId.Q70023001)
+                {
+                    quest.QuestLayoutFlagList = quest.QuestLayoutFlagList.Where(x =>
+                        x.FlagId != QuestFlags.HollowOfBeginnings.Mordred.Value &&
+                        x.FlagId != QuestFlags.HollowOfBeginnings.SpiritDragon.Value).ToList();
+                }
+
+                // if ((QuestId)quest.QuestId == Server.GameSettings.DebugSettings.QuestId)
+                // {
+                //     quest.QuestLayoutFlagList = Server.GameSettings.DebugSettings.UintList.Select(x => new Shared.Entity.Structure.CDataQuestLayoutFlag() { FlagId = x }).ToList();
+                // }
                 // quest.QuestLayoutFlagList = leaderClient.Character.GetWorldManageLayoutUnlocks((QuestId)quest.QuestId);
             }
 

--- a/Arrowgene.Ddon.Server/GameSettings.cs
+++ b/Arrowgene.Ddon.Server/GameSettings.cs
@@ -6,6 +6,7 @@ namespace Arrowgene.Ddon.Server
     public class GameSettings
     {
         private ScriptableSettings SettingsData { get; set; }
+        public DebugSettings DebugSettings { get; private set; }
         public GameServerSettings GameServerSettings { get; private set; }
         public SeasonalEventSettings SeasonalEventsSettings { get; private set; }
         public PointModifierSettings PointModifiersSettings { get; private set; }
@@ -20,6 +21,7 @@ namespace Arrowgene.Ddon.Server
             PointModifiersSettings = new PointModifierSettings(SettingsData);
             ChatCommandsSettings = new ChatCommandSettings(SettingsData);
             EmblemSettings = new EmblemSettings(SettingsData);
+            DebugSettings = new DebugSettings(SettingsData);
         }
 
         public T Get<T>(string scriptName, string variableName)

--- a/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
+++ b/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
@@ -39,6 +39,7 @@ namespace Arrowgene.Ddon.Server.Scripting.modules
             // that defaults need to be assigned for
             DefaultSettings = new List<IGameSettings>()
             {
+                GameSettings.DebugSettings,
                 GameSettings.GameServerSettings,
                 GameSettings.ChatCommandsSettings,
                 GameSettings.SeasonalEventsSettings,

--- a/Arrowgene.Ddon.Server/Settings/DebugSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/DebugSettings.cs
@@ -1,0 +1,47 @@
+using Arrowgene.Ddon.Server.Scripting.utils;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Arrowgene.Ddon.Server.Settings
+{
+    public class DebugSettings : IGameSettings
+    {
+        public DebugSettings(ScriptableSettings settingsData) : base(settingsData, typeof(DebugSettings).Name)
+        {
+        }
+
+        /// <summary>
+        /// Used when debugging requires a hot reloadable quest id.
+        /// </summary>
+        [DefaultValue(_QuestId)]
+        public QuestId QuestId
+        {
+            set
+            {
+                SetSetting("QuestId", value);
+            }
+            get
+            {
+                return TryGetSetting("QuestId", _QuestId);
+            }
+        }
+        private const QuestId _QuestId = 0;
+
+        /// <summary>
+        /// Used when debugging requires a hot reloadable list of uints
+        /// </summary>
+        [DefaultValue("new List<uint>() {}")]
+        public List<uint> UintList
+        {
+            set
+            {
+                SetSetting("UintList", value);
+            }
+            get
+            {
+                return TryGetSetting<List<uint>>("UintList", []);
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Reflection;
 
 namespace Arrowgene.Ddon.Shared.Model.Quest
@@ -468,6 +467,16 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Unlocks "Valtable Hall" in Stage.HollowofBeginnings0 when set
             /// </summary>
             public static QuestFlagInfo ValtableHall { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(2183, QuestId.Q70023001);
+
+            /// <summary>
+            /// Spawns Spirit Dragon in Hallow of Beginnings
+            /// </summary>
+            public static QuestFlagInfo SpiritDragon { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(4515, QuestId.Q70023001, Stage.HollowofBeginnings1);
+
+            /// <summary>
+            /// Spawns Mordred in Hallow of Beginnings
+            /// </summary>
+            public static QuestFlagInfo Mordred { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(4973, QuestId.Q70023001, Stage.HollowofBeginnings1);
         }
 
         public static class ValtableHall
@@ -578,6 +587,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Opens the door to Epitaph Road: Rathnite Foothills
             /// </summary>
             public static QuestFlagInfo EpitaphRoadRathniteFoothills { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(3518, QuestId.Q70030001);
+
+            /// <summary>
+            /// Spawns Quintus in Fort Thines infront of the seat where Nedo sits.
+            /// @note Only appears to be set when the party is first created and doesn't change afterwards.
+            /// </summary>
+            public static QuestFlagInfo Quintus { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(8166, QuestId.Q70033001, StageInfo);
         }
 
         public static class RathniteFoothillsLakeside


### PR DESCRIPTION
Removed Quintus from the stage so he is not standing in front of Nedo in S3.0 CS. Removed Spirit Dragin and Modred from the stage so they are not there blocking multiple cutscenes in Season 2.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
