### PR TITLE
fix: Add enemy override to q60030001.json

### DIFF
--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -137,7 +137,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 return false;
             }
 
-                assetData.OverrideEnemySpawn = (assetData.QuestType == QuestType.Main || assetData.QuestType == QuestType.ExtremeMission);
+            assetData.OverrideEnemySpawn = (assetData.QuestType == QuestType.Main || assetData.QuestType == QuestType.ExtremeMission);
             if (jQuest.TryGetProperty("override_enemy_spawn", out JsonElement jOverrideEnemySpawn))
             {
                 assetData.OverrideEnemySpawn = jOverrideEnemySpawn.GetBoolean();

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q60030001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q60030001.json
@@ -12,6 +12,7 @@
     },
     "area_id": "MysreeForest",
     "adventure_guide_category": "AreaTrialOrMission",
+    "override_enemy_spawn": true,
     "order_conditions": [],
     "rewards": [
         {


### PR DESCRIPTION
Added flag that override enemy spawn while quest is active.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
