### PR TITLE
fix: Fix issue with the EXM board

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetQuestScheduleInfoHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetQuestScheduleInfoHandler.cs
@@ -1,19 +1,8 @@
-using Arrowgene.Buffers;
 using Arrowgene.Ddon.GameServer.Characters;
-using Arrowgene.Ddon.GameServer.Dump;
-using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
-using Arrowgene.Ddon.Server.Network;
-using Arrowgene.Ddon.Shared.Asset;
-using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
-using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.Json;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -25,12 +14,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-        public override S2CQuestGetQuestScheduleInfoRes Handle(GameClient client, C2SQuestGetQuestScheduleInfoReq packet)
+        public override S2CQuestGetQuestScheduleInfoRes Handle(GameClient client, C2SQuestGetQuestScheduleInfoReq request)
         {
-            // TODO: Convert QuestScheduleId to QuestId
+            var quest = QuestManager.GetQuestByScheduleId(request.QuestScheduleId) ??
+                throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_INTERNAL_ERROR, $"QuestScheduleId={request.QuestScheduleId} doesn't exist");
             return new S2CQuestGetQuestScheduleInfoRes()
             {
-                QuestId = packet.QuestScheduleId
+                QuestId = quest.QuestId
             };
         }
     }

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -960,14 +960,14 @@ namespace Arrowgene.Ddon.Shared.AssetReader
 
             if (!jMissionParams.TryGetProperty("group", out JsonElement jGroup))
             {
-                Logger.Error($"Missing required member 'group' from ExtremeMission config.");
+                Logger.Error($"Missing required member 'group' from Extreme Mission config.");
                 return false;
             }
             assetData.MissionParams.Group = jGroup.GetUInt32();
 
             if (!jMissionParams.TryGetProperty("phase_groups", out JsonElement jPhaseGroups))
             {
-                Logger.Error($"Missing required member 'phase_groups' from ExtremeMission config.");
+                Logger.Error($"Missing required member 'phase_groups' from Extreme Mission config.");
                 return false;
             }
 

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetQuestScheduleInfoReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SQuestGetQuestScheduleInfoReq.cs
@@ -1,8 +1,5 @@
 using Arrowgene.Buffers;
-using Arrowgene.Ddon.Shared.Entity.Structure;
-using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
-using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 {

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetQuestScheduleInfoRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestGetQuestScheduleInfoRes.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Arrowgene.Buffers;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 
 namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
@@ -9,21 +10,21 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
     {
         public override PacketId Id => PacketId.S2C_QUEST_GET_QUEST_SCHEDULE_INFO_RES;
 
-        public uint QuestId { get; set; }
+        public QuestId QuestId { get; set; }
 
         public class Serializer : PacketEntitySerializer<S2CQuestGetQuestScheduleInfoRes>
         {
             public override void Write(IBuffer buffer, S2CQuestGetQuestScheduleInfoRes obj)
             {
                 WriteServerResponse(buffer, obj);
-                WriteUInt32(buffer, obj.QuestId);
+                WriteUInt32(buffer, (uint) obj.QuestId);
             }
 
             public override S2CQuestGetQuestScheduleInfoRes Read(IBuffer buffer)
             {
                 S2CQuestGetQuestScheduleInfoRes obj = new S2CQuestGetQuestScheduleInfoRes();
                 ReadServerResponse(buffer, obj);
-                obj.QuestId = ReadUInt32(buffer);
+                obj.QuestId = (QuestId) ReadUInt32(buffer);
                 return obj;
             }
         }


### PR DESCRIPTION
Fixed an issue where the EXM board no longer worked as expected after quest schedule id changes. The quest schedule id was passed to a response packet that was expecting a quest id.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
