### PR TITLE
Add ability to merge epitaph drop tables

### DIFF
--- a/Arrowgene.Ddon.Shared/AssetReader/EpitaphRoadAssertDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EpitaphRoadAssertDeserializer.cs
@@ -6,6 +6,7 @@ using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 
 namespace Arrowgene.Ddon.Shared.AssetReader
@@ -165,6 +166,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                     epiPath.DropTables[dropTable.TableId] = dropTable;
                 }
 
+                uint mergedTableId = 0x80000000;
                 foreach (var jChests in jEpiPath.GetProperty("chests").EnumerateArray())
                 {
                     EpitaphWeeklyReward.Type definitionType = EpitaphWeeklyReward.Type.Single;
@@ -180,7 +182,26 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                     var dropTableIds = new List<uint>();
                     foreach (var jTableId in jChests.GetProperty("drop_tables").EnumerateArray())
                     {
-                        dropTableIds.Add(jTableId.GetUInt32());
+                        if (jTableId.ValueKind == JsonValueKind.Array)
+                        {
+                            var dropTable = new EpitaphDropTable()
+                            {
+                                TableId = mergedTableId++
+                            };
+
+                            if (!CreateMergedTable(epiPath, dropTable, jTableId))
+                            {
+                                Logger.Error($"Failed to create a new merged table with ID 0x{dropTable.TableId:08x} for {epiPath.Name}");
+                                continue;
+                            }
+
+                            dropTableIds.Add(dropTable.TableId);
+                            epiPath.DropTables[dropTable.TableId] = dropTable;
+                        }
+                        else
+                        {
+                            dropTableIds.Add(jTableId.GetUInt32());
+                        }
                     }
 
                     if (definitionType == EpitaphWeeklyReward.Type.Range)
@@ -314,6 +335,35 @@ namespace Arrowgene.Ddon.Shared.AssetReader
             }
 
             return asset;
+        }
+
+        private bool CreateMergedTable(EpitaphPath epiPath, EpitaphDropTable dropTable, JsonElement jTableIds)
+        {
+            EpitaphItemReward reward = new()
+            {
+                Rolls = 1,
+                Type = SoulOrdealRewardType.Pool
+            };
+
+            foreach (var jTableId in jTableIds.EnumerateArray())
+            {
+                var tableId = jTableId.GetUInt32();
+                if (!epiPath.DropTables.ContainsKey(tableId))
+                {
+                    Logger.Error($"A drop table with the ID {tableId} doesn't exist in {epiPath.Name}");
+                    return false;
+                }
+
+                var oldTable = epiPath.DropTables[tableId];
+                foreach (var item in oldTable.Items)
+                {
+                    reward.Items.AddRange(item.Items);
+                }
+            }
+
+            dropTable.Items.Add(reward);
+
+            return true;
         }
     }
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/EpitaphRoad.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/EpitaphRoad.json
@@ -2026,7 +2026,7 @@
                         "group_id": 214
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 1 ]
+                    "drop_tables": [ [ 6, 1 ] ]
                 },
                 {
                     "comment": "Gold Chest (Ruins)",
@@ -2036,7 +2036,7 @@
                         "group_id": 215
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 1 ]
+                    "drop_tables": [ [ 6, 1 ] ]
                 },
                 {
                     "comment": "Gold Chest (Ruins)",
@@ -2046,7 +2046,7 @@
                         "group_id": 217
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 1 ]
+                    "drop_tables": [ [ 6, 1 ] ]
                 },
                 {
                     "comment": "Bronze Chest (Ruins)",
@@ -2126,7 +2126,7 @@
                         "group_id": 214
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 2 ]
+                    "drop_tables": [ [ 6, 2 ] ]
                 },
                 {
                     "comment": "Gold Chest (Well)",
@@ -2136,7 +2136,7 @@
                         "group_id": 215
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 2 ]
+                    "drop_tables": [ [ 6, 2 ] ]
                 },
                 {
                     "comment": "Gold Chest (Well)",
@@ -2146,7 +2146,7 @@
                         "group_id": 217
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 2 ]
+                    "drop_tables": [ [ 6, 2 ] ]
                 },
                 {
                     "comment": "Bronze Chest (Well)",
@@ -2226,7 +2226,7 @@
                         "group_id": 214
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 3 ]
+                    "drop_tables": [ [ 6, 3 ] ]
                 },
                 {
                     "comment": "Gold Chest (Tomb)",
@@ -2246,7 +2246,7 @@
                         "group_id": 215
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 3 ]
+                    "drop_tables": [ [ 6, 3 ] ]
                 },
                 {
                     "comment": "Gold Chest (Tomb)",
@@ -2256,7 +2256,7 @@
                         "group_id": 217
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 3 ]
+                    "drop_tables": [ [ 6, 3 ] ]
                 },
                 {
                     "comment": "Bronze Chest (Tomb)",
@@ -2336,7 +2336,7 @@
                         "group_id": 214
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 3 ]
+                    "drop_tables": [ [ 6, 3 ] ]
                 },
                 {
                     "comment": "Gold Chest (Ruin Depths)",
@@ -2356,7 +2356,7 @@
                         "group_id": 215
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 3 ]
+                    "drop_tables": [ [ 6, 3 ] ]
                 },
                 {
                     "comment": "Gold Chest (Ruin Depths)",
@@ -2366,7 +2366,7 @@
                         "group_id": 217
                     },
                     "pos_id": 0,
-                    "drop_tables": [ 6, 3 ]
+                    "drop_tables": [ [ 6, 3 ] ]
                 },
                 {
                     "comment": "Gold Chest (Final Trial)",


### PR DESCRIPTION
When defining epitaph weekly chest rewards, it's possible to provide an array of drop table ids to create a single drop slot which contains a pool of items from all provided ids.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
