### PR TITLE
Fix Another ExpLimit Index Error

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/CraftManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CraftManager.cs
@@ -433,7 +433,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 rankUpNtc.CraftRank = leadPawn.CraftData.CraftRank;
                 rankUpNtc.TotalCraftPoint = leadPawn.CraftData.CraftPoint;
                 
-                leadPawn.CraftData.CraftExp = Math.Clamp(leadPawn.CraftData.CraftExp, 0, craftRankExpLimit[(int)leadPawn.CraftData.CraftRankLimit-1]);
+                leadPawn.CraftData.CraftExp = Math.Clamp(leadPawn.CraftData.CraftExp, 0, craftRankExpLimit[Math.Min((int)leadPawn.CraftData.CraftRankLimit-1, craftRankExpLimit.Count - 1)]);
             }
 
             return rankUpNtc;


### PR DESCRIPTION
Missed on the first pass, this fixes an S-1 error thrown due an index out of range on leveling from 66-68. CraftRankLimit is 71 after the final trial, and craftRankExpLimit[70] doesn't exist.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
