### PR TITLE
fix: Fix scripting module load dependencies

### DIFF
--- a/Arrowgene.Ddon.GameServer/Scripting/GameServerScriptManager.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/GameServerScriptManager.cs
@@ -1,6 +1,7 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Scripting;
 using Arrowgene.Logging;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
@@ -53,19 +54,26 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             AddModule(JobEmblemStatModule);
             AddModule(SpecialSkillAugmentationModule);
             AddModule(JobOrbSpecialConditionModule);
-
-            // World Manage Quests have some dependency on Caution Spots, so load caution spots first
-            // to prevent unecssary quest relod on server load
             AddModule(MonsterCautionSpotModule);
-            AddModule(QuestModule);
-
-            // This module should run last since it applies fine grained modifications to other modules
-            AddModule(AddendumModule);
         }
 
         public override void Initialize()
         {
             base.Initialize(Globals);
+        }
+
+        protected override void CompileScripts(List<ScriptModule> modules = null)
+        {
+            base.CompileScripts(modules);
+
+            // World Manage Quests have a dependency on Caution Spots, so load quests after
+            // caution spots
+            base.CompileScripts([QuestModule]);
+            AddModule(QuestModule);
+
+            // This module should run last since it applies fine grained modifications to other modules
+            base.CompileScripts([AddendumModule]);
+            AddModule(AddendumModule);
         }
 
         protected override void OnChanged(object sender, FileSystemEventArgs e)

--- a/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
+++ b/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -167,10 +168,10 @@ namespace Arrowgene.Ddon.Shared.Scripting
             return false;
         }
 
-        protected void CompileScripts()
+        protected virtual void CompileScripts(List<ScriptModule> modules = null)
         {
-            Dictionary<string, ScriptModule>.ValueCollection scriptModulesValues = ScriptModules.Values;
-            Parallel.ForEach(scriptModulesValues, module =>
+            var scriptModules = modules ?? ScriptModules.Values.ToList();
+            Parallel.ForEach(scriptModules, module =>
             {
                 var path = Path.Combine(ScriptsRoot, module.ModuleRoot);
                 if (!module.IsEnabled)


### PR DESCRIPTION
- Fixed an issue where the addendum module was not always loaded last.
- Fixed an issue where the world manage quest for caution spots was loaded before all caution spots were parsed.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
