### PR TITLE
fix: Unlock EM4 skill on job which completes it only

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -279,10 +279,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             // The skill level has no unlock requirements
                             isRelease = true;
                         }
-                        else if (SkillData.Em4CustomSkills.ContainsKey(jobId) && SkillData.IsEm4Skill(jobId, skill.SkillNo, skillLevel.Lv))
+                        else if (SkillData.IsEm4Skill(jobId, skill.SkillNo, skillLevel.Lv))
                         {
                             // The skill has an unlock requirement on EM4
-                            isRelease = character.HasQuestCompleted(QuestId.TheShiningGate);
+                            isRelease = character.LearnedCustomSkills.Where(x => x.Job == jobId && x.SkillId == skill.SkillNo).Any();
                         }
                         else if (SkillData.IsUnlockableSkill(skill.Job, skill.SkillNo, skillLevel.Lv))
                         {

--- a/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
@@ -49,27 +49,33 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             var packets = new PacketQueue();
 
-            var unlockedSkills = new S2CSkillAcquirementLearnNtc();
-            // TODO: Track quest completion on per job instead of unlocking all
-            foreach (var (jobId, releaseId) in SkillData.Em4CustomSkills)
+            var jobId = client.Character.Job;
+            if (!SkillData.Em4CustomSkills.ContainsKey(jobId))
             {
-                Server.CharacterManager.UnlockCustomSkill(client.Character, jobId, releaseId, 1);
-
-                // Handle players who had existing skills before they were locked
-                var existing = client.Character.LearnedCustomSkills.Where(x => x.SkillId == releaseId && x.Job == jobId).FirstOrDefault();
-                if (existing == null && client.Character.CharacterJobDataList.Any(x => x.Job == jobId))
-                {
-                    Server.JobManager.UnlockCustomSkill(client, client.Character, jobId, releaseId, 1, connectionIn);
-                }
-
-                unlockedSkills.SkillParamList.Add(new CDataSkillLevelBaseParam()
-                {
-                    Job = jobId,
-                    SkillNo = releaseId,
-                    SkillLv = existing?.SkillLv ?? 1,
-                });
+                return new();
             }
-            packets.Enqueue(client, unlockedSkills);
+
+            var releaseId = SkillData.Em4CustomSkills[jobId];
+            if (client.Character.LearnedCustomSkills.Where(x => x.Job == jobId && x.SkillId == releaseId).Any())
+            {
+                return new();
+            }
+
+            Server.CharacterManager.UnlockCustomSkill(client.Character, jobId, releaseId, 1);
+            Server.JobManager.UnlockCustomSkill(client, client.Character, jobId, releaseId, 1, connectionIn);
+
+            var unlockedSkill = new S2CSkillAcquirementLearnNtc()
+            {
+                SkillParamList = [
+                    new()
+                    {
+                        Job = jobId,
+                        SkillNo = releaseId,
+                        SkillLv = 1,
+                    }
+                ]
+            };
+            packets.Enqueue(client, unlockedSkill);
 
             return packets;
         }


### PR DESCRIPTION
Adjust behavior of the EM4 skills to unlock only on the job which completes it.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
