### PR TITLE
fixes: Fix reported issues 6/28/2025

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobMasterManager.cs
@@ -235,7 +235,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             var packets = new PacketQueue();
 
             var jobId = client.Character.ActiveCharacterJobData.Job;
-            if (!client.Character.JobMasterActiveOrders.ContainsKey(jobId))
+            if (!client.Character.HasContentReleased(jobId.JobTrainingReleaseId()) || !client.Character.JobMasterActiveOrders.ContainsKey(jobId))
             {
                 return new();
             }

--- a/Arrowgene.Ddon.GameServer/Enemies/Generators/QuestEnemySetGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/Enemies/Generators/QuestEnemySetGenerator.cs
@@ -1,8 +1,12 @@
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Context;
 using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Logging;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Enemies.Generators
@@ -29,7 +33,6 @@ namespace Arrowgene.Ddon.GameServer.Enemies.Generators
 
         private Quest FindQuestBasedOnPriority(GameClient client, StageLayoutId stageLayoutId, uint subgroupId)
         {
-
             var quests = new List<Quest>();
             foreach (var questScheduleId in QuestManager.CollectQuestScheduleIds(client, stageLayoutId))
             {

--- a/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
@@ -94,11 +94,7 @@ public class InstanceEnemyManager : InstanceAssetManager<Enemy, InstancedEnemy>
             {
                 _EnemyData[stageId] = new Dictionary<int, InstancedEnemy>();
             }
-
-            if (!_EnemyData[stageId].ContainsKey(index))
-            {
-                _EnemyData[stageId][index] = enemy;
-            }
+            _EnemyData[stageId][index] = enemy;
         }
     }
 

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -92,14 +92,24 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Server.Database.ExecuteInTransaction(connectionIn =>
             {
-
                 List<InstancedEnemy> group = client.Party.InstanceEnemyManager.GetInstancedEnemies(stageId);
-                bool groupDestroyed = group.Where(x => x.IsRequired).All(x => x.IsKilled);
+
+                bool groupDestroyed;
+                if (isQuestControlled)
+                {
+                    groupDestroyed = group.Where(x => x.IsRequired && x.QuestScheduleId == quest.QuestScheduleId).All(x => x.IsKilled);
+                }
+                else
+                {
+                    groupDestroyed = group.Where(x => x.IsRequired).All(x => x.IsKilled);
+                }
+
                 if (groupDestroyed)
                 {
-                    bool IsAreaBoss = group.Any(x => x.IsAreaBoss);
+                    bool isAreaBoss = group.Any(x => x.IsAreaBoss);
                     bool isDungeon = StageManager.IsDungeon(stageId);
-                    
+                    bool isCautionSpot = Server.ScriptManager.MonsterCautionSpotModule.IsEnabledCautionSpotGroup(Server, client.Party, stageId, client.Character.AreaId);
+
                     if (isQuestControlled)
                     {
                         var ntcs = QuestManager.GetQuestStateManager(client, quest).HandleDestroyGroupWorkNotice(client.Party, quest, stageId, enemyKilled, connectionIn);
@@ -110,11 +120,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     S2CInstanceEnemyGroupDestroyNtc groupDestroyedNtc = new S2CInstanceEnemyGroupDestroyNtc()
                     {
                         LayoutId = packet.LayoutId,
-                        IsAreaBoss = IsAreaBoss && !isDungeon && (client.GameMode == GameMode.Normal)
+                        IsAreaBoss = isCautionSpot && (client.GameMode == GameMode.Normal)
                     };
                     client.Party.EnqueueToAll(groupDestroyedNtc, queuedPackets);
 
-                    if (IsAreaBoss && client.GameMode == GameMode.BitterblackMaze)
+                    if (isAreaBoss && client.GameMode == GameMode.BitterblackMaze)
                     {
                         foreach (var memberClient in client.Party.Clients)
                         {
@@ -122,7 +132,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                             queuedPackets.AddRange(ntcs);
                         }
                     }
-                    else if (IsAreaBoss && isDungeon && client.GameMode == GameMode.Normal)
+                    else if (isAreaBoss && isDungeon && client.GameMode == GameMode.Normal)
                     {
                         var boss = group.Where(x => x.IsAreaBoss).First();
                         client.Party.EnqueueToAll(new S2CInstanceEnemyStageBossAnnihilateNtc()

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceGetEnemySetListHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Context;
 using Arrowgene.Ddon.GameServer.Enemies.Generators;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Crypto;
@@ -6,6 +7,7 @@ using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -56,7 +58,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
             for (var i = 0; i < instancedEnemyList.Count; i++)
             {
                 var enemy = client.Party.InstanceEnemyManager.GetInstanceEnemy(stageLayoutId, instancedEnemyList[i].Index);
-                if (enemy == null)
+
+                if (enemy != null && (enemy.QuestScheduleId != instancedEnemyList[i].QuestScheduleId))
+                {
+                    var uid = ContextManager.CreateEnemyUID(enemy.Index, stageLayoutId.ToCDataStageLayoutId());
+                    ContextManager.RemoveContext(client.Party, uid);
+                }
+
+                if (enemy == null || (enemy.QuestScheduleId != instancedEnemyList[i].QuestScheduleId))
                 {
                     enemy = instancedEnemyList[i].CreateNewInstance();
                     if (Server.GameSettings.GameServerSettings.EnableAutomaticExpCalculationForAll)

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/MonsterCautionSpotModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/MonsterCautionSpotModule.cs
@@ -1,9 +1,12 @@
 using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
 {
@@ -19,6 +22,23 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         public MonsterCautionSpotModule()
         {
             EnemyGroups = new Dictionary<QuestAreaId, List<IMonsterSpotInfo>>();
+        }
+
+        public bool IsEnabledCautionSpotGroup(DdonGameServer server, PartyGroup party, StageLayoutId stageLayoutId, QuestAreaId areaId)
+        {
+            if (party.Leader == null || !EnemyGroups.ContainsKey(areaId))
+            {
+                return false;
+            }
+
+            var cautionSpot = EnemyGroups[areaId].Where(x => x.StageLayoutId.Equals(stageLayoutId)).FirstOrDefault();
+            if (cautionSpot == null || !cautionSpot.CautionPlayer)
+            {
+                return false;
+            }
+
+            var leaderClient = party.Leader.Client;
+            return server.AreaRankManager.GetEffectiveRank(leaderClient.Character, areaId) >= cautionSpot.RequiredAreaRank;
         }
 
         public override bool EvaluateResult(string path, ScriptState<object> result)

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/05_dowe_valley/ar03_white_sands_riverbank.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/05_dowe_valley/ar03_white_sands_riverbank.csx
@@ -6,7 +6,7 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(495);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(491);
     public override QuestAreaId AreaId => QuestAreaId.DoweValley;
     public override uint RequiredAreaRank => 3;
 
@@ -20,11 +20,11 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.GiantSulfurSaurian, 32, 0)
+            LibDdon.Enemy.CreateAuto(EnemyId.GiantSulfurSaurian, 32, 5)
                 .SetNamedEnemyParams(NamedParamId.SulfurTigerTail),
-            LibDdon.Enemy.CreateAuto(EnemyId.SulfurSaurian, 30, 1)
+            LibDdon.Enemy.CreateAuto(EnemyId.SulfurSaurian, 30, 6)
                 .SetNamedEnemyParams(NamedParamId.Strange),
-            LibDdon.Enemy.CreateAuto(EnemyId.SnowHarpy, 28, 2),
+            LibDdon.Enemy.CreateAuto(EnemyId.SnowHarpy, 28, 7),
         };
 
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.1/q00030125.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.1/q00030125.csx
@@ -110,7 +110,7 @@ public class ScriptedQuest : IQuest
             .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.RoyalFamilysSecretPath.LookoutCastleDoor1)
             .AddQuestFlag(QuestFlagAction.Set, QuestFlags.RoyalFamilysSecretPath.LookoutCastleDoor0)
             .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34);
-        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.FortThines1, 2, 0, NpcId.Nedo0, 21805)
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.FortThines1, 2, 0, NpcId.Nedo0, 24355)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.FortThinesNpcs2);
         process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.RoyalFamilysSecretPath)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.SecretPathNedo)

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009.json
@@ -8,6 +8,7 @@
   "discoverable": false,
   "area_id": "DoweValley",
   "news_image": 64,
+  "variant_index": 0,
   "rewards": [
     {
       "type": "wallet",
@@ -39,44 +40,41 @@
           "num": 1
         }
       ]
-  },
-  {
-      "type": "random",
-      "loot_pool": [
-          {
-              "item_id": 9429,
-              "num": 2,
-              "chance": 0.7
-          },
-          {
-            "item_id": 9196,
-            "num": 1,
-            "chance": 0.7
-        },
-        {
-          "item_id": 7888,
-          "num": 1,
-          "chance": 0.7
-      }
-      ]
-  }
+    },
+    {
+        "type": "random",
+        "loot_pool": [
+            {
+                "item_id": 9429,
+                "num": 2,
+                "chance": 0.7
+            },
+            {
+                "item_id": 9196,
+                "num": 1,
+                "chance": 0.7
+            },
+            {
+                "item_id": 7888,
+                "num": 1,
+                "chance": 0.7
+            }
+        ]
+    }
   ],
   "enemy_groups": [
     {
       "stage_id": {
         "id": 1,
-        "group_id": 495
+        "group_id": 228
       },
-      "placement_type": "manual",
       "enemies": [
         {
           "enemy_id": "0x015707",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+          "named_enemy_params_id": 53,
           "level": 36,
-          "exp": 6040,
-          "is_boss": true,
-          "index": 2
+          "exp_scheme": "Automatic",
+          "is_boss": true
         }
       ]
     }
@@ -84,6 +82,7 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
+      "show_marker": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_1.json
@@ -46,18 +46,15 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 495
+        "group_id": 228
       },
-      "placement_type": "manual",
       "enemies": [
         {
           "enemy_id": "0x015707",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+		  "named_enemy_params_id": 53,
           "level": 40,
-          "exp": 6476,
-          "is_boss": true,
-          "index": 2
+          "exp_scheme": "Automatic",
+          "is_boss": true
         }
       ]
     }
@@ -65,6 +62,7 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
+      "show_marker": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_2.json
@@ -46,18 +46,15 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 495
+        "group_id": 228
       },
-      "placement_type": "manual",
       "enemies": [
         {
           "enemy_id": "0x015710",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 60,
-          "exp": 34700,
-          "is_boss": true,
-          "index": 2
+          "exp_scheme": "Automatic",
+          "is_boss": true
         }
       ]
     }
@@ -65,6 +62,7 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
+      "show_marker": false,
       "groups": [ 0 ]
     },
     {


### PR DESCRIPTION
- Fixed an incorrect NPC line in for Nedo in the main story quest "A Desperate Infiltration".
  - q00030125.csx
- Fixed an issue where job training markers show before the current
  class unlocks job training.
- Updated the AR enemy spawn position for White Sands Riverbank in Dowe
  Valley.
  - ar03_white_sands_riverbank.csx
- Updated the spawn location of the enemies for world quest After That Dragon!
  - q20035009.json
  - q20035009_1.json
  - q20035009_2.json
- Fixed an issue where in Lestania it is possible to query a group of
  enemies before the world quests are queried which results in the quest
  enemy not appearing.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
