### PR TITLE
Feat: GC Mode, Reusing Script DLLs

### DIFF
--- a/Arrowgene.Ddon.Cli/Arrowgene.Ddon.Cli.csproj
+++ b/Arrowgene.Ddon.Cli/Arrowgene.Ddon.Cli.csproj
@@ -29,5 +29,7 @@
     <ItemGroup>
       <PackageReference Include="Arrowgene.Logging" Version="1.2.1" />
     </ItemGroup>
-    
+    <ItemGroup>
+        <RuntimeHostConfigurationOption Include="System.GC.Server" Value="true" />
+    </ItemGroup>
 </Project>

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/AddendumModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/AddendumModule.cs
@@ -1,5 +1,5 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
-using Microsoft.CodeAnalysis.Scripting;
+using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
 {
@@ -14,14 +14,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         {
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            IAddendum addendum = (IAddendum)result.ReturnValue;
+            IAddendum addendum = (IAddendum)result;
             addendum.Amend();
 
             return true;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/ChatCommandModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/ChatCommandModule.cs
@@ -1,5 +1,4 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
@@ -17,14 +16,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         {
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            IChatCommand command = (IChatCommand)result.ReturnValue;
+            IChatCommand command = (IChatCommand)result;
             if (command != null)
             {
                 Commands[command.CommandName.ToLowerInvariant()] = command; 

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/GameItemModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/GameItemModule.cs
@@ -1,6 +1,5 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Model;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
@@ -43,14 +42,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             Items = new Dictionary<ItemId, IGameItem>();
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            IGameItem item = (IGameItem)result.ReturnValue;
+            IGameItem item = (IGameItem)result;
             Items[item.ItemId] = item;
 
             return true;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/InstanceEnemyPropertyGeneratorModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/InstanceEnemyPropertyGeneratorModule.cs
@@ -1,5 +1,4 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -25,14 +24,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             return InstanceEnemyProperties.Values.ToList();
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            var generator = (IInstanceEnemyPropertyGenerator)result.ReturnValue;
+            var generator = (IInstanceEnemyPropertyGenerator)result;
             if (generator == null)
             {
                 return false;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/JobEmblemStatModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/JobEmblemStatModule.cs
@@ -1,7 +1,6 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -32,14 +31,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             return (ushort) StatTables[equipStatId].Where(x => x.Level <= level).Sum(x => x.Amount);
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            var statTable = (IJobEmblemStatTable)result.ReturnValue;
+            var statTable = (IJobEmblemStatTable)result;
             if (statTable != null)
             {
                 StatTables[statTable.StatId] = statTable.StatUpgradeData;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/JobOrbTreeModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/JobOrbTreeModule.cs
@@ -1,6 +1,5 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Model;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
@@ -25,14 +24,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             SkillAugmentations = new Dictionary<JobId, List<JobOrbUpgrade>>();
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            var skillAugmentationInformation = (ISkillAugmentation) result.ReturnValue;
+            var skillAugmentationInformation = (ISkillAugmentation) result;
             if (skillAugmentationInformation != null)
             {
                 SkillAugmentations[skillAugmentationInformation.JobId] = skillAugmentationInformation.Upgrades;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/JobOrbTreeSpecialConditionModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/JobOrbTreeSpecialConditionModule.cs
@@ -1,6 +1,5 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Entity.Structure;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,14 +19,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             return SpecialConditions.Select(x => x.Value.ToCDataJobOrbDevoteElementSpecialCondition(client)).ToList();
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            var specialCondition = (IJobOrbSpecialCondition)result.ReturnValue;
+            var specialCondition = (IJobOrbSpecialCondition)result;
             if (specialCondition != null)
             {
                 SpecialConditions[specialCondition.ConditionId] = specialCondition;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/MixinModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/MixinModule.cs
@@ -1,4 +1,3 @@
-using Microsoft.CodeAnalysis.Scripting;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -29,7 +28,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             return (T) Mixins[scriptName];
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
@@ -38,7 +37,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
 
             // Mixins are c# Func<> with arbitary return and params based on the functionality
             string mixinName = Path.GetFileNameWithoutExtension(path);
-            Mixins[mixinName] = result.ReturnValue;
+            Mixins[mixinName] = result;
 
             return true;
         }

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/MonsterCautionSpotModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/MonsterCautionSpotModule.cs
@@ -3,7 +3,6 @@ using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -41,14 +40,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             return server.AreaRankManager.GetEffectiveRank(leaderClient.Character, areaId) >= cautionSpot.RequiredAreaRank;
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            IMonsterSpotInfo spotInfo = (IMonsterSpotInfo)result.ReturnValue;
+            IMonsterSpotInfo spotInfo = (IMonsterSpotInfo)result;
             if (spotInfo == null)
             {
                 return false;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/NpcExtendedFacilityModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/NpcExtendedFacilityModule.cs
@@ -1,6 +1,5 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Model;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 
 namespace Arrowgene.Ddon.GameServer.Scripting
@@ -19,14 +18,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             NpcExtendedFacilities = new Dictionary<NpcId, INpcExtendedFacility>();
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
                 return false;
             }
 
-            INpcExtendedFacility extendedFacility = (INpcExtendedFacility)result.ReturnValue;
+            INpcExtendedFacility extendedFacility = (INpcExtendedFacility)result;
             NpcExtendedFacilities[extendedFacility.NpcId] = extendedFacility;
 
             return true;

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/PointModifierModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/PointModifierModule.cs
@@ -1,7 +1,6 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Shared.Model;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -36,7 +35,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         {
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
@@ -44,7 +43,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             }
 
             string scriptName = Path.GetFileNameWithoutExtension(path);
-            Modifiers[scriptName] = (IPointModifier)result.ReturnValue;
+            Modifiers[scriptName] = (IPointModifier)result;
 
             return true;
         }

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/QuestModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/QuestModule.cs
@@ -1,5 +1,4 @@
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
-using Microsoft.CodeAnalysis.Scripting;
 using System.Collections.Generic;
 using System.IO;
 
@@ -22,7 +21,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         {
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (result == null)
             {
@@ -34,7 +33,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
                 return true;
             }
 
-            IQuest quest = (IQuest)result.ReturnValue;
+            IQuest quest = (IQuest)result;
             if (quest == null)
             {
                 return false;

--- a/Arrowgene.Ddon.Scripts/scripts/README.md
+++ b/Arrowgene.Ddon.Scripts/scripts/README.md
@@ -7,6 +7,10 @@ terminate once reaching the root.
 
 Each directory inside scripts defines the scripting module. A module name should be all lowercase. Inside each module, there should be a `README.md` file which describes the purpose and usage of the module. It should also describe any guidelines required. When implementing a module, be aware if you want the module to be hotloadable. If you do, make sure to program in such a way that the settings can reflect as such after an update.
 
+> [!NOTE]
+> To improve startup times, scripts will be cached and restored from their pre-compiled DLLs if the source has not changed since they were last loaded. To prevent this, declare a variable named `PREVENT_SCRIPT_CACHE` (of any type and value).
+> You can reset the cache and force recompilation for all scripts by deleting `Files\script_assemblies\hashes.csv`.
+
 ## Setting up code completion
 
 Next section describes how to configure code completion for your scripts.

--- a/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
+++ b/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
@@ -1,16 +1,18 @@
 using Arrowgene.Ddon.GameServer.Scripting;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Csv;
 using Arrowgene.Logging;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Scripting;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -25,6 +27,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
         public string LibsRoot { get; private set; } = string.Empty;
         public T GlobalVariables { get; protected set; }
         public List<string> PathsToIgnore { get; protected set; }
+        protected ConcurrentDictionary<string, (string DllPath, string Hash)> ScriptHashes { get; private set; }
 
         public ScriptManager(string assetsPath, string libsPath)
         {
@@ -32,6 +35,17 @@ namespace Arrowgene.Ddon.Shared.Scripting
             ScriptsRoot = Path.Combine(assetsPath, "scripts");
             PathsToIgnore = new List<string>();
 
+            ScriptHashes = [];
+            var hashPath = Path.GetFullPath(Path.Combine(ScriptsRoot, "../../script_assemblies/hashes.csv"));
+            if (File.Exists(hashPath))
+            {
+                try
+                {
+                    ScriptHashes = new(new ScriptHashReader().ReadPath(hashPath).ToDictionary(k => k.ScriptPath, v => (v.DllPath, v.Hash)));
+                }
+                catch { }
+            }
+            
             if (libsPath != "")
             {
                 LibsRoot = Path.Combine(ScriptsRoot, libsPath);
@@ -53,6 +67,12 @@ namespace Arrowgene.Ddon.Shared.Scripting
             SetupFileWatchers();
         }
 
+        private (string AssemblyPath, string OutputPath) EmitScriptAsDllPath(ScriptModule module, string path)
+        {
+            var assembliesPath = Path.GetFullPath(Path.Combine(ScriptsRoot, "../../script_assemblies", module.ModuleRoot));
+            return (assembliesPath, Path.Combine(assembliesPath, $"{Path.GetFileNameWithoutExtension(path)}.dll"));
+        }
+
         /// <summary>
         /// To debug scripts which include other scripts, we need emit
         /// the compiled script as a dll so the debugger can find the 
@@ -64,8 +84,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
         private void EmitScriptsAsDllForDebug(ScriptModule module, Script script, string path)
         {
             // Put the debug assemblies in <asset_path>/net9.0/Files
-            var assembliesPath = Path.Combine(Path.Combine(ScriptsRoot, "../../script_assemblies"), module.ModuleRoot);
-            assembliesPath = Path.GetFullPath(assembliesPath);
+            var (assembliesPath, outputPath) = EmitScriptAsDllPath(module, path);
             if (!Directory.Exists(assembliesPath))
             {
                 Directory.CreateDirectory(assembliesPath);
@@ -73,7 +92,6 @@ namespace Arrowgene.Ddon.Shared.Scripting
 
             var compilation = script.GetCompilation();
 
-            var outputPath = Path.Combine(assembliesPath, $"{Path.GetFileNameWithoutExtension(path)}.dll");
             var emitOptions = new EmitOptions()
                 .WithDebugInformationFormat(DebugInformationFormat.Pdb)
                 .WithPdbFilePath(outputPath);
@@ -98,6 +116,50 @@ namespace Arrowgene.Ddon.Shared.Scripting
                 Logger.Info(path);
 
                 var code = Util.ReadAllText(path);
+
+                using var stream = File.OpenRead(path);
+                var hash = stream.GetHash<MD5>();
+#if DEBUG
+                try
+                {
+                    if (ScriptHashes.TryGetValue(path, out var pastResult))
+                    {
+                        if (pastResult.Hash == hash)
+                        {
+                            var assembly = Assembly.LoadFile(pastResult.DllPath);
+                            var type = assembly.GetType("Submission#0");
+                            var factory = type.GetMethod("<Factory>");
+                            var submissionArray = new object[2];
+                            Task<object> task = (Task<object>)factory.Invoke(null, [submissionArray]);
+                            await task;
+
+                            Dictionary<string, object> dllVariables = [];
+                            foreach (var member in type.GetMembers())
+                            {
+                                if (member is FieldInfo fieldInfo)
+                                {
+                                    object value = fieldInfo.GetValue(submissionArray[1]);
+                                    if (value is not null)
+                                    {
+                                        dllVariables.Add(fieldInfo.Name, value);
+                                    }
+                                }
+                            }
+
+                            if (!module.EvaluateResult(path, task.Result, dllVariables))
+                            {
+                                throw new Exception("Failed to evaluate the result of executing a stored DLL.");
+                            }
+                            return;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Failed to restore hashed assembly for '{path}', doing a fresh compilation.");
+                    Logger.Error(ex.ToString());
+                }
+#endif
 
                 var options = module.Options()
 #if DEBUG
@@ -125,10 +187,17 @@ namespace Arrowgene.Ddon.Shared.Scripting
 #endif
 
                 var result = await script.RunAsync(globals: GlobalVariables);
-                if (!module.EvaluateResult(path, result))
+                var variables = result?.Variables.ToDictionary(k => k.Name, v => v.Value);
+                if (!module.EvaluateResult(path, result?.ReturnValue, variables))
                 {
                     Logger.Error($"Failed to evaluate the result of executing '{path}'");
                 }
+#if DEBUG       
+                else if (!variables.ContainsKey("PREVENT_SCRIPT_CACHE"))
+                {
+                    ScriptHashes[path] = (EmitScriptAsDllPath(module, path).OutputPath, hash);
+                }
+#endif
             }
             catch (Exception ex)
             {
@@ -201,6 +270,10 @@ namespace Arrowgene.Ddon.Shared.Scripting
                     CompileScript(module, fileToCompile);
                 }
             });
+
+#if DEBUG
+            WriteScriptHashesToFile();
+#endif
         }
 
         private void SetupFileWatchers()
@@ -338,6 +411,31 @@ namespace Arrowgene.Ddon.Shared.Scripting
                 Logger.Error($"{ex.Message}");
                 Logger.Error($"Stacktrace:");
                 PrintException(ex.InnerException);
+            }
+        }
+
+        private void WriteScriptHashesToFile()
+        {
+            try
+            {
+                var hashes = ScriptHashes.Select(x => $"{x.Key},{x.Value.DllPath},{x.Value.Hash}").ToArray();
+                var path = Path.GetFullPath(Path.Combine(ScriptsRoot, "../../script_assemblies/hashes.csv"));
+                File.WriteAllLines(path, hashes);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Error when writing script hashes to file.");
+                Logger.Error(ex.ToString());
+            }
+        }
+
+        private class ScriptHashReader : CsvReaderWriter<(string ScriptPath, string DllPath, string Hash)>
+        {
+            protected override int NumExpectedItems => 3;
+
+            protected override (string ScriptPath, string DllPath, string Hash) CreateInstance(string[] properties)
+            {
+                return (properties[0], properties[1], properties[2]);
             }
         }
     }

--- a/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
+++ b/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
+using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -24,6 +25,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
 
         protected Dictionary<string, ScriptModule> ScriptModules { get; private set; }
         public string ScriptsRoot { get; private set; }
+        public string HashPath { get; private set; }
         public string LibsRoot { get; private set; } = string.Empty;
         public T GlobalVariables { get; protected set; }
         public List<string> PathsToIgnore { get; protected set; }
@@ -33,15 +35,16 @@ namespace Arrowgene.Ddon.Shared.Scripting
         {
             ScriptModules = new Dictionary<string, ScriptModule>();
             ScriptsRoot = Path.Combine(assetsPath, "scripts");
+            HashPath = Path.GetFullPath(Path.Combine(ScriptsRoot, "../../script_assemblies/hashes.csv"));
+
             PathsToIgnore = new List<string>();
 
             ScriptHashes = [];
-            var hashPath = Path.GetFullPath(Path.Combine(ScriptsRoot, "../../script_assemblies/hashes.csv"));
-            if (File.Exists(hashPath))
+            if (File.Exists(HashPath))
             {
                 try
                 {
-                    ScriptHashes = new(new ScriptHashReader().ReadPath(hashPath).ToDictionary(k => k.ScriptPath, v => (v.DllPath, v.Hash)));
+                    ScriptHashes = new(new ScriptHashReader().ReadPath(HashPath).ToDictionary(k => k.ScriptPath, v => (v.DllPath, v.Hash)));
                 }
                 catch { }
             }
@@ -115,52 +118,16 @@ namespace Arrowgene.Ddon.Shared.Scripting
             {
                 Logger.Info(path);
 
-                var code = Util.ReadAllText(path);
-
+#if DEBUG
                 using var stream = File.OpenRead(path);
                 var hash = stream.GetHash<MD5>();
-#if DEBUG
-                try
+                if (await RestoreScriptFromStoredDll(module, path, hash))
                 {
-                    if (ScriptHashes.TryGetValue(path, out var pastResult))
-                    {
-                        if (pastResult.Hash == hash)
-                        {
-                            var assembly = Assembly.LoadFile(pastResult.DllPath);
-                            var type = assembly.GetType("Submission#0");
-                            var factory = type.GetMethod("<Factory>");
-                            var submissionArray = new object[2];
-                            Task<object> task = (Task<object>)factory.Invoke(null, [submissionArray]);
-                            await task;
-
-                            Dictionary<string, object> dllVariables = [];
-                            foreach (var member in type.GetMembers())
-                            {
-                                if (member is FieldInfo fieldInfo)
-                                {
-                                    object value = fieldInfo.GetValue(submissionArray[1]);
-                                    if (value is not null)
-                                    {
-                                        dllVariables.Add(fieldInfo.Name, value);
-                                    }
-                                }
-                            }
-
-                            if (!module.EvaluateResult(path, task.Result, dllVariables))
-                            {
-                                throw new Exception("Failed to evaluate the result of executing a stored DLL.");
-                            }
-                            return;
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.Error($"Failed to restore hashed assembly for '{path}', doing a fresh compilation.");
-                    Logger.Error(ex.ToString());
+                    return;
                 }
 #endif
 
+                var code = Util.ReadAllText(path);
                 var options = module.Options()
 #if DEBUG
                     .WithFilePath(path)
@@ -193,6 +160,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
                     Logger.Error($"Failed to evaluate the result of executing '{path}'");
                 }
 #if DEBUG       
+                // Flag to prevent script cacheing.
                 else if (!variables.ContainsKey("PREVENT_SCRIPT_CACHE"))
                 {
                     ScriptHashes[path] = (EmitScriptAsDllPath(module, path).OutputPath, hash);
@@ -419,14 +387,58 @@ namespace Arrowgene.Ddon.Shared.Scripting
             try
             {
                 var hashes = ScriptHashes.Select(x => $"{x.Key},{x.Value.DllPath},{x.Value.Hash}").ToArray();
-                var path = Path.GetFullPath(Path.Combine(ScriptsRoot, "../../script_assemblies/hashes.csv"));
-                File.WriteAllLines(path, hashes);
+                File.WriteAllLines(HashPath, hashes);
             }
             catch (Exception ex)
             {
                 Logger.Error("Error when writing script hashes to file.");
                 Logger.Error(ex.ToString());
             }
+        }
+
+        private async Task<bool> RestoreScriptFromStoredDll(ScriptModule module, string path, string hash)
+        {
+            try
+            {
+                if (ScriptHashes.TryGetValue(path, out var pastResult))
+                {
+                    if (pastResult.Hash == hash)
+                    {
+                        var assembly = Assembly.LoadFile(pastResult.DllPath);
+                        var type = assembly.GetType("Submission#0");
+                        var factory = type.GetMethod("<Factory>");
+                        var submissionArray = new object[2];
+                        Task<object> task = (Task<object>)factory.Invoke(null, [submissionArray]);
+                        await task;
+
+                        Dictionary<string, object> variables = [];
+                        foreach (var member in type.GetMembers())
+                        {
+                            if (member is FieldInfo fieldInfo)
+                            {
+                                object value = fieldInfo.GetValue(submissionArray[1]);
+                                if (value is not null)
+                                {
+                                    variables.Add(fieldInfo.Name, value);
+                                }
+                            }
+                        }
+
+                        if (!module.EvaluateResult(path, task.Result, variables))
+                        {
+                            throw new Exception("Failed to evaluate the result of executing a stored DLL.");
+                        }
+                        return true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to restore stored DLL for '{path}', doing a fresh compilation.");
+                Logger.Error(ex.ToString());
+                return false;
+            }
+            return false;
         }
 
         private class ScriptHashReader : CsvReaderWriter<(string ScriptPath, string DllPath, string Hash)>

--- a/Arrowgene.Ddon.Server/Scripting/ScriptModule.cs
+++ b/Arrowgene.Ddon.Server/Scripting/ScriptModule.cs
@@ -51,7 +51,8 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         /// </summary>
         /// <param name="path">Path to the script that was executed</param>
         /// <param name="result">The result object of the script that executed</param>
+        /// <param name="variables">The local variables of the script that executed</param>
         /// <returns></returns>
-        public abstract bool EvaluateResult(string path, ScriptState<object> result);
+        public abstract bool EvaluateResult(string path, object result, IDictionary<string, object> variables);
     }
 }

--- a/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
+++ b/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
@@ -80,7 +80,7 @@ namespace Arrowgene.Ddon.Server.Scripting.modules
                 .AddImports("Arrowgene.Ddon.Shared.Model.Quest");
         }
 
-        public override bool EvaluateResult(string path, ScriptState<object> result)
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
         {
             if (path.Contains(TemplatesDirectory))
             {
@@ -89,9 +89,9 @@ namespace Arrowgene.Ddon.Server.Scripting.modules
 
             var scriptName = Path.GetFileNameWithoutExtension(path);
 
-            foreach (var variable in result.Variables)
+            foreach (var (name, value) in variables)
             {
-                SettingsData.Set(scriptName, variable.Name, variable.Value);
+                SettingsData.Set(scriptName, name, value);
             }
 
             return true;

--- a/Arrowgene.Ddon.Shared/Util.cs
+++ b/Arrowgene.Ddon.Shared/Util.cs
@@ -1,11 +1,12 @@
+using Arrowgene.Buffers;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
-using Arrowgene.Buffers;
 
 namespace Arrowgene.Ddon.Shared
 {
@@ -511,6 +512,14 @@ namespace Arrowgene.Ddon.Shared
             }
 
             return content;   
+        }
+
+        public static string GetHash<T>(this Stream stream) where T : HashAlgorithm
+        {
+            using T crypt = (T)CryptoConfig.CreateFromName(typeof(T).Name);
+            var hash = crypt.ComputeHash(stream);
+            stream.Position = 0;
+            return Convert.ToHexStringLower(hash);
         }
     }
 }


### PR DESCRIPTION
- Sets the GC mode for the process to "Server" mode, "which is intended for server applications that need high throughput and scalability." "Because multiple garbage collection threads work together, server garbage collection is faster than workstation garbage collection on the same size heap." However, "Server garbage collection can be resource-intensive.".
- Hopefully this addresses the rolling DCs and improves overall performance, but we'll be monitoring this impact closely.
- Emitted DLLs as part of the scripting engine are re-used when possible. This should have a minimal impact on servers that boot relatively rarely, but it reduced boot time by ~80% so it should be very nice for development and testing.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
