### PR TITLE
Volden Mines Level 40 Trial: Remove Harpy Boss Flags

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q60040002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q60040002.json
@@ -41,7 +41,7 @@
                     "comment": "Harpy Grave Robber",
                     "enemy_id": "0x010600",
                     "level": 38,
-                    "is_boss": true,
+                    "is_boss": false,
                     "named_enemy_params_id": 217,
                     "exp_scheme": "automatic"
                 },
@@ -49,7 +49,7 @@
                     "comment": "Harpy Grave Robber",
                     "enemy_id": "0x010600",
                     "level": 38,
-                    "is_boss": true,
+                    "is_boss": false,
                     "named_enemy_params_id": 217,
                     "exp_scheme": "automatic"
                 },
@@ -57,7 +57,7 @@
                     "comment": "Harpy Grave Robber",
                     "enemy_id": "0x010600",
                     "level": 38,
-                    "is_boss": true,
+                    "is_boss": false,
                     "named_enemy_params_id": 217,
                     "exp_scheme": "automatic"
                 },


### PR DESCRIPTION
Removed the boss flags from the harpies in the level 40 Volden Mines trial "Summit-Concealing Wings."

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
