### PR TITLE
Feat: Exempt Pawns from Job Training

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
@@ -28,7 +28,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             // but its fine to return the normal gamemode result no matter what because the BBM character can't interact with abilities/augments.
 
             S2CSkillGetAcquirableAbilityListRes response = new S2CSkillGetAcquirableAbilityListRes();
-            if (request.Job != 0)
+            if (request.CharacterId != 0 && Server.GameSettings.GameServerSettings.PawnSkipJobTraining)
+            {
+                response.AbilityParamList = SkillData.AllAbilities.Where(x => x.Job == request.Job).ToList();
+            }
+            else if (request.Job != 0)
             {
                 response.AbilityParamList = client.Character.AcquirableAbilities[request.Job]
                         .Where(x => !SkillData.IsUnlockableAbility(request.Job, x.AbilityNo, 1) || IsAbilityUnlocked(client.Character, request.Job, x.AbilityNo))

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
@@ -16,10 +17,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CSkillGetAcquirableSkillListRes Handle(GameClient client, C2SSkillGetAcquirableSkillListReq request)
         {
             // This list can't be filtered based on progress because it's cached between BBM and normal gameplay.
-            return new S2CSkillGetAcquirableSkillListRes()
+            //CharacterId = 0 in the request is for the player
+            if (request.CharacterId == 0 || Server.GameSettings.GameServerSettings.PawnSkipJobTraining == false)
             {
-                SkillParamList = client.Character.AcquirableSkills[request.Job]
-            };
+                return new S2CSkillGetAcquirableSkillListRes()
+                {
+                    SkillParamList = client.Character.AcquirableSkills[request.Job]
+                };
+            }
+            else 
+            {
+                return new S2CSkillGetAcquirableSkillListRes()
+                {
+                    SkillParamList = SkillData.AllSkills.Where(x => x.Job == request.Job).ToList()
+                };
+            }
         }
     }
 }

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1483,5 +1483,23 @@ namespace Arrowgene.Ddon.Server.Settings
             }
         }
         private const bool _EnableHighOrbConversion = true;
+
+        /// <summary>
+        /// When set to true, allows pawns to bypass Job Training requirements
+        /// and learn any skill or augment they otherwise meet the requirements of.
+        /// </summary>
+        [DefaultValue(_PawnSkipJobTraining)]
+        public bool PawnSkipJobTraining
+        {
+            set
+            {
+                SetSetting("PawnSkipJobTraining", value);
+            }
+            get
+            {
+                return TryGetSetting("PawnSkipJobTraining", _PawnSkipJobTraining);
+            }
+        }
+        private const bool _PawnSkipJobTraining = true;
     }
 }


### PR DESCRIPTION
Adds a game server setting (defaulted to true) that allows pawns to acquire skills and abilities/augments without the necessary Job Training finished on the client's character. This behavior was added to the game with patch 3.2 as seen [here](https://web.archive.org/web/20180424060620/http://dogmaonlinefun.wiki.fc2.com/wiki/【シーズン3.2アップデート】アップデート情報とリファイン内容) in the 'Pawn Refinements' section.

Server admins can disable this feature if desired in `GameServerSettings.csx` by setting `bool PawnSkipJobtraining = false;`

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
