### PR TITLE
feat: Area/Dungeon Boss AP reward

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/AreaRankManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/AreaRankManager.cs
@@ -132,6 +132,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return queue;
             }
 
+            if (points.BasePoints + points.BonusPoints == 0)
+            {
+                return queue;
+            }
+
             AreaRank clientRank = client.Character.AreaRanks.GetValueOrDefault(areaId)
                 ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_AREAMASTER_AREA_INFO_NOT_FOUND);
             if (clientRank is null || clientRank.Rank == 0) {

--- a/Arrowgene.Ddon.GameServer/GatheringItems/Generators/EnemyDropGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/Generators/EnemyDropGenerator.cs
@@ -1,0 +1,25 @@
+using Arrowgene.Ddon.Shared.Model;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.GameServer.GatheringItems.Generators
+{
+    public class EnemyDropGenerator : IDropGenerator
+    {
+        private readonly DdonGameServer Server;
+
+        public EnemyDropGenerator(DdonGameServer server)
+        {
+            Server = server;
+        }
+
+        public List<InstancedGatheringItem> Generate(GameClient client, InstancedEnemy enemyKilled)
+        {
+            var results = new List<InstancedGatheringItem>();
+            foreach (var generator in Server.ScriptManager.InstanceEnemyDropModule.GetGenerators(client.GameMode))
+            {
+                results.AddRange(generator.Generate(client, enemyKilled));
+            }
+            return results;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/GatheringItems/InstanceDropItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/GatheringItems/InstanceDropItemManager.cs
@@ -25,7 +25,8 @@ namespace Arrowgene.Ddon.GameServer.GatheringItems
             {
                 new EnemyDropTableDropGenerator(),
                 new EnemyEpitaphRoadDropGenerator(server),
-                new EnemyEventDropGenerator(server)
+                new EnemyEventDropGenerator(server),
+                new EnemyDropGenerator(server),
             };
         }
 

--- a/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InstanceEnemyKillHandler.cs
@@ -140,6 +140,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
                             LayoutId = boss.StageLayoutId.ToCDataStageLayoutId(),
                         }, queuedPackets);
                     }
+
+                    if (isAreaBoss && client.GameMode == GameMode.Normal)
+                    {
+                        foreach (var memberClient in client.Party.Clients)
+                        {
+                            queuedPackets.AddRange(Server.AreaRankManager.AddAreaPoint(memberClient, client.Character.AreaId, (Server.GameSettings.GameServerSettings.AreaBossApReward, 0), connectionIn));
+                        }
+                    }
                 }
 
                 if (!packet.IsNoBattleReward && !client.QuestState.IsQuestActive(QuestId.ResolutionsAndOmens))

--- a/Arrowgene.Ddon.GameServer/Scripting/GameServerScriptManager.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/GameServerScriptManager.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Scripting.Modules;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Scripting;
 using Arrowgene.Logging;
@@ -31,8 +32,8 @@ namespace Arrowgene.Ddon.GameServer.Scripting
         public JobOrbTreeModule SkillAugmentationModule { get; private set; } = new JobOrbTreeModule("job_orb_tree/skill_augmentation");
         public JobOrbTreeModule SpecialSkillAugmentationModule { get; private set; } = new JobOrbTreeModule("job_orb_tree/special_skill_augmentation");
         public JobOrbTreeSpecialConditionModule JobOrbSpecialConditionModule { get; private set; } = new();
-
         public JobEmblemStatModule JobEmblemStatModule { get; private set; } = new JobEmblemStatModule();
+        public InstanceEnemyDropModule InstanceEnemyDropModule { get; private set; } = new();
 
 
         public GameServerScriptManager(DdonGameServer server) : base(server.AssetRepository.AssetsPath, ".")
@@ -55,6 +56,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             AddModule(SpecialSkillAugmentationModule);
             AddModule(JobOrbSpecialConditionModule);
             AddModule(MonsterCautionSpotModule);
+            AddModule(InstanceEnemyDropModule);
         }
 
         public override void Initialize()

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IInstanceEnemyDropGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IInstanceEnemyDropGenerator.cs
@@ -1,0 +1,11 @@
+using Arrowgene.Ddon.Shared.Model;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
+{
+    public interface IInstanceEnemyDropGenerator
+    {
+        public GameMode GameMode { get; }
+        public List<InstancedGatheringItem> Generate(GameClient client, InstancedEnemy enemyKilled);
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IInstanceEnemyPropertyGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IInstanceEnemyPropertyGenerator.cs
@@ -4,6 +4,12 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
 {
     public abstract class IInstanceEnemyPropertyGenerator
     {
+        /// <summary>
+        /// Can be used to control the order of the scripts which are executed.
+        /// Scripts with a lower rank are executed before scripts with a higher
+        /// rank.
+        /// </summary>
+        public virtual uint ScriptRank { get; } = 1;
         public abstract void ApplyChanges(GameClient client, StageLayoutId stageLayotuId, byte subGroupId, InstancedEnemy enemy);
     }
 }

--- a/Arrowgene.Ddon.GameServer/Scripting/LibDdon.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/LibDdon.cs
@@ -40,6 +40,14 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             }
         }
 
+        public static AreaRankManager AreaRank
+        {
+            get
+            {
+                return Server.AreaRankManager;
+            }
+        }
+
         public static void SetServer(DdonGameServer server)
         {
             // TODO: How to block this after being set one time without breaking tests
@@ -205,6 +213,21 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             public InstancedEnemy CreateRandom(ushort lv, uint exp, List<EnemyId> enemyIds, bool assignDefaultDrops = true)
             {
                 return CreateRandom(lv, exp, 0, enemyIds, assignDefaultDrops);
+            }
+
+            public List<InstancedEnemy> GetEnemiesForGroup(GameClient client, StageLayoutId stageLayoutId)
+            {
+                return client.Party.InstanceEnemyManager.GetInstancedEnemies(stageLayoutId);
+            }
+
+            public bool IsGroupDestroyed(GameClient client, StageLayoutId stageLayoutId)
+            {
+                return GetEnemiesForGroup(client, stageLayoutId).Where(x => x.IsRequired).All(x => x.IsKilled);
+            }
+
+            public bool IsGroupDestroyed(GameClient client, InstancedEnemy enemy)
+            {
+                return IsGroupDestroyed(client, enemy.StageLayoutId);
             }
         }
 

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/InstanceEnemyDropModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/InstanceEnemyDropModule.cs
@@ -1,0 +1,46 @@
+using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
+using Arrowgene.Ddon.Shared.Model;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer.Scripting.Modules
+{
+    public class InstanceEnemyDropModule : GameServerScriptModule
+    {
+        public override string ModuleRoot => Path.Combine("enemies", "drop_generators");
+        public override string Filter => "*.csx";
+        public override bool ScanSubdirectories => true;
+        public override bool EnableHotLoad => true;
+
+        public InstanceEnemyDropModule()
+        {
+        }
+
+        private Dictionary<string, IInstanceEnemyDropGenerator> EnemyDropGenerators = new();
+
+        public List<IInstanceEnemyDropGenerator> GetGenerators(GameMode gameMode)
+        {
+            return EnemyDropGenerators.Values.Where(x => x.GameMode == gameMode).ToList();
+        }
+
+        public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)
+        {
+            if (result == null)
+            {
+                return false;
+            }
+
+            var generator = (IInstanceEnemyDropGenerator)result;
+            if (generator == null)
+            {
+                return false;
+            }
+
+            string scriptName = Path.GetFileNameWithoutExtension(path);
+            EnemyDropGenerators[scriptName] = generator;
+
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/InstanceEnemyPropertyGeneratorModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/InstanceEnemyPropertyGeneratorModule.cs
@@ -21,7 +21,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting
 
         public List<IInstanceEnemyPropertyGenerator> GetGenerators()
         {
-            return InstanceEnemyProperties.Values.ToList();
+            return InstanceEnemyProperties.Values.OrderBy(x => x.ScriptRank).ToList();
         }
 
         public override bool EvaluateResult(string path, object result, IDictionary<string, object> variables)

--- a/Arrowgene.Ddon.Scripts/scripts/enemies/drop_generators/README.md
+++ b/Arrowgene.Ddon.Scripts/scripts/enemies/drop_generators/README.md
@@ -1,0 +1,30 @@
+# Scriptable Enemy Drop Generator
+
+It's possible to have the server inject additional drops when an enemy is killed by providing `.csx` scripts in this directory. These scripts are hotloadable. Each drop generator should implement the interface `IInstanceEnemyDropGenerator`.
+
+> [!WARNING]
+> This script module is called in a transaction so don't call functions which use or generate packets directly.
+
+```c#
+public interface IInstanceEnemyDropGenerator
+{
+    public GameMode GameMode { get; }
+    public List<InstancedGatheringItem> Generate(GameClient client, InstancedEnemy enemyKilled);
+}
+```
+
+## Guidelines
+
+The scripts in this directory should be organized by the game mode the generator is used in.
+
+```
+enemies
+  drop_generator
+    normal
+      dungeon_boss.csx
+      ...
+    bbm
+      ...
+```
+
+If you need to know the location or stage the enemy is killed on, the `InstancedEnemy` object has a field `enemyKilled.StageLayoutId` which contains the location of the enemy.

--- a/Arrowgene.Ddon.Scripts/scripts/enemies/drop_generators/bbm/.trackme
+++ b/Arrowgene.Ddon.Scripts/scripts/enemies/drop_generators/bbm/.trackme
@@ -1,0 +1,1 @@
+this file can be deleted once other files are added to this directory

--- a/Arrowgene.Ddon.Scripts/scripts/enemies/drop_generators/normal/.trackme
+++ b/Arrowgene.Ddon.Scripts/scripts/enemies/drop_generators/normal/.trackme
@@ -1,0 +1,1 @@
+this file can be deleted once other files are added to this directory

--- a/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
+++ b/Arrowgene.Ddon.Server/Scripting/ScriptManager.cs
@@ -121,7 +121,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
                 using (FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     hash = stream.GetHash<MD5>();
-                    if (await RestoreScriptFromStoredDll(module, path, hash))
+                    if (RestoreScriptFromStoredDll(module, path, hash))
                     {
                         return;
                     }
@@ -407,7 +407,7 @@ namespace Arrowgene.Ddon.Shared.Scripting
             }
         }
 
-        private async Task<bool> RestoreScriptFromStoredDll(ScriptModule module, string path, string hash)
+        private bool RestoreScriptFromStoredDll(ScriptModule module, string path, string hash)
         {
             try
             {

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -836,6 +836,24 @@ namespace Arrowgene.Ddon.Server.Settings
         private const bool _EnableAreaRankSpotLocks = true;
 
         /// <summary>
+        /// Confgures the amount of AP to be rewarded when clearing an area or dungeon boss
+        /// in the normal game mode.
+        /// </summary>
+        [DefaultValue(_AreaBossApReward)]
+        public uint AreaBossApReward
+        {
+            set
+            {
+                SetSetting("AreaBossApReward", value);
+            }
+            get
+            {
+                return TryGetSetting("AreaBossApReward", _AreaBossApReward);
+            }
+        }
+        private const uint _AreaBossApReward = 500;
+
+        /// <summary>
         /// Configures the chance that various gathering tools can break
         /// when the player performs a gathering action.
         /// </summary>

--- a/Arrowgene.Ddon.Shared/Model/InstancedRandomEnemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/InstancedRandomEnemy.cs
@@ -66,7 +66,7 @@ namespace Arrowgene.Ddon.Shared.Model
             return enemy;
         }
 
-        //Adds drop to all enemy drop tables in pool of random enemies
+        // Adds drop to all enemy drop tables in pool of random enemies
         public override InstancedEnemy AddDrop(ItemId itemId, uint minAmount, uint maxAmount, double chance, uint quality = 0, bool isHidden = false) {
             foreach(var (enemyId, _) in Enemies) {
                 var table = DropTables[enemyId].Clone().AddDrop(itemId, minAmount, maxAmount, chance, quality, isHidden);


### PR DESCRIPTION
- Enemies which are now labeled as an area boss will reward AP when the group is defeated.
- The amount of AP is configurable via the new setting AreaBossApReward.
  - The default value is 500 AP for the current Area the defeated enemy is in.
- Added a new member to instance enemy properties which allows a rank to be assigned to a scripts. The rank helps to control the order scripts are executed. The scripts with a lower rank are executed before scripts with a higher rank.
- Added a new script module InstanceEnemyDropGenerator. This module can be used to have the server assign drops to an enemy when killed. Intended to eventually replace the event item generator via json.
- Fixed a few await warnings introduced from PR #919 related to scripting.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
