### PR TITLE
update: Parse index field from ddon-tools

### DIFF
--- a/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
@@ -72,14 +72,20 @@ public class InstanceEnemyManager : InstanceAssetManager<Enemy, InstancedEnemy>
                 if(gameTimeMSec <= original.SpawnTimeEnd || gameTimeMSec >= original.SpawnTimeStart)
                 {
                     var enemy = new InstancedEnemy(original);
-                    enemy.Index = (byte)filteredEnemyList.Count;
+                    if (enemy.Index == Enemy.INVALID_INDEX)
+                    {
+                        enemy.Index = (byte)filteredEnemyList.Count;
+                    }
                     filteredEnemyList.Add(enemy);
                 }
             }
             else if(gameTimeMSec >= original.SpawnTimeStart && gameTimeMSec <= original.SpawnTimeEnd)
             {
                 var enemy = new InstancedEnemy(original);
-                enemy.Index = (byte)filteredEnemyList.Count;
+                if (enemy.Index == Enemy.INVALID_INDEX)
+                {
+                    enemy.Index = (byte)filteredEnemyList.Count;
+                }
                 filteredEnemyList.Add(enemy);
             }
         }

--- a/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
@@ -20,7 +20,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
 
         private static readonly ILogger Logger = LogProvider.Logger(typeof(EnemySpawnAssetDeserializer));
 
-        private static readonly string[] ENEMY_HEADERS = {"StageId", "LayerNo", "GroupId", "SubGroupId", "EnemyId", "NamedEnemyParamsId", "RaidBossId", "Scale", "Lv", "HmPresetNo", "StartThinkTblNo", "RepopNum", "RepopCount", "EnemyTargetTypesId", "MontageFixNo", "SetType", "InfectionType", "IsBossGauge", "IsBossBGM", "IsManualSet", "IsAreaBoss", "IsBloodOrbEnemy", "BloodOrbs", "IsHighOrbEnemy", "HighOrbs", "Experience", "DropsTableId", "SpawnTime", "PPDrop"};
+        private static readonly string[] ENEMY_HEADERS = {"StageId", "LayerNo", "GroupId", "SubGroupId", "PositionIndex", "EnemyId", "NamedEnemyParamsId", "RaidBossId", "Scale", "Lv", "HmPresetNo", "StartThinkTblNo", "RepopNum", "RepopCount", "EnemyTargetTypesId", "MontageFixNo", "SetType", "InfectionType", "IsBossGauge", "IsBossBGM", "IsManualSet", "IsAreaBoss", "IsBloodOrbEnemy", "BloodOrbs", "IsHighOrbEnemy", "HighOrbs", "Experience", "DropsTableId", "SpawnTime", "PPDrop"};
         private static readonly string[] DROPS_TABLE_HEADERS = {"ItemId", "ItemNum", "MaxItemNum", "Quality", "IsHidden", "DropChance"};
 
         private Dictionary<uint, NamedParam> namedParams;
@@ -113,9 +113,14 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                     BloodOrbs = row[enemySchemaIndexes["BloodOrbs"]].GetUInt32(),
                     HighOrbs = row[enemySchemaIndexes["HighOrbs"]].GetUInt32(),
                     Experience = row[enemySchemaIndexes["Experience"]].GetUInt32(),
-
                     Subgroup = subGroupId,
                 };
+
+                enemy.Index = Enemy.INVALID_INDEX;
+                if (enemySchemaIndexes.ContainsKey("PositionIndex"))
+                {
+                    enemy.Index = row[enemySchemaIndexes["PositionIndex"]].GetByte();
+                }
 
                 // Fallback for old style schema
                 enemy.IsBloodOrbEnemy = enemy.BloodOrbs > 0;

--- a/Arrowgene.Ddon.Shared/Model/Enemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/Enemy.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 namespace Arrowgene.Ddon.Shared.Model
 {
     public class Enemy
-    {       
+    {
+        public const byte INVALID_INDEX = 0xff;
+
         public Enemy()
         {
             NamedEnemyParams = NamedParam.DEFAULT_NAMED_PARAM;
@@ -37,6 +39,7 @@ namespace Arrowgene.Ddon.Shared.Model
             Experience = enemy.Experience;
             DropsTable = enemy.DropsTable;
             Subgroup = enemy.Subgroup;
+            Index = enemy.Index;
             PPDrop = enemy.PPDrop;
             IsBloodOrbEnemy = enemy.IsBloodOrbEnemy;
             IsHighOrbEnemy = enemy.IsHighOrbEnemy;
@@ -75,6 +78,7 @@ namespace Arrowgene.Ddon.Shared.Model
             } 
         }
         public byte Subgroup { get; set; }
+        public byte Index { get; set; }
 
         public uint GetDroppedExperience()
         {

--- a/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
+++ b/Arrowgene.Ddon.Shared/Model/InstancedEnemy.cs
@@ -19,7 +19,6 @@ namespace Arrowgene.Ddon.Shared.Model
         public InstancedEnemy(InstancedEnemy enemy) : base (enemy)
         {
             IsKilled = false;
-            Index = enemy.Index;
             IsRequired = enemy.IsRequired;
             RepopWaitSecond = enemy.RepopWaitSecond;
             StageLayoutId = enemy.StageLayoutId;
@@ -31,7 +30,6 @@ namespace Arrowgene.Ddon.Shared.Model
         }
 
         public StageLayoutId StageLayoutId { get; set; }
-        public byte Index { get; set; }
         public bool IsRequired { get; set; }
         public bool IsKilled { get; set; }
         public uint RepopWaitSecond {  get; set; }


### PR DESCRIPTION
Uses PositionIndex from ddon-tools if it is present in the schema. Added a fallback mechanism so older enemy spawns still work.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
