### PR TITLE
default gathering: Adjust script

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/mixins/default_gathering.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/mixins/default_gathering.csx
@@ -27,6 +27,97 @@ private static class Settings
     }
 }
 
+private class GatheringExtensions
+{
+    public const int MIN_GATHERING_RANK = 1;
+    public const int MAX_GATHERING_RANK = 11;
+
+    private static readonly Dictionary<GatheringType, int> ChestModifierRank = new Dictionary<GatheringType, int>()
+    {
+        [GatheringType.OM_GATHER_NONE] = 0,
+        [GatheringType.OM_GATHER_TREA_OLD] = 0,
+        [GatheringType.OM_GATHER_SHIP] = 1,
+        [GatheringType.OM_GATHER_TREA_TREE] = 1,
+        [GatheringType.OM_GATHER_KEY_LV1] = 1,
+        [GatheringType.OM_GATHER_KEY_LV2] = 2,
+        [GatheringType.OM_GATHER_TREA_IRON] = 2,
+        [GatheringType.OM_GATHER_KEY_LV3] = 3,
+        [GatheringType.OM_GATHER_KEY_LV4] = 4,
+    };
+
+    private static readonly Dictionary<OmGatheringPoint, int> TreasureChestBaseRank = new Dictionary<OmGatheringPoint, int>()
+    {
+        [OmGatheringPoint.BrownChest] = 1,
+        [OmGatheringPoint.IronChest] = 2,
+        [OmGatheringPoint.TreasureChest] = 3,
+        [OmGatheringPoint.BronzeChest] = 4,
+        [OmGatheringPoint.SilverChest] = 5,
+        [OmGatheringPoint.GoldChest] = 6,
+        [OmGatheringPoint.PurpleChest] = 7,
+    };
+
+    public static int GetTreasureChestRank(GatheringSpotInfo spotInfo)
+    {
+        if (!spotInfo.UnitId.IsTreasureChest())
+        {
+            return MIN_GATHERING_RANK;
+        }
+        return TreasureChestBaseRank[spotInfo.UnitId] + ChestModifierRank[spotInfo.GatheringType];
+    }
+
+    private static readonly Dictionary<GatheringType, int> LumberModifierRank = new Dictionary<GatheringType, int>()
+    {
+        [GatheringType.OM_GATHER_NONE] = 0,
+        [GatheringType.OM_GATHER_TREE_LV1] = 1,
+        [GatheringType.OM_GATHER_TREE_LV2] = 2,
+        [GatheringType.OM_GATHER_TREE_LV3] = 3,
+        [GatheringType.OM_GATHER_TREE_LV4] = 4,
+    };
+
+    private static readonly Dictionary<GatheringType, int> GemstoneModifierRank = new Dictionary<GatheringType, int>()
+    {
+        [GatheringType.OM_GATHER_NONE] = 0,
+        [GatheringType.OM_GATHER_JWL_LV1] = 1,
+        [GatheringType.OM_GATHER_JWL_LV2] = 2,
+        [GatheringType.OM_GATHER_JWL_LV3] = 3,
+    };
+
+    private static readonly Dictionary<GatheringType, int> OreModiferRank = new Dictionary<GatheringType, int>()
+    {
+        [GatheringType.OM_GATHER_NONE] = 0,
+        [GatheringType.OM_GATHER_CRST_LV1] = 1,
+        [GatheringType.OM_GATHER_CRST_LV2] = 2,
+        [GatheringType.OM_GATHER_CRST_LV3] = 3,
+        [GatheringType.OM_GATHER_CRST_LV4] = 4,
+    };
+
+    private static readonly Dictionary<GatheringType, int> CorpseModifier = new Dictionary<GatheringType, int>()
+    {
+        [GatheringType.OM_GATHER_NONE] = 0,
+        [GatheringType.OM_GATHER_CORPSE] = 1,
+        [GatheringType.OM_GATHER_DRAGON] = 2,
+    };
+
+
+    public static int GetGatherSpotRank(GatheringSpotInfo spotInfo)
+    {
+        switch (spotInfo.UnitId.GetGatheringPointType())
+        {
+            case GatheringPointType.TreasureChest:
+                return GetTreasureChestRank(spotInfo);
+            case GatheringPointType.Lumber:
+                return MIN_GATHERING_RANK + LumberModifierRank[spotInfo.GatheringType];
+            case GatheringPointType.Gemstone:
+                return MIN_GATHERING_RANK + GemstoneModifierRank[spotInfo.GatheringType];
+            case GatheringPointType.Ore:
+                return MIN_GATHERING_RANK + OreModiferRank[spotInfo.GatheringType];
+            case GatheringPointType.Corpse:
+                return MIN_GATHERING_RANK + CorpseModifier[spotInfo.GatheringType];
+        }
+        return MIN_GATHERING_RANK;
+    }
+}
+
 public class Mixin : IDefaultGatherMixin
 {
     private static readonly ILogger Logger = LogProvider.Logger(typeof(Mixin));
@@ -41,32 +132,10 @@ public class Mixin : IDefaultGatherMixin
         List<InstancedGatheringItem> results = new();
         if (LibDdon.Assets.DefaultGatheringDropsAsset.SpotDefaultDrops.ContainsKey((stageLayoutId, index)))
         {
-            results = HandleSpotDrops(client, stageLayoutId, index);
-        }
-        else
-        {
-            results = HandleAreaDrops(client, stageLayoutId, index);
+            return new();
         }
 
-        return results;
-    }
-
-    private List<InstancedGatheringItem> HandleSpotDrops(GameClient client, StageLayoutId stageLayoutId, uint index)
-    {
-        // TODO: Fill in spot info before using it
-        return new();
-        /*
-        var drops = LibDdon.Assets.DefaultGatheringDropsAsset.SpotDefaultDrops[(stageLayoutId, index)];
-
-        // Create a list which golds all the items we can roll
-        var rolls = drops.Select(x => x.ItemId).ToList();
-
-        // Determine how many items to generate
-        var slots = Random.Shared.WeightedNext(1, drops.Count, Settings.DefaultGatherDropsRandomBias);
-
-        var dropTable = drops.ToDictionary(x => x.ItemId, x => x);
-        return RollDrops(slots, rolls, dropTable, Settings.DefaultGatherDropsRandomBias);
-        */
+        return HandleAreaDrops(client, stageLayoutId, index);
     }
 
     private List<InstancedGatheringItem> HandleAreaDrops(GameClient client, StageLayoutId stageLayoutId, uint index)
@@ -90,13 +159,15 @@ public class Mixin : IDefaultGatherMixin
 
         var spotInfo = stageSpots[(stageLayoutId.GroupId, index)];
 
-        Logger.Debug($"{stageLayoutId}.{index} {spotInfo.GatheringType}");
+        Logger.Debug($"{stageLayoutId}.{index}  OmType={spotInfo.UnitId}, GatheringType={spotInfo.GatheringType}");
 
-        var dropTable = GetDropCategoriesForType(spotInfo.GatheringType)
+        var dropTable = GetDropCategoriesForSpot(spotInfo)
             .Select(x => LibDdon.Assets.DefaultGatheringDropsAsset.AreaDefaultDrops[client.Character.AreaId][x])
             .Where(x => x.Count > 0)
             .SelectMany(x => x)
             .Where(x => x.StageId == stage.StageId)
+            .GroupBy(x => x.ItemId)
+            .Select(x => x.First())
             .OrderBy(x => x.ItemLevel)
             .ToDictionary(x => x.ItemId, x => x);
         if (dropTable.Count == 0)
@@ -104,14 +175,8 @@ public class Mixin : IDefaultGatherMixin
             return new();
         }
 
-        var potentialSlots = Settings.DefaultGatherDropMaxSlots;
-
-        var gatherPointRank = GatherTypeExtension.MIN_TYPE_RANK;
-        if (spotInfo.GatheringType.IsChest())
-        {
-            gatherPointRank = spotInfo.GatheringType.GetChestRank();
-            potentialSlots += (int)(gatherPointRank - GatherTypeExtension.MIN_TYPE_RANK);
-        }
+        var gatherPointRank = GatheringExtensions.GetGatherSpotRank(spotInfo);
+        var potentialSlots = Settings.DefaultGatherDropMaxSlots + (int)(gatherPointRank - GatheringExtensions.MIN_GATHERING_RANK);
 
         // Create a list which holds all the items we can roll
         var rolls = dropTable.Keys.ToList();
@@ -125,12 +190,12 @@ public class Mixin : IDefaultGatherMixin
 
     private double FindRollBiasForSpot(int rank)
     {
-        var preferenceScore = GatherTypeExtension.MAX_TYPE_RANK - rank + 1;
+        var preferenceScore = GatheringExtensions.MAX_GATHERING_RANK - rank + 1;
 
         double minBias = Settings.DefaultGatherDropsRandomBias; // Higher makes more skewed to common items
         double maxBias = 0.3; // lower makes it more skewed to rarer items
 
-        double t = (rank - 1.0) / (GatherTypeExtension.MAX_TYPE_RANK - 1.0); // Normalized rank [0, 1]
+        double t = (rank - 1.0) / (GatheringExtensions.MAX_GATHERING_RANK - 1.0); // Normalized rank [0, 1]
         return minBias * Math.Pow(maxBias / minBias, t);
     }
 
@@ -173,66 +238,39 @@ public class Mixin : IDefaultGatherMixin
         return results;
     }
 
-    private static List<DropCategory> SimpleTreasureChestCategories = new()
+    private static Dictionary<GatheringPointType, List<DropCategory>> DropCategories = new Dictionary<GatheringPointType, List<DropCategory>>()
     {
-        DropCategory.Currency,
-        DropCategory.Consumable,
-        DropCategory.Ore,
-        DropCategory.Sand,
-        DropCategory.Thread,
-        DropCategory.Plants,
-        DropCategory.Meat,
-        DropCategory.Scrolls,
+        [GatheringPointType.Alchemy] = [DropCategory.Liquids, DropCategory.Lumber, DropCategory.Other],
+        [GatheringPointType.Box] = [
+            DropCategory.Consumable, DropCategory.Dye, DropCategory.Thread, DropCategory.Fabric, DropCategory.Ingots, DropCategory.Ore,
+            DropCategory.Gemstones, DropCategory.Scrolls, DropCategory.Leather
+        ],
+        [GatheringPointType.Corpse] = [
+            DropCategory.Meat, DropCategory.Claws, DropCategory.Bones, DropCategory.Fang, DropCategory.Hides, DropCategory.Horns,
+            DropCategory.Furs, DropCategory.Feathers
+        ],
+        [GatheringPointType.Furniture] = [DropCategory.Consumable, DropCategory.Dye, DropCategory.Thread, DropCategory.Fabric, DropCategory.CrestArmor, DropCategory.CrestWeapon],
+        [GatheringPointType.Gemstone] = [DropCategory.Gemstones],
+        [GatheringPointType.Lumber] = [DropCategory.Lumber],
+        [GatheringPointType.Mushroom] = [DropCategory.Mushrooms],
+        [GatheringPointType.Ore] = [DropCategory.Ore],
+        [GatheringPointType.Plants] = [DropCategory.Plants],
+        [GatheringPointType.Sand] = [DropCategory.Sand],
+        [GatheringPointType.SealedTreasureChest] = [DropCategory.Equipment, DropCategory.Jewelry, DropCategory.Unappraised, DropCategory.Regional],
+        [GatheringPointType.Shell] = [DropCategory.Shell],
+        [GatheringPointType.TreasureChest] = DropCategoryExtension.All,
+        [GatheringPointType.Twinkle] = DropCategoryExtension.All,
+        [GatheringPointType.Water] = [DropCategory.Liquids],
     };
 
-    private static Dictionary<GatheringType, List<DropCategory>> DropCategories = new Dictionary<GatheringType, List<DropCategory>>()
+    private List<DropCategory> GetDropCategoriesForSpot(GatheringSpotInfo spotInfo)
     {
-        [GatheringType.OM_GATHER_NONE] = SimpleTreasureChestCategories, // Some spots are assigned as none? Looks like plain treasure chests
-        [GatheringType.OM_GATHER_TREE_LV1] = new() { DropCategory.Lumber },
-        [GatheringType.OM_GATHER_TREE_LV2] = new() { DropCategory.Lumber },
-        [GatheringType.OM_GATHER_TREE_LV3] = new() { DropCategory.Lumber },
-        [GatheringType.OM_GATHER_TREE_LV4] = new() { DropCategory.Lumber },
-        [GatheringType.OM_GATHER_JWL_LV1] = new() { DropCategory.Gemstones },
-        [GatheringType.OM_GATHER_JWL_LV2] = new() { DropCategory.Gemstones },
-        [GatheringType.OM_GATHER_JWL_LV3] = new() { DropCategory.Gemstones },
-        [GatheringType.OM_GATHER_CRST_LV1] = new() { DropCategory.Ore },
-        [GatheringType.OM_GATHER_CRST_LV2] = new() { DropCategory.Ore },
-        [GatheringType.OM_GATHER_CRST_LV3] = new() { DropCategory.Ore },
-        [GatheringType.OM_GATHER_CRST_LV4] = new() { DropCategory.Ore },
-        [GatheringType.OM_GATHER_KEY_LV1] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_KEY_LV2] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_KEY_LV3] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_TREA_OLD] = SimpleTreasureChestCategories,
-        [GatheringType.OM_GATHER_KEY_LV4] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_TREA_IRON] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_TREA_TREE] = SimpleTreasureChestCategories,
-        [GatheringType.OM_GATHER_TREA_SILVER] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_TREA_GOLD] = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().ToList(),
-        [GatheringType.OM_GATHER_BOX] = SimpleTreasureChestCategories,
-        [GatheringType.OM_GATHER_SHIP] = SimpleTreasureChestCategories,
-        [GatheringType.OM_GATHER_DRAGON] = new() { DropCategory.Meat, DropCategory.Claws, DropCategory.Bones, DropCategory.Hides, DropCategory.Horns },
-        [GatheringType.OM_GATHER_CORPSE] = new() { DropCategory.Meat, DropCategory.Claws, DropCategory.Bones, DropCategory.Hides, DropCategory.Horns, DropCategory.Furs, DropCategory.Feathers },
-        [GatheringType.OM_GATHER_GRASS] = new() { DropCategory.Plants },
-        [GatheringType.OM_GATHER_FLOWER] = new() { DropCategory.Plants },
-        [GatheringType.OM_GATHER_MUSHROOM] = new() { DropCategory.Mushrooms },
-        [GatheringType.OM_GATHER_CLOTH] = new() { DropCategory.Fabric, DropCategory.Thread },
-        [GatheringType.OM_GATHER_BOOK] = new() { DropCategory.Scrolls },
-        [GatheringType.OM_GATHER_SAND] = new() { DropCategory.Sand },
-        [GatheringType.OM_GATHER_ALCHEMY] = new() { DropCategory.Liquids, DropCategory.Lumber, DropCategory.Other },
-        [GatheringType.OM_GATHER_WATER] = new() { DropCategory.Liquids },
-        [GatheringType.OM_GATHER_SHELL] = new() { DropCategory.Sand, DropCategory.Bones, DropCategory.Gemstones, DropCategory.Currency, DropCategory.Other },
-        [GatheringType.OM_GATHER_ANTIQUE] = new() { DropCategory.Plants },
-        [GatheringType.OM_GATHER_ONE_OFF] = new(),  // Red Light's in S2 areas
-        [GatheringType.OM_GATHER_TWINKLE] = new() { DropCategory.Sand }
-    };
-
-    private List<DropCategory> GetDropCategoriesForType(GatheringType gatheringType)
-    {
-        if (!DropCategories.ContainsKey(gatheringType))
+        var gatheringPointType = spotInfo.UnitId.GetGatheringPointType();
+        if (!DropCategories.ContainsKey(gatheringPointType))
         {
             return new();
         }
-        return DropCategories[gatheringType];
+        return DropCategories[gatheringPointType];
     }
 }
 

--- a/Arrowgene.Ddon.Shared/Asset/GatheringInfoAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/GatheringInfoAsset.cs
@@ -8,7 +8,7 @@ namespace Arrowgene.Ddon.Shared.Asset
         public uint GroupNo { get; set; }
         public uint PosId { get; set; }
         public GatheringType GatheringType { get; set; }
-        public uint UintId { get; set; }
+        public OmGatheringPoint UnitId { get; set; }
         public (double X, double Y, double Z) Position { get; set; }
     }
 

--- a/Arrowgene.Ddon.Shared/AssetReader/GatheringSpotInfoAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/GatheringSpotInfoAssetDeserializer.cs
@@ -35,7 +35,7 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                         GroupNo = jGroup.GetProperty("GroupNo").GetUInt32(),
                         PosId = jGroup.GetProperty("PosId").GetUInt32(),
                         GatheringType = (GatheringType) jGroup.GetProperty("GatheringType").GetUInt32(),
-                        UintId = jGroup.GetProperty("UnitId").GetUInt32(),
+                        UnitId = (OmGatheringPoint) jGroup.GetProperty("UnitId").GetUInt32(),
                         Position = (
                             jGroup.GetProperty("Position").GetProperty("x").GetDouble(),
                             jGroup.GetProperty("Position").GetProperty("y").GetDouble(),

--- a/Arrowgene.Ddon.Shared/Model/DropCategory.cs
+++ b/Arrowgene.Ddon.Shared/Model/DropCategory.cs
@@ -1,33 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Arrowgene.Ddon.Shared.Model
 {
     public enum DropCategory : uint
     {
         None,
-        Meat,
-        Horns,
-        Bones,
+        Bones, // MaterialAnimalBone
         Claws,
-        Liquids,
-        Sand,
-        Ore,
-        Ingots,
-        Gemstones,
-        Hides,
-        Leather,
-        Thread,
-        Plants,
-        Furs,
-        Feathers,
-        Fabric,
-        Lumber,
-        Mushrooms,
-        Scrolls,
-        Other,
-        Regional,
-        Unappraised,
         Consumable,
         Currency,
+        CrestArmor, // MaterialCrestArmor
+        CrestWeapon, // MaterialCrestWeapon
+        Dye, // MaterialSpecialDye
+        DragonAbility, // MaterialDragonAbility
         Equipment,
+        Fabric, // MaterialSewingCloth
+        Fang, // MaterialAnimalFang
+        Feathers, //MaterialAnimalFeather
+        Furs, // MaterialSewingFur
+        Gemstones, //MaterialInorganicGem
+        Hides, // MaterialAnimalSkin
+        Horns, // MaterialAnimalHorn
+        Ingots, // MaterialInorganicMetal
         Jewelry,
+        Leather,
+        Liquids, // MaterialInorganicLiquid
+        Lumber, // MaterialPlantLumber
+        Meat, // MaterialAnimalMeat
+        Mushrooms, // MaterialPlantMushroom
+        Ore, // MaterialInorganicOre
+        Other, // MaterialSpecialOther
+        PawnInspiration, // MaterialPawnInspiration
+        Plants, // MaterialPlantGrass
+        RefiningArmor, // MaterialRefiningArmor
+        RefiningWeapon, // MaterialRefiningWeapon
+        Regional, //  MaterialRegionalMaterial
+        Sand, // MaterialInorganicSand
+        Scrolls, // MaterialSpecialScroll
+        Shell, // MaterialUnusedShell
+        SlayerStone, // MaterialSlayerStone
+        Thread, // MaterialSewingString
+        Unappraised, // MaterialAppraisedItem
+    }
+
+    public static class DropCategoryExtension
+    {
+        public static readonly List<DropCategory> All = Enum.GetValues(typeof(DropCategory)).Cast<DropCategory>().Where(x => x != DropCategory.None).ToList();
     }
 }

--- a/Arrowgene.Ddon.Shared/Model/GatheringType.cs
+++ b/Arrowgene.Ddon.Shared/Model/GatheringType.cs
@@ -1,9 +1,186 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Arrowgene.Ddon.Shared.Model
 {
+    public enum OmGatheringPoint : uint
+    {
+        // SetInfoOmGather
+        Alchemy0 = 520080,
+        Alchemy1 = 520081,
+        Alchemy2 = 520111,
+        Antique0 = 520110,
+        Antique1 = 520111,
+        Book = 520041,
+        Box0 = 520070,
+        Box1 = 520071,
+        Corpse = 520170,
+        Flower0 = 520010,
+        Flower1 = 520011,
+        Flower2 = 520012,
+        Grass0 = 520000,
+        Grass1 = 520001,
+        Grass2 = 520002,
+        Grass3 = 520003,
+        Grass4 = 520004,
+        Lumber0 = 520030,
+        Lumber1 = 520031,
+        Lumber2 = 520032,
+        Lumber3 = 520033,
+        MiningGemstone0 = 520050,
+        MiningGemstone1 = 520051,
+        MiningGemstone2 = 520052,
+        MiningGemstone3 = 520160,
+        MiningGemstone4 = 520161,
+        MiningGemstone5 = 520162,
+        MiningOre0 = 520160,
+        MiningOre1 = 520161,
+        MiningOre2 = 520162,
+        MiningOre3 = 520163,
+        Mushroom0 = 520020,
+        Mushroom1 = 520021,
+        Mushroom2 = 520022,
+        Mushroom3 = 520023,
+        Mushroom4 = 520024,
+        OneOff0 = 513054,
+        OneOff1 = 520171,
+        Sand = 520060,
+        Shells = 520100,
+        Twinkle0 = 520170,
+        Twinkle1 = 522552,
+        Twinkle2 = 523240,
+        Water = 520090,
+        // SetInfoOmTreasureBox
+        IronChest = 513050,
+        BrownChest = 513051,
+        TreasureChest = 513052,
+        BronzeChest = 513053,
+        SilverChest = 513054,
+        GoldChest = 513055,
+        PurpleChest = 513056,
+        UnkChest0 = 513060,
+        UnkChest1 = 513061,
+        // SetInfoOmTreasureBoxG (BBM)
+        OrangeSealedChest = 513130,
+        PurpleSealedChest = 513133,
+    }
+
+    public enum GatheringPointType
+    {
+        None,
+        Alchemy,
+        Box,
+        Corpse,
+        Furniture,
+        Gemstone,
+        Lumber,
+        Mushroom,
+        OneOff,
+        Ore,
+        Plants,
+        Sand,
+        SealedTreasureChest,
+        Shell,
+        TreasureChest,
+        Twinkle,
+        Water,
+    }
+
+    public static class GatheringPointTypeExtension
+    {
+        private static readonly Dictionary<OmGatheringPoint, GatheringPointType> OmGatherToGatheringPointTypeMap = new Dictionary<OmGatheringPoint, GatheringPointType>()
+        {
+            // OmSetGather
+            [OmGatheringPoint.Alchemy0] = GatheringPointType.Alchemy,
+            [OmGatheringPoint.Alchemy1] = GatheringPointType.Alchemy,
+            [OmGatheringPoint.Alchemy2] = GatheringPointType.Alchemy,
+            [OmGatheringPoint.Antique0] = GatheringPointType.Furniture,
+            [OmGatheringPoint.Antique1] = GatheringPointType.Furniture,
+            [OmGatheringPoint.Book] = GatheringPointType.Furniture,
+            [OmGatheringPoint.Box0] = GatheringPointType.Box,
+            [OmGatheringPoint.Box1] = GatheringPointType.Box,
+            [OmGatheringPoint.Corpse] = GatheringPointType.Corpse,
+            [OmGatheringPoint.Flower0] = GatheringPointType.Plants,
+            [OmGatheringPoint.Flower1] = GatheringPointType.Plants,
+            [OmGatheringPoint.Flower2] = GatheringPointType.Plants,
+            [OmGatheringPoint.MiningGemstone0] = GatheringPointType.Gemstone,
+            [OmGatheringPoint.MiningGemstone1] = GatheringPointType.Gemstone,
+            [OmGatheringPoint.MiningGemstone2] = GatheringPointType.Gemstone,
+            [OmGatheringPoint.MiningGemstone3] = GatheringPointType.Gemstone,
+            [OmGatheringPoint.MiningGemstone4] = GatheringPointType.Gemstone,
+            [OmGatheringPoint.MiningGemstone5] = GatheringPointType.Gemstone,
+            [OmGatheringPoint.Grass0] = GatheringPointType.Plants,
+            [OmGatheringPoint.Grass1] = GatheringPointType.Plants,
+            [OmGatheringPoint.Grass2] = GatheringPointType.Plants,
+            [OmGatheringPoint.Grass3] = GatheringPointType.Plants,
+            [OmGatheringPoint.Grass4] = GatheringPointType.Plants,
+            [OmGatheringPoint.Lumber0] = GatheringPointType.Lumber,
+            [OmGatheringPoint.Lumber1] = GatheringPointType.Lumber,
+            [OmGatheringPoint.Lumber2] = GatheringPointType.Lumber,
+            [OmGatheringPoint.Lumber3] = GatheringPointType.Lumber,
+            [OmGatheringPoint.Mushroom0] = GatheringPointType.Mushroom,
+            [OmGatheringPoint.Mushroom1] = GatheringPointType.Mushroom,
+            [OmGatheringPoint.Mushroom2] = GatheringPointType.Mushroom,
+            [OmGatheringPoint.Mushroom3] = GatheringPointType.Mushroom,
+            [OmGatheringPoint.Mushroom4] = GatheringPointType.Mushroom,
+            [OmGatheringPoint.MiningOre0] = GatheringPointType.Ore,
+            [OmGatheringPoint.MiningOre1] = GatheringPointType.Ore,
+            [OmGatheringPoint.MiningOre2] = GatheringPointType.Ore,
+            [OmGatheringPoint.MiningOre3] = GatheringPointType.Ore,
+            [OmGatheringPoint.Sand] = GatheringPointType.Sand,
+            [OmGatheringPoint.Shells] = GatheringPointType.Shell,
+            [OmGatheringPoint.Twinkle0] = GatheringPointType.Twinkle,
+            [OmGatheringPoint.Twinkle1] = GatheringPointType.Twinkle,
+            [OmGatheringPoint.Twinkle2] = GatheringPointType.Twinkle,
+            [OmGatheringPoint.Water] = GatheringPointType.Water,
+            // OneOffGathering (special)
+            [OmGatheringPoint.OneOff0] = GatheringPointType.OneOff,
+            [OmGatheringPoint.OneOff1] = GatheringPointType.OneOff,
+            // OmTreasureBox
+            [OmGatheringPoint.IronChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.BrownChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.TreasureChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.BronzeChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.SilverChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.GoldChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.PurpleChest] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.UnkChest0] = GatheringPointType.TreasureChest,
+            [OmGatheringPoint.UnkChest1] = GatheringPointType.TreasureChest,
+            // OmTreasureBoxG
+            [OmGatheringPoint.OrangeSealedChest] = GatheringPointType.SealedTreasureChest,
+            [OmGatheringPoint.PurpleSealedChest] = GatheringPointType.SealedTreasureChest,
+        };
+
+        public static GatheringPointType GetGatheringPointType(this OmGatheringPoint omGatheringPoint)
+        {
+            if (OmGatherToGatheringPointTypeMap.ContainsKey(omGatheringPoint))
+            {
+                return OmGatherToGatheringPointTypeMap[omGatheringPoint];
+            }
+            return GatheringPointType.None;
+        }
+
+        public static bool IsTreasureChest(this OmGatheringPoint omGatheringPoint)
+        {
+            var gatheringPointType = GetGatheringPointType(omGatheringPoint);
+            return gatheringPointType == GatheringPointType.TreasureChest || gatheringPointType == GatheringPointType.SealedTreasureChest;
+        }
+
+        public static bool IsLumberGatheringPoint(this OmGatheringPoint omGatheringPoint)
+        {
+            return GetGatheringPointType(omGatheringPoint) == GatheringPointType.Lumber;
+        }
+
+        public static bool IsOreMiningPoint(this OmGatheringPoint omGatheringPoint)
+        {
+            return GetGatheringPointType(omGatheringPoint) == GatheringPointType.Ore;
+        }
+
+        public static bool IsGemstoneMiningPoint(this OmGatheringPoint omGatheringPoint)
+        {
+            return GetGatheringPointType(omGatheringPoint) == GatheringPointType.Gemstone;
+        }
+    }
+
     public enum GatheringType : uint
     {
         OM_GATHER_NONE = 0x0,
@@ -47,26 +224,6 @@ namespace Arrowgene.Ddon.Shared.Model
 
     public static class GatherTypeExtension
     {
-        private static List<GatheringType> ChestType = new()
-        {
-            GatheringType.OM_GATHER_NONE,
-            GatheringType.OM_GATHER_TREA_OLD,
-            GatheringType.OM_GATHER_TREA_TREE,
-            GatheringType.OM_GATHER_SHIP,
-            GatheringType.OM_GATHER_KEY_LV1,
-            GatheringType.OM_GATHER_KEY_LV2,
-            GatheringType.OM_GATHER_KEY_LV3,
-            GatheringType.OM_GATHER_KEY_LV4,
-            GatheringType.OM_GATHER_TREA_IRON,
-            GatheringType.OM_GATHER_TREA_SILVER,
-            GatheringType.OM_GATHER_TREA_GOLD,
-        };
-
-        public static bool IsChest(this GatheringType gatheringType)
-        {
-            return ChestType.Contains(gatheringType);
-        }
-
         private static List<GatheringType> LockedChestType = new()
         {
             GatheringType.OM_GATHER_KEY_LV1,
@@ -78,33 +235,6 @@ namespace Arrowgene.Ddon.Shared.Model
         public static bool IsLockedChest(this GatheringType gatheringType)
         {
             return LockedChestType.Contains(gatheringType);
-        }
-
-        private static Dictionary<GatheringType, int> ChestRank = new()
-        {
-            [GatheringType.OM_GATHER_NONE] = 1,
-            [GatheringType.OM_GATHER_TREA_OLD] = 1,
-            [GatheringType.OM_GATHER_TREA_TREE] = 2,
-            [GatheringType.OM_GATHER_SHIP] = 2,
-            [GatheringType.OM_GATHER_KEY_LV1] = 3,
-            [GatheringType.OM_GATHER_TREA_IRON] = 4,
-            [GatheringType.OM_GATHER_KEY_LV2] = 5,
-            [GatheringType.OM_GATHER_KEY_LV3] = 6,
-            [GatheringType.OM_GATHER_KEY_LV4] = 7,
-            [GatheringType.OM_GATHER_TREA_SILVER] = 8,
-            [GatheringType.OM_GATHER_TREA_GOLD] = 9,
-        };
-
-        public const int MIN_TYPE_RANK = 1;
-        public const int MAX_TYPE_RANK = 9;
-
-        public static int GetChestRank(this GatheringType gatheringType)
-        {
-            if (!ChestRank.ContainsKey(gatheringType))
-            {
-                return 1;
-            }
-            return ChestRank[gatheringType];
         }
     }
 }

--- a/docs/epitaph_road/guide.md
+++ b/docs/epitaph_road/guide.md
@@ -32,11 +32,13 @@ Due to these differences, in the main `EpitaphRoad.json` file, there will be fie
 | Stone Statue Space | om511320 | Red door which blocks the entrance to the Stone Statue
 | Mysterious Doors   | om522554 | Doors with Green light that can be unlocked
 | Mysterious Powers  | om522552 | Green light pillars spawned when touching door (gathering points)
+| Iron Chest         | om513050 |
 | Brown Chest        | om513051 | Dungeon trash (souls)
 | Treasure Chest     | om513052 | Chests behind the gate of mysterious doors
 | Bronze Chest       | om513053 | Weekly reward
 | Silver Chest       | om513054 |
 | Gold Chest         | om513055 | Weekly reward
+| Purple Chest       | om513056 |
 
 ### Pattern for Mysterious doors
 

--- a/docs/gathering_nodes.md
+++ b/docs/gathering_nodes.md
@@ -1,0 +1,38 @@
+## SetInfoOmGather
+| Type                    | OM ID    | Comment
+|:------------------------|:--------:|:-------
+| Alchemy                 | om520080 | OM_GATHER_ALCHEMY
+| Alchemy                 | om520081 | OM_GATHER_ALCHEMY
+| Antique                 | om520111 | OM_GATHER_ANTIQUE
+| Book                    | om520041 | OM_GATHER_BOOK (OM_ID_GATHERABLE_OLD_BOOK_WITH_FEATHER)
+| Box                     | om520070 | OM_GATHER_BOX
+| Corpse                  | om520170 | OM_GATHER_CORPSE (OM_ID_GATHER_TWINKLE)
+| Flower                  | om520012 | OM_GATHER_FLOWER
+| Grass                   | om520000 | OM_GATHER_GRASS (OM_ID_GATHERABLE_GRASS)
+| Mining (Gemstone)       | om520050 | OM_GATHER_JWL_LV1, OM_GATHER_JWL_LV2
+| Mining (Ore)            | om520162 | OM_GATHER_CRST_LV1, OM_GATHER_CRST_LV2
+| Mushroom                | om520024 | OM_GATHER_MUSHROOM
+| One off                 | om520171 | OM_GATHER_ONE_OFF
+| Sand                    | om520060 | OM_GATHER_SAND
+| Shells                  | om520100 | OM_GATHER_SHELL
+| Twinkle                 | om522552 | OM_GATHER_TWINKLE
+| Wood                    | om520030 | OM_GATHER_TREE_LV1, OM_GATHER_TREE_LV2
+| Water                   | om520090 | OM_GATHER_WATER
+
+## SetInfoOmTreasureBox
+
+| Type               | OM ID    | Comment
+|:-------------------|:--------:|:-------
+| Iron Chest         | om513050 | Associated with OM_GATHER_KEY_LV1, OM_GATHER_KEY_LV2, OM_GATHER_SHIP
+| Brown Chest        | om513051 | Associated with OM_GATHER_TREA_OLD
+| Treasure Chest     | om513052 | Associated with OM_GATHER_TREA_TREE, OM_GATHER_NONE
+| Bronze Chest??     | om513053 | Associated with OM_GATHER_TREA_SILVER, (these look bronze to me)
+| Silver Chest??     | om513054 | Associated with OM_GATHER_NONE
+| Gold Chest         | om513055 | Associated with OM_GATHER_TREA_GOLD, OM_GATHER_NONE
+| Purple Chest       | om513056 | Associated with OM_GATHER_NONE
+
+## SetInfoOmTreasureBoxG
+| Type                    | OM ID    | Comment
+|:------------------------|:--------:|:-------
+| Orange Sealed Chest     | om513130 | Used in BBM (OM_ID_BBM_SEALED_TREASURE_BOX_ORANGE)
+| Blue Sealed Chest       | om513133 | Used in BBM (OM_ID_BBM_SEALED_TREASURE_BOX_BLUE) (looks purple to me)


### PR DESCRIPTION
- Added better checks for gathering types.
- Improved type print outs when the script is calculating drops.
- Moved gathering config rank data from the server into the script so if someone wants to modify certain fields or remove them completely.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
