### PR TITLE
Change Pawn Skip Job Training Default to False

### DIFF
--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1500,6 +1500,6 @@ namespace Arrowgene.Ddon.Server.Settings
                 return TryGetSetting("PawnSkipJobTraining", _PawnSkipJobTraining);
             }
         }
-        private const bool _PawnSkipJobTraining = true;
+        private const bool _PawnSkipJobTraining = false;
     }
 }


### PR DESCRIPTION
Defaulting the setting to false until a fix can be found for a bug letting players learn augments they shouldn't.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
