### PR TITLE
Fix: Exempt Pawns from Job Training

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
@@ -30,7 +30,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             S2CSkillGetAcquirableAbilityListRes response = new S2CSkillGetAcquirableAbilityListRes();
             if (request.CharacterId != 0 && Server.GameSettings.GameServerSettings.PawnSkipJobTraining)
             {
-                response.AbilityParamList = SkillData.AllAbilities.Where(x => x.Job == request.Job).ToList();
+                var allDefaultAbilities = SkillData.AllAbilities.Where(x => x.Job == request.Job && !SkillData.IsUnlockableAbility(request.Job, x.AbilityNo, 1));
+                var pawnUnlocks = SkillData.AllAbilities.Where(x => x.Job == request.Job
+                    && SkillData.IsUnlockableAbility(request.Job, x.AbilityNo, 1)
+                    && client.Character.LearnedAbilities.Any(y => x.AbilityNo == y.AbilityId)
+                );
+                response.AbilityParamList = allDefaultAbilities.Concat(pawnUnlocks).ToList();
             }
             else if (request.Job != 0)
             {

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
@@ -3,6 +3,7 @@ using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
+using static Arrowgene.Ddon.Server.Network.Challenge;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -27,9 +28,14 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else 
             {
+                var allDefaultSkills = SkillData.AllSkills.Where(x => x.Job == request.Job && !SkillData.IsUnlockableSkill(request.Job, x.SkillNo, 1));
+                var pawnUnlocks = SkillData.AllSkills.Where(x => x.Job == request.Job
+                    && SkillData.IsUnlockableSkill(request.Job, x.SkillNo, 1)
+                    && client.Character.LearnedCustomSkills.Any(y => x.SkillNo == y.SkillId)
+                    );
                 return new S2CSkillGetAcquirableSkillListRes()
                 {
-                    SkillParamList = SkillData.AllSkills.Where(x => x.Job == request.Job).ToList()
+                    SkillParamList = allDefaultSkills.Concat(pawnUnlocks).ToList()
                 };
             }
         }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
@@ -3,7 +3,6 @@ using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
-using static Arrowgene.Ddon.Server.Network.Challenge;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1500,6 +1500,6 @@ namespace Arrowgene.Ddon.Server.Settings
                 return TryGetSetting("PawnSkipJobTraining", _PawnSkipJobTraining);
             }
         }
-        private const bool _PawnSkipJobTraining = false;
+        private const bool _PawnSkipJobTraining = true;
     }
 }


### PR DESCRIPTION
Limited pawns to only skills/augments the player has access to. This gets around the weird client caching issue that let players buy skills and augments the pawns could access but the player shouldn't have been able to yet.

With thanks to @RyanYappert for code cleanup on the LINQ statements.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
