### PR TITLE
feat: Add world quests for Rathnite Foothills

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.0/q00030020.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.0/q00030020.csx
@@ -145,7 +145,7 @@ public class ScriptedQuest : IQuest
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.Gillian);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.AudienceChamber, NpcId.Joseph, 21291);
         process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.AudienceChamber)
-            .AddResultCmdReleaseAnnounce(ContentsRelease.RathniteFoothillsWorldQuests);
+            .AddResultCmdReleaseAnnounce(ContentsRelease.RathniteFoothillsWorldQuests, flagInfo: QuestFlags.RathniteFoothills.CaveOfHellsDescent);
         process0.AddProcessEndBlock(true);
     }
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018002.json
@@ -1,0 +1,183 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Reckless Action",
+    "quest_id": 22018002,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "RathniteFoothills",
+    "news_image": 330,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 25200
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5139
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "AreaPoints",
+            "amount": 500
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Royal Crest Medal",
+                    "item_id": 18815,
+                    "num": 5
+                },
+                {
+                    "comment": "Rock Leather",
+                    "item_id": 17870,
+                    "num": 3
+                },
+                {
+                    "comment": "Harpy Breast Meat",
+                    "item_id": 17928,
+                    "num": 3
+                }
+            ]
+        },
+        {
+            "type": "random",
+            "loot_pool": [
+                {
+                    "comment": "Random Item 1",
+                    "item_id": 17870,
+                    "num": 2,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Random Item 2",
+                    "item_id": 9324,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "comment": "GroupId: 0",
+            "stage_id": {
+                "id": 495,
+                "group_id": 16
+            },
+            "placement_type": "Manual",
+            "enemies": [
+                {
+                    "comment": "Little Crag",
+                    "enemy_id": "0x015509",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 2
+                },
+                {
+                    "comment": "Little Crag",
+                    "enemy_id": "0x015509",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 3
+                },
+                {
+                    "comment": "Little Crag",
+                    "enemy_id": "0x015509",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 4
+                },
+                {
+                    "comment": "Little Crag",
+                    "enemy_id": "0x015509",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 5
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 7
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 8
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "index": 9
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 461
+            },
+            "npc_id": "Andrea",
+            "message_id": 23477
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 495,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "announce_type": "Accept",
+            "npc_id": "Elton",
+            "message_id": 23860,
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 5462, "comment": "Spawns Elton"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [0]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 495,
+                "group_id": 1,
+                "layer_no": 0
+            },
+            "announce_type": "Update",
+            "npc_id": "Elton",
+            "message_id": 23479,
+            "flags": [
+                {"type": "QstLayout", "action": "Clear", "value": 5462, "comment": "Spawns Elton"},
+                {"type": "QstLayout", "action": "Set", "value": 5465, "comment": "Spawns post fight Elton"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 461
+            },
+            "announce_type": "Update",
+            "npc_id": "Andrea",
+            "message_id": 23476
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018003.json
@@ -1,0 +1,181 @@
+﻿{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Cowardly Soldier's Distraction",
+    "quest_id": 22018003,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "RathniteFoothills",
+    "news_image": 330,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5139
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "AreaPoints",
+            "amount": 500
+        },
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Acre Royal Family Intaglio",
+                    "item_id": 17912,
+                    "num": 1
+                },
+                {
+                    "comment": "Royal Crest Medal (Rathnite District)",
+                    "item_id": 18815,
+                    "num": 5
+                },
+                {
+                    "comment": "Highly Viscous Slime Liquid",
+                    "item_id": 17880,
+                    "num": 3
+                }
+            ]
+        },
+        {
+            "type": "random",
+            "loot_pool": [
+                {
+                    "comment": "Random Item 1",
+                    "item_id": 17870,
+                    "num": 2,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Random Item 2",
+                    "item_id": 9324,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "comment": "GroupId: 0 - Troll, Green Guardians, Deep Slimes",
+            "stage_id": {
+                "id": 493,
+                "group_id": 10
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015040",
+                    "level": 80,
+                    "exp": 100000,
+                    "is_boss": true,
+                    "comment": "Troll"
+                },
+                {
+                    "enemy_id": "0x010210",
+                    "level": 80,
+                    "exp": 6000,
+                    "is_boss": false,
+                    "comment": "Green Guardian"
+                },
+                {
+                    "enemy_id": "0x010210",
+                    "level": 80,
+                    "exp": 6000,
+                    "is_boss": false,
+                    "comment": "Green Guardian"
+                },
+                {
+                    "enemy_id": "0x010210",
+                    "level": 80,
+                    "exp": 6000,
+                    "is_boss": false,
+                    "comment": "Green Guardian"
+                },
+                {
+                    "enemy_id": "0x010901",
+                    "level": 80,
+                    "exp": 4500,
+                    "is_boss": false,
+                    "comment": "Deep Slime"
+                },
+                {
+                    "enemy_id": "0x010901",
+                    "level": 80,
+                    "exp": 4500,
+                    "is_boss": false,
+                    "comment": "Deep Slime"
+                },
+                {
+                    "enemy_id": "0x010901",
+                    "level": 80,
+                    "exp": 4500,
+                    "is_boss": false,
+                    "comment": "Deep Slime"
+                },
+                {
+                    "enemy_id": "0x010901",
+                    "level": 80,
+                    "exp": 4500,
+                    "is_boss": false,
+                    "comment": "Deep Slime"
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 461
+            },
+            "npc_id": "Fran",
+            "message_id": 23482
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 461
+            },
+            "npc_id": "Fran",
+            "announce_type": "Accept",
+            "items": [
+                {
+                    "id": 17911,
+                    "amount": 5
+                }
+            ],
+            "message_id": 23484
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 461
+            },
+            "announce_type": "Update",
+            "npc_id": "Fran",
+            "message_id": 23486
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018005.json
@@ -1,0 +1,313 @@
+﻿{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Serve from Above",
+    "quest_id": 22018005,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "RathniteFoothills",
+    "news_image": 330,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5139
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "AreaPoints",
+            "amount": 500
+        },
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Royal Crest Medal (Rathnite District)",
+                    "item_id": 18815,
+                    "num": 5
+                },
+                {
+                    "comment": "Rock Leather",
+                    "item_id": 17870,
+                    "num": 3
+                },
+                {
+                    "comment": "Goblin's Spellstaff",
+                    "item_id": 17867,
+                    "num": 3
+                }
+            ]
+        },
+        {
+            "type": "random",
+            "loot_pool": [
+                {
+                    "comment": "Random Item 1",
+                    "item_id": 18655,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Random Item 2",
+                    "item_id": 9261,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "comment": "GroupId: 0 - Sword Soldier Orcs, Grim Goblins",
+            "stage_id": {
+                "id": 461,
+                "group_id": 26
+            },
+            "starting_index": 6,
+            "enemies": [
+                {
+                    "enemy_id": "0x015821",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Sword Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x015821",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Sword Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x015821",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Sword Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x010120",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Grim Goblin"
+                },
+                {
+                    "enemy_id": "0x010120",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Grim Goblin"
+                },
+                {
+                    "enemy_id": "0x010120",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Grim Goblin"
+                }
+            ]
+        },
+        {
+            "comment": "GroupId: 1 - Blunt Soldier Orcs, Goblin Shamans",
+            "stage_id": {
+                "id": 461,
+                "group_id": 67
+            },
+            "starting_index": 6,
+            "enemies": [
+                {
+                    "enemy_id": "0x015822",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Blunt Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x015822",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Blunt Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x015822",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Blunt Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x015822",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Blunt Soldier Orc"
+                },
+                {
+                    "enemy_id": "0x010140",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Goblin Shaman"
+                },
+                {
+                    "enemy_id": "0x010140",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Goblin Shaman"
+                },
+                {
+                    "enemy_id": "0x010140",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Goblin Shaman"
+                }
+            ]
+        },
+        {
+            "comment": "GroupId: 2 - Ranged Soldier Dwarf Orcs, War Ready Ogre",
+            "stage_id": {
+                "id": 461,
+                "group_id": 4
+            },
+            "starting_index": 6,
+            "enemies": [
+                {
+                    "enemy_id": "0x015824",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Ranged Soldier Dwarf Orc"
+                },
+                {
+                    "enemy_id": "0x015824",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Ranged Soldier Dwarf Orc"
+                },
+                {
+                    "enemy_id": "0x015824",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 18000,
+                    "is_boss": false,
+                    "comment": "Ranged Soldier Dwarf Orc"
+                },
+                {
+                    "enemy_id": "0x015510",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 458,
+                    "level": 80,
+                    "exp": 210000,
+                    "is_boss": true,
+                    "comment": "War Ready Ogre (Light Armor)"
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NewNpcTalkAndOrder",
+            "stage_id": {
+                "id": 461
+            },
+            "npc_id": "Soule",
+            "message_id": 23506,
+            "flags": [
+                {
+                    "type": "QstLayout",
+                    "action": "Set",
+                    "value": 5425
+                }
+            ]
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 461
+            },
+            "announce_type": "Update",
+            "npc_id": "Soule",
+            "message_id": 23512
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_1.json
@@ -1,0 +1,249 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Waiting to Catch Monsters (Variant 1)",
+  "quest_id": 22018006,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5139
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 37800
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Rathnite District)",
+          "item_id": 18815,
+          "num": 5
+        },
+        {
+          "comment": "Manticore Raw Pelt",
+          "item_id": 17866,
+          "num": 1
+        },
+        {
+          "comment": "Battle Armor Fragment",
+          "item_id": 17876,
+          "num": 3
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Volcanic Mountain Ash",
+          "item_id": 21259,
+          "num": 1,
+          "chance": 0.6
+        },
+        {
+          "comment": "Cobalt Ingot",
+          "item_id": 17892,
+          "num": 1,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 23 - Strix, Brute Apes",
+      "stage_id": {
+        "id": 462,
+        "group_id": 23
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x015504",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Brute Ape"
+        },
+        {
+          "enemy_id": "0x015504",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Brute Ape"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 28 - Strix, Little Crag",
+      "stage_id": {
+        "id": 462,
+        "group_id": 28
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x015509",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Little Crag"
+        },
+        {
+          "enemy_id": "0x015509",
+          "level": 80,
+          "exp": 15000,
+          "is_boss": false,
+          "comment": "Little Crag"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 1 - Ogre, Cragger",
+      "stage_id": {
+        "id": 479,
+        "group_id": 1
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015500",
+          "level": 80,
+          "exp": 170000,
+          "is_boss": true,
+          "comment": "Ogre"
+        },
+        {
+          "enemy_id": "0x015508",
+          "level": 80,
+          "exp": 180000,
+          "is_boss": true,
+          "comment": "Cragger"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 462
+      },
+      "npc_id": "Paul",
+      "message_id": 23513
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [1]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [2]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [2]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 462
+      },
+      "announce_type": "Update",
+      "npc_id": "Paul",
+      "message_id": 23516
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_2.json
@@ -1,0 +1,271 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Waiting to Catch Monsters (Variant 2)",
+  "quest_id": 22018006,
+  "base_level": 83,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 555
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 37800
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Rathnite District)",
+          "item_id": 18815,
+          "num": 5
+        },
+        {
+          "comment": "Rock-Cutter",
+          "item_id": 17871,
+          "num": 1
+        },
+        {
+          "comment": "Rock Leather",
+          "item_id": 17870,
+          "num": 3
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Volcanic Mountain Ash",
+          "item_id": 21259,
+          "num": 1,
+          "chance": 0.6
+        },
+        {
+          "comment": "Cobalt Ingot",
+          "item_id": 17892,
+          "num": 1,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 23 - Strix, Brute Apes",
+      "stage_id": {
+        "id": 462,
+        "group_id": 23
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Brute Ape"
+        },
+        {
+          "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Brute Ape"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 28 - Strix, Little Crag",
+      "stage_id": {
+        "id": 462,
+        "group_id": 28
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x015509",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Little Crag"
+        },
+        {
+          "enemy_id": "0x015509",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Little Crag"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 1 - Ogre, Cragger",
+      "stage_id": {
+        "id": 479,
+        "group_id": 1
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 190000,
+          "is_boss": true,
+          "comment": "Ogre"
+        },
+        {
+          "enemy_id": "0x015508",
+          "named_enemy_params_id": 53,
+          "level": 83,
+          "exp": 200000,
+          "is_boss": true,
+          "comment": "Cragger"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 462
+      },
+      "npc_id": "Paul",
+      "message_id": 23513
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [1]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [2]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [2]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 462
+      },
+      "announce_type": "Update",
+      "npc_id": "Paul",
+      "message_id": 23516
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018008.json
@@ -1,0 +1,276 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Rioting Beasts",
+  "quest_id": 22018008,
+  "base_level": 83,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 555
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 37800
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Rathnite District)",
+          "item_id": 18815,
+          "num": 5
+        },
+        {
+          "comment": "Rock Leather",
+          "item_id": 17870,
+          "num": 3
+        },
+        {
+          "comment": "Giant Apophyllite",
+          "item_id": 17872,
+          "num": 3
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Volcanic Mountain Ash",
+          "item_id": 21259,
+          "num": 3,
+          "chance": 0.6
+        },
+        {
+          "comment": "Giant Apophyllite",
+          "item_id": 17872,
+          "num": 1,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 30 - Saurians, Giant Saurians",
+      "stage_id": {
+        "id": 462,
+        "group_id": 30
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010401",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Giant Saurian"
+        },
+        {
+          "enemy_id": "0x010401",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Giant Saurian"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 27 - Saurians, Giant Saurians",
+      "stage_id": {
+        "id": 462,
+        "group_id": 27
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010401",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Giant Saurian"
+        },
+        {
+          "enemy_id": "0x010401",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Giant Saurian"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 10 - Saurians, Wight, Ogre",
+      "stage_id": {
+        "id": 496,
+        "group_id": 10
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x010400",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Saurian"
+        },
+        {
+          "enemy_id": "0x015600",
+          "level": 83,
+          "exp": 44000,
+          "is_boss": false,
+          "comment": "Wight"
+        },
+        {
+          "enemy_id": "0x015500",
+          "level": 83,
+          "exp": 170000,
+          "is_boss": true,
+          "comment": "Ogre"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 462
+      },
+      "npc_id": "Asena",
+      "message_id": 23519
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [1]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [2]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [2]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 462
+      },
+      "announce_type": "Update",
+      "npc_id": "Asena",
+      "message_id": 23518
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018009.json
@@ -1,0 +1,158 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Love Thy Neighbor",
+    "quest_id": 22018009,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "RathniteFoothills",
+    "news_image": 330,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5139
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "AreaPoints",
+            "amount": 500
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Magickal Potion",
+                    "item_id": 7832,
+                    "num": 1
+                },
+                {
+                    "comment": "Royal Crest Medal (Rathnite District)",
+                    "item_id": 18815,
+                    "num": 5
+                },
+                {
+                    "comment": "Cursed Letter",
+                    "item_id": 17878,
+                    "num": 1
+                }
+            ]
+        },
+        {
+            "type": "random",
+            "loot_pool": [
+                {
+                    "comment": "Random Item 1",
+                    "item_id": 17870,
+                    "num": 2,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Random Item 2",
+                    "item_id": 9324,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "comment": "GroupId: 0",
+            "stage_id": {
+                "id": 493,
+                "group_id": 1
+            },
+            "placement_type": "Manual",
+            "enemies": [
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "is_boss": true,
+                    "index": 4
+                },
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "is_boss": true,
+                    "index": 5
+                },
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 80,
+                    "exp_scheme": "Automatic",
+                    "is_boss": true,
+                    "index": 11
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 461
+            },
+            "npc_id": "Boris",
+            "message_id": 23543
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 493,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "announce_type": "Accept",
+            "npc_id": "Eileen",
+            "message_id": 23861,
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 5468, "comment": "Spawns Eileen"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [0]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 493,
+                "group_id": 1,
+                "layer_no": 0
+            },
+            "announce_type": "Update",
+            "npc_id": "Elton",
+            "message_id": 23545,
+            "flags": [
+                {"type": "QstLayout", "action": "Clear", "value": 5468, "comment": "Spawns Elieen"},
+                {"type": "QstLayout", "action": "Set", "value": 5471, "comment": "Spawns post fight Elieen"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 461
+            },
+            "announce_type": "Update",
+            "npc_id": "Boris",
+            "message_id": 23541
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018010.json
@@ -1,0 +1,238 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Ambush of the Armed Demon Army",
+  "quest_id": 22018010,
+  "base_level": 83,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 555
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 50400
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Demon Beast's Liver",
+          "item_id": 18655,
+          "num": 3
+        },
+        {
+          "comment": "Royal Crest Medal (Rathnite District)",
+          "item_id": 18815,
+          "num": 5
+        },
+        {
+          "comment": "Mark of Brute Courage",
+          "item_id": 17859,
+          "num": 3
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Giant Animal Skull",
+          "item_id": 21232,
+          "num": 1,
+          "chance": 0.9
+        },
+        {
+          "comment": "Mark of Brute Courage",
+          "item_id": 17892,
+          "num": 1,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 13 - Griffin, War-Ready Grimwargs",
+      "stage_id": {
+        "id": 462,
+        "group_id": 13
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015300",
+          "level": 83,
+          "exp": 170000,
+          "is_boss": true,
+          "comment": "Griffin"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Grimwarg"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Grimwarg"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Grimwarg"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 37 - Dwarf Orcs",
+      "stage_id": {
+        "id": 462,
+        "group_id": 37
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015823",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Heavy Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015824",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Ranged Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015821",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Sword Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015821",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Sword Soldier Dwarf Orc"
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 18 - War-Ready Goremanticore, Dwarf Orcs",
+      "stage_id": {
+        "id": 462,
+        "group_id": 18
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015220",
+          "level": 83,
+          "exp": 220000,
+          "is_boss": true,
+          "comment": "War-Ready Goremanticore"
+        },
+        {
+          "enemy_id": "0x015821",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Sword Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015821",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Sword Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015821",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Sword Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015821",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Sword Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015824",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Ranged Soldier Dwarf Orc"
+        },
+        {
+          "enemy_id": "0x015824",
+          "level": 83,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Ranged Soldier Dwarf Orc"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [1]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [2]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [2]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018011.json
@@ -1,0 +1,136 @@
+﻿{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Expose The One in the Shadows",
+    "quest_id": 22018011,
+    "base_level": 83,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "RathniteFoothills",
+    "news_image": 330,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5500
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": 17878,
+                    "num": 1
+                },
+                {
+                    "item_id": 18815,
+                    "num": 5
+                },
+                {
+                    "item_id": 17880,
+                    "num": 3
+                }
+            ]
+        },
+        {
+            "type": "random",
+            "loot_pool": [
+                {
+                    "item_id": 17892,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "item_id": 18508,
+                    "num": 2,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "comment": "GroupId: 0 - Aqua Jellies, Medusa, and Frost Machina",
+            "stage_id": {
+                "id": 496,
+                "group_id": 1
+            },
+            "enemies": [
+                {
+                    "enemy_id": "0x015851",
+                    "level": 83,
+                    "exp": 100000,
+                    "is_boss": true
+                },
+                {
+                    "enemy_id": "0x015610",
+                    "level": 83,
+                    "exp": 90000,
+                    "is_boss": true
+                },
+                {
+                    "enemy_id": "0x010904",
+                    "level": 83,
+                    "exp": 4500,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010904",
+                    "level": 83,
+                    "exp": 4500,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010904",
+                    "level": 83,
+                    "exp": 4500,
+                    "is_boss": false
+                },
+                {
+                    "enemy_id": "0x010904",
+                    "level": 83,
+                    "exp": 4500,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 480
+            },
+            "npc_id": "Gerald",
+            "message_id": 23611
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 480
+            },
+            "announce_type": "Update",
+            "npc_id": "Gerald",
+            "message_id": 23589
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018013.json
@@ -1,0 +1,182 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Merchant's Requital",
+  "quest_id": 22018013,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 37800
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Rathnite District)",
+          "item_id": 18815,
+          "num": 5
+        },
+        {
+          "comment": "Blood-Colored Spiral Shell",
+          "item_id": 17910,
+          "num": 1
+        },
+        {
+          "comment": "Demonic Beast Snakeskin",
+          "item_id": 17857,
+          "num": 1
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Cloud Trinket Soldier",
+          "item_id": 21280,
+          "num": 1,
+          "chance": 0.6
+        },
+        {
+          "comment": "Blood-Colored Spiral Shell",
+          "item_id": 17910,
+          "num": 2,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 10 - Gorechimera, Manticore, Aqua Slimes",
+      "stage_id": {
+        "id": 497,
+        "group_id": 22
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015210",
+          "level": 85,
+          "exp": 220000,
+          "is_boss": true,
+          "comment": "Gorechimera"
+        },
+        {
+          "enemy_id": "0x015200",
+          "level": 85,
+          "exp": 220000,
+          "is_boss": true,
+          "comment": "Manticore"
+        },
+        {
+          "enemy_id": "0x010500",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Aqua Slime"
+        },
+        {
+          "enemy_id": "0x010500",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Aqua Slime"
+        },
+        {
+          "enemy_id": "0x010500",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Aqua Slime"
+        },
+        {
+          "enemy_id": "0x010500",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Aqua Slime"
+        },
+        {
+          "enemy_id": "0x010500",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Aqua Slime"
+        },
+        {
+          "enemy_id": "0x010500",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Aqua Slime"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 513
+      },
+      "npc_id": "Elsen",
+      "message_id": 23571
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 513
+      },
+      "npc_id": "Elsen",
+      "announce_type": "Accept",
+      "items": [
+        {
+          "id": 17909,
+          "amount": 9,
+          "comment": "Flesh-Eating Snail"
+        }
+      ],
+      "message_id": 23573
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 513
+      },
+      "announce_type": "Update",
+      "npc_id": "Elsen",
+      "message_id": 23574
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018014.json
@@ -1,0 +1,166 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Dangerous Daydream",
+  "quest_id": 22018014,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 37800
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Stone-Curser's Tears",
+          "item_id": 17856,
+          "num": 1
+        },
+        {
+          "comment": "Blood-Colored Spiral Shell",
+          "item_id": 17910,
+          "num": 3
+        },
+        {
+          "comment": "Flesh-Eating Snail",
+          "item_id": 17909,
+          "num": 6
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Beast Luring Meat",
+          "item_id": 18661,
+          "num": 2,
+          "chance": 0.6
+        },
+        {
+          "comment": "Fluttering Rags",
+          "item_id": 17929,
+          "num": 2,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 10 - War-Ready Goremanticore, Strix, War-Ready Wargs",
+      "stage_id": {
+        "id": 479,
+        "group_id": 10
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015220",
+          "level": 85,
+          "exp": 220000,
+          "is_boss": true,
+          "comment": "War-Ready Goremanticore (Light Armor)"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010610",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Strix"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Warg (Light Armor)"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Warg (Light Armor)"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Warg (Light Armor)"
+        },
+        {
+          "enemy_id": "0x010230",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "War-Ready Warg (Light Armor)"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 467
+      },
+      "npc_id": "Michaela",
+      "message_id": 23590
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 467
+      },
+      "announce_type": "Update",
+      "npc_id": "Michaela",
+      "message_id": 23593
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018015.json
@@ -1,0 +1,136 @@
+﻿{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Clerk's Misery",
+  "quest_id": 22018015,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "RathniteFoothills",
+  "news_image": 330,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 37800
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Rathnite District)",
+          "item_id": 18815,
+          "num": 5
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 10
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 10
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Volcanic Mountain Ash",
+          "item_id": 21259,
+          "num": 1,
+          "chance": 0.6
+        },
+        {
+          "comment": "Cobalt Ingot",
+          "item_id": 17892,
+          "num": 1,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 16 - Dread Apes",
+      "stage_id": {
+        "id": 497,
+        "group_id": 16
+      },
+      "enemies": [
+        {
+          "enemy_id": "0x015504",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Dread Ape"
+        },
+        {
+          "enemy_id": "0x015504",
+          "level": 85,
+          "exp": 18000,
+          "is_boss": false,
+          "comment": "Dread Ape"
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 480
+      },
+      "npc_id": "Selma",
+      "message_id": 23547
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 497
+      },
+      "announce_type": "Accept",
+      "npc_id": "Anna",
+      "message_id": 23551,
+      "groups": [0],
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 5474
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 480
+      },
+      "announce_type": "Update",
+      "npc_id": "Selma",
+      "message_id": 23862
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
@@ -561,6 +561,11 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Opens the gate to Fort Thines (443)
             /// </summary>
             public static QuestFlagInfo FortThines1 { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(5407, QuestId.Q70030001, StageInfo);
+
+            /// <summary>
+            /// Opens the entrance to the cave of hells descent.
+            /// </summary>
+            public static QuestFlagInfo CaveOfHellsDescent { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(3414, QuestId.Q70030001);
             
         }
 


### PR DESCRIPTION
- Updated the second MSQ in 3.0 to unlock "Cave of Hell's Descent".
  - q00030020.csx
- Added new world quuests for Rathnite Foothills.
  - q22018002.json
  - q22018003.json
  - q22018005.json
  - q22018006_1.json
  - q22018006_2.json
  - q22018008.json
  - q22018009.json
  - q22018010.json
  - q22018011.json
  - q22018013.json
  - q22018014.json
  - q22018015.json

Co-authored-by: LostMyLeg

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
