### PR TITLE
Pawn Skip JT: Change Check to Unlocked

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableAbilityListHandler.cs
@@ -33,7 +33,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var allDefaultAbilities = SkillData.AllAbilities.Where(x => x.Job == request.Job && !SkillData.IsUnlockableAbility(request.Job, x.AbilityNo, 1));
                 var pawnUnlocks = SkillData.AllAbilities.Where(x => x.Job == request.Job
                     && SkillData.IsUnlockableAbility(request.Job, x.AbilityNo, 1)
-                    && client.Character.LearnedAbilities.Any(y => x.AbilityNo == y.AbilityId)
+                    && IsAbilityUnlocked(client.Character, request.Job, x.AbilityNo)
                 );
                 response.AbilityParamList = allDefaultAbilities.Concat(pawnUnlocks).ToList();
             }

--- a/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/SkillGetAcquirableSkillListHandler.cs
@@ -30,13 +30,18 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 var allDefaultSkills = SkillData.AllSkills.Where(x => x.Job == request.Job && !SkillData.IsUnlockableSkill(request.Job, x.SkillNo, 1));
                 var pawnUnlocks = SkillData.AllSkills.Where(x => x.Job == request.Job
                     && SkillData.IsUnlockableSkill(request.Job, x.SkillNo, 1)
-                    && client.Character.LearnedCustomSkills.Any(y => x.SkillNo == y.SkillId && x.Job == y.Job)
+                    && IsSkillUnlocked(client.Character, request.Job, x.SkillNo)
                     );
                 return new S2CSkillGetAcquirableSkillListRes()
                 {
                     SkillParamList = allDefaultSkills.Concat(pawnUnlocks).ToList()
                 };
             }
+        }
+
+        private bool IsSkillUnlocked(Character character, JobId jobId, uint skillNo)
+        {
+            return character.UnlockedCustomSkills[jobId].Contains(skillNo);
         }
     }
 }


### PR DESCRIPTION
Switched the check on skills/augments from Learned to Unlocked to fix an exploit with existing players that learned these abilities before they were locked behind the Orb tree.

> [!IMPORTANT]
> As a result of these changes, pawns will lose access to EX skill variants they know but the player has not yet unlocked. They will retain currently equipped EX variants, but changing their skills around will result in reverting to the normal versions.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
