### PR TITLE
fix: Fix issue with orb tree currency check

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/JobOrbUnlockManager.cs
@@ -161,7 +161,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             var upgrade = jobOrbUpgrades[jobId].Where(x => x.ElementId == elementId).FirstOrDefault() ??
                 throw new ResponseErrorException(ErrorCode.ERROR_CODE_CONTENTS_RELEASE_NOT_JOB_ORB_TREE, $"An element with the ID {elementId} doesn't exist for {jobId}");
 
-            var amount = Server.WalletManager.GetWalletAmount(client.Character, WalletType.BloodOrbs);
+            var amount = Server.WalletManager.GetWalletAmount(client.Character, upgrade.WalletType);
             if (amount < upgrade.Cost)
             {
                 throw new ResponseErrorException(ErrorCode.ERROR_CODE_TREE_RELEASE_COST_LACK);


### PR DESCRIPTION
Fixed an issue where the handler for releasing nodes from the orb tree only checked for blood orbs instead of the currency type assigned to the upgrade.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
