### PR TITLE
Fix: Update Empty String in Migration Script

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_pawn_rental.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_pawn_rental.sql
@@ -18,7 +18,7 @@ SELECT
 	title_index,
 	motion_id,
 	motion_frame_no,
-	"" as comment
+	'' as comment
 FROM "ddon_character_arisen_profile"
 NATURAL JOIN "ddon_character";
 
@@ -30,7 +30,7 @@ SELECT
 	0 as title_index,
 	0 as motion_id,
 	0 as motion_frame_no,
-	"" as comment
+	'' as comment
 FROM "ddon_pawn";
 
 CREATE TABLE IF NOT EXISTS "ddon_rental_pawn"


### PR DESCRIPTION
Postgres does not like using double quotes for empty strings, so the Pawn Rental migration (DB49) was throwing an error because of it.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
