### PR TITLE
Fixes: Followup on rental pawns

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbRentalPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbRentalPawn.cs
@@ -74,11 +74,11 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                 SUM("ddon_rental_pawn_feedback"."kill_count") as "kill_count",
                 SUM("ddon_rental_pawn_feedback"."craft_count") as "craft_count",
                 AVG("ddon_rental_pawn_feedback"."appearance_score") as "average_appearance",
-            	STRING_AGG("ddon_rental_pawn_feedback"."appearance_comment", ',') as "appearance_comment",
+            	STRING_AGG(CAST("ddon_rental_pawn_feedback"."appearance_comment" AS TEXT), '') as "appearance_comment",
                 AVG("ddon_rental_pawn_feedback"."combat_score") as "average_combat",
-            	STRING_AGG("ddon_rental_pawn_feedback"."combat_comment", ',') as "combat_comment",
+            	STRING_AGG(CAST("ddon_rental_pawn_feedback"."combat_comment" AS TEXT), '') as "combat_comment",
                 AVG("ddon_rental_pawn_feedback"."craft_score") as "average_craft",
-            	STRING_AGG("ddon_rental_pawn_feedback"."craft_comment", ',') as "craft_comment"
+            	STRING_AGG(CAST("ddon_rental_pawn_feedback"."craft_comment" AS TEXT), '') as "craft_comment"
                 FROM "ddon_rental_pawn_feedback"
             WHERE "ddon_rental_pawn_feedback"."pawn_id" = @pawn_id
             GROUP BY "ddon_rental_pawn_feedback"."pawn_id";

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -907,17 +907,17 @@ namespace Arrowgene.Ddon.GameServer.Characters
         }
 
 
-        public CDataItemUpdateResult CreateItemUpdateResult(CharacterCommon character, Item item, StorageType storageType, ushort slotNo, uint itemNum, uint updateItemNum)
+        public CDataItemUpdateResult CreateItemUpdateResult(CharacterCommon common, Item item, StorageType storageType, ushort slotNo, uint itemNum, uint updateItemNum)
         {
             uint pawnId = 0;
             uint characterId = 0;
-            if (character is Character)
+            if (common is Character character)
             {
-                characterId = ((Character)character).CharacterId;
+                characterId = character.CharacterId;
             }
-            else if (character is Pawn)
+            else if (common is Pawn pawn)
             {
-                pawnId = ((Pawn)character).PawnId;
+                pawnId = pawn.PawnId;
             }
 
             CDataItemUpdateResult updateResult = new CDataItemUpdateResult();

--- a/Arrowgene.Ddon.GameServer/Characters/RentalPawnManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RentalPawnManager.cs
@@ -73,7 +73,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                                 if (Server.GameSettings.GameServerSettings.RentalPawnAdventureTimerAutoReset)
                                 {
                                     Server.TimerManager.CancelTimer(pawnMember.AdventureTimer);
-                                    SetupTimer(client, pawnMember);
+                                    SetupTimer(client, pawnMember, false);
                                     Logger.Info($"Automatically resetting adventure timer for {client.Character.CDataCharacterName}'s rental pawn {rentalPawn.CDataCharacterName}");
                                 }
                                 else
@@ -107,7 +107,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     else if (pawnMember.AdventureTimer == 0)
                     {
                         // Reapply timer to any rental pawns that have finished theirs.
-                        SetupTimer(client, pawnMember);
+                        SetupTimer(client, pawnMember, false);
                     }
                 }
             }
@@ -115,7 +115,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return queue;
         }
 
-        public void SetupTimer(GameClient client, PawnPartyMember pawnMember)
+        public void SetupTimer(GameClient client, PawnPartyMember pawnMember, bool silent = true)
         {
             uint adventureTimeLength = Server.GameSettings.GameServerSettings.RentalPawnAdventureTimer;
             lock (pawnMember.TimerLock)
@@ -125,6 +125,15 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     Logger.Info($"Triggering adventure timer for {client.Character.CDataCharacterName}'s rental pawn {pawnMember.Pawn.CDataCharacterName}");
                     HandleAdventureCountDecrement(client, (RentalPawn)pawnMember.Pawn).Send();
                     pawnMember.AdventureTimer = 0;
+                });
+            }
+
+            if (!silent)
+            {
+                client.Send(new S2CLobbyChatMsgNotice()
+                {
+                    Type = LobbyChatMsgType.ManagementGuideC,
+                    Message = $"{pawnMember.Pawn.CDataCharacterName} is ready for a new adventure."
                 });
             }
         }
@@ -191,6 +200,18 @@ namespace Arrowgene.Ddon.GameServer.Characters
             {
                 rentalPawn.KillCount++;
                 Server.Database.UpdateRentalPawn(rentalPawn.CharacterId, rentalPawn, connectionIn);
+            }
+        }
+
+        public (bool IsRunning, uint MinutesLeft) GetAdventureTimeRemaining(PawnPartyMember pawn)
+        {
+            if (pawn.AdventureTimer == 0)
+            {
+                return (false, 0);
+            }
+            else
+            {
+                return (true, (uint)(Server.TimerManager.GetTimeLeftInSeconds(pawn.AdventureTimer) / 60));
             }
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemAttachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemAttachElementHandler.cs
@@ -56,15 +56,15 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         .ToList();
                     if (crests.Count == 0)
                     {
-                        throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INTERNAL_ERROR, "Failed to locate crest ids for emblem inheritance");
+                        throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INTERNAL_ERROR, "Failed to locate crest ids for emblem inheritance.");
                     }
 
                     // Select a random crest to inherit if there are multiple
                     var crest = crests[Random.Shared.Next(0, crests.Count)];
                     foreach (var uid in request.EmblemUIDs)
                     {
-                        var (storageType, storageInfo) = client.Character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, uid);
-                        var (slotNo, item, _) = storageInfo;
+                        var (storageType, (slotNo, item, _)) = client.Character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, uid)
+                            ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_NOT_FOUND, "Failed to locate crest for emblem inheritance.");
 
                         ushort relativeSlotNo = slotNo;
                         CharacterCommon characterCommon = client.Character;
@@ -72,7 +72,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         {
                             uint pawnId = Storages.DeterminePawnId(client.Character, storageType, relativeSlotNo);
                             characterCommon = client.Character.Pawns.Where(x => x.PawnId == pawnId).SingleOrDefault()
-                                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PAWN_NOT_FOUNDED, "Unable to locate the pawn that has this emblem item equipped");
+                                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PAWN_NOT_FOUNDED, "Unable to locate the pawn that has this emblem item equipped.");
                             relativeSlotNo = EquipManager.DeterminePawnEquipSlot(relativeSlotNo);
                         }
 
@@ -92,7 +92,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                             match.Add = crest.Add;
                         }
 
-                        Server.Database.InsertCrest(characterCommon.CommonId, uid, request.InheritanceSlot, crest.CrestId, crest.Add, connection);
+                        Server.Database.InsertCrest(client.Character.CommonId, uid, request.InheritanceSlot, crest.CrestId, crest.Add, connection);
                         itemUpdateNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 1, 1));
                     }
                 }

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemDetachElementHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemDetachElementHandler.cs
@@ -3,6 +3,7 @@ using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System;
 using System.Linq;
@@ -52,8 +53,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     }
 
                     updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 0, 0));
-                    item.EquipElementParamList.Where(x => x.SlotNo == request.InheritanceSlot).FirstOrDefault().CrestId = 0;
-                    Server.Database.RemoveCrest(characterCommon.CommonId, uid, request.InheritanceSlot, connection);
+                    var removedCrest = item.EquipElementParamList.Where(x => x.SlotNo == request.InheritanceSlot).FirstOrDefault()
+                        ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_CRAFT_ELEMENT_SLOT_NOT_OCCUPIED, "Unable to locate crest to be removed from emblem.");
+                    if (removedCrest is not null)
+                    {
+                        removedCrest.CrestId = 0;
+                    }
+                    Server.Database.RemoveCrest(client.Character.CommonId, uid, request.InheritanceSlot, connection);
                     updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(characterCommon, item, storageType, relativeSlotNo, 1, 1));
 
                     // note: This might be set multiple times but should all be the same

--- a/Arrowgene.Ddon.GameServer/Handler/PawnJoinPartyRentedPawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnJoinPartyRentedPawnHandler.cs
@@ -24,7 +24,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             pawn.CharacterId = client.Character.CharacterId;
             pawn.IsRented = true;
             pawn.PawnType = PawnType.Support;
-            Server.RentalPawnManager.SetupTimer(client, partyMember);
+            Server.RentalPawnManager.SetupTimer(client, partyMember, true);
 
             client.Party.SendToAll(new S2CPawnJoinPartyPawnNtc() { PartyMember = partyMember.CDataPartyMember });
             client.Party.SendToAll(partyMember.GetS2CContextGetPartyRentedPawn_ContextNtc());

--- a/Arrowgene.Ddon.GameServer/Handler/PawnRentRegisteredPawnHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PawnRentRegisteredPawnHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -67,7 +68,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 response.TotalRim = walletUpdate.Value;
 
-                rentalRecord = RentalPawnRecord.FromPawn(pawn);
+                rentalRecord = RentalPawnRecord.FromPawn(pawn, ownerCharacter);
                 Server.Database.InsertRentalPawn(client.Character.CharacterId, rentalRecord, AdventureCount, CraftCount, connectionIn);
 
                 packetQueue.AddRange(Server.AchievementManager.HandleHirePawn(client, connectionIn));

--- a/Arrowgene.Ddon.Scripts/scripts/chat_commands/pawntime.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/chat_commands/pawntime.csx
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Text;
+
+public class ChatCommand : IChatCommand
+{
+    public override AccountStateType AccountState => AccountStateType.User;
+    public override string CommandName => "pawntime";
+    public override string HelpText => "usage: `/pawntime` - Check rental pawn adventure timers.";
+
+    public override void Execute(DdonGameServer server, string[] command, GameClient client, ChatMessage message, List<ChatResponse> responses)
+    {
+        responses.Add(ChatResponse.ServerChat(client, $"Pawn Adventure Timers: "));
+        foreach (var member in client.Party.Members)
+        {
+            if (member is PawnPartyMember pawnMember
+                && pawnMember.Pawn is RentalPawn rentalPawn
+                && rentalPawn.CharacterId == client.Character.CharacterId)
+            {
+                var (isRunning, timeLeft) = server.RentalPawnManager.GetAdventureTimeRemaining(pawnMember);
+                if (isRunning)
+                {
+                    responses.Add(ChatResponse.ServerChat(client, $"  {rentalPawn.Name} : {timeLeft} minutes."));
+                }
+                else
+                {
+                    responses.Add(ChatResponse.ServerChat(client, $"  {rentalPawn.Name} : -Elapsed-"));
+                }
+            }
+        }
+    }
+}
+
+return new ChatCommand();

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1625,7 +1625,7 @@ namespace Arrowgene.Ddon.Server.Settings
                 return TryGetSetting("RentalPawnAdventureTimerAutoReset", _RentalPawnAdventureTimerAutoReset);
             }
         }
-        private const bool _RentalPawnAdventureTimerAutoReset = false;
+        private const bool _RentalPawnAdventureTimerAutoReset = true;
 
         /// <summary>
         /// If true, rental pawns will consume an adventure charge when starting an EXM, but won't have their usual adventure timer running.

--- a/Arrowgene.Ddon.Shared/Model/RentalPawnRecord.cs
+++ b/Arrowgene.Ddon.Shared/Model/RentalPawnRecord.cs
@@ -38,7 +38,7 @@ namespace Arrowgene.Ddon.Shared.Model
             // This has to exist for JSON reasons.
         }
 
-        public static RentalPawnRecord FromPawn(Pawn pawn)
+        public static RentalPawnRecord FromPawn(Pawn pawn, Character ownerCharacter)
         {
             var record = new RentalPawnRecord()
             {
@@ -60,7 +60,9 @@ namespace Arrowgene.Ddon.Shared.Model
                 LearnedNormalSkills = [.. pawn.LearnedNormalSkills.Where(x => x.Job == pawn.Job)],
                 EquippedCustomSkills = pawn.EquippedCustomSkillsDictionary.GetValueOrDefault(pawn.Job),
                 EquippedAbilities = pawn.EquippedAbilitiesDictionary.GetValueOrDefault(pawn.Job),
-                ExtendedParams = pawn.ExtendedParams + pawn.ExtendedJobParams.GetValueOrDefault(pawn.Job, new()),
+                ExtendedParams = pawn.ExtendedParams 
+                    + ownerCharacter.ExtendedJobParams.GetValueOrDefault(JobId.None, new()) 
+                    + ownerCharacter.ExtendedJobParams.GetValueOrDefault(pawn.Job, new()),
                 HireDate = DateTime.Now,
                 PawnProfile = pawn.CharacterProfile
             };
@@ -73,60 +75,61 @@ namespace Arrowgene.Ddon.Shared.Model
             RentalPawn pawn = new()
             {
                 // RentalPawn Fields
-                OwningCharacterId = this.CharacterId,
+                OwningCharacterId = CharacterId,
                 AdventureCount = adventureCount,
                 CraftCount = craftCount,
-                KillCount = 0,
+                KillCount = killCount,
                 HireDate = HireDate,
 
                 // Pawn Fields
-                PawnId = this.PawnId,
+                PawnId = PawnId,
                 CharacterId = hiringCharacterId,
-                Name = this.Name,
+                Name = Name,
                 HmType = 1,
                 PawnType = PawnType.Support,
-                PawnReactionList = this.PawnReactionList,
-                CraftData = this.CraftData,
-                TrainingStatus = new() { { this.Job, this.TrainingStatus } },
-                SpSkills = new() { { this.Job, this.SpSkills } },
-                IsOfficialPawn = this.IsOfficialPawn,
+                PawnReactionList = PawnReactionList,
+                CraftData = CraftData,
+                TrainingStatus = new() { { Job, TrainingStatus } },
+                SpSkills = new() { { Job, SpSkills } },
+                IsOfficialPawn = IsOfficialPawn,
                 IsRented = true,
                 PawnState = PawnState.None,
 
                 // CharacterCommon Fields
-                CommonId = this.CommonId,
+                CommonId = CommonId,
                 Server = new(), // ???
-                EditInfo = this.EditInfo,
-                StatusInfo = new(),
-                Job = this.Job,
-                HideEquipHead = this.HideEquipHead,
-                HideEquipLantern = this.HideEquipLantern,
-                CharacterJobDataList = new() { this.CharacterJobData },
-                Equipment = this.Equipment,
-                JewelrySlotNum = (byte)(1 + this.ExtendedParams.JewelrySlot),
-                LearnedNormalSkills = this.LearnedNormalSkills,
-                LearnedCustomSkills = [.. this.EquippedCustomSkills.Where(x => x is not null)],
-                EquippedCustomSkillsDictionary = new() { { this.Job, this.EquippedCustomSkills } },
-                LearnedAbilities = [.. this.EquippedAbilities.Where(x => x is not null)],
-                EquippedAbilitiesDictionary = new() { { this.Job, this.EquippedAbilities } },
-                ExtendedParams = this.ExtendedParams,
-                ExtendedJobParams = new() { { this.Job, new() } },
-                OrbRelease = new(),
-                CharacterProfile = this.PawnProfile
+                EditInfo = EditInfo,
+                StatusInfo = new()
+                {
+                    GainAttack = ExtendedParams.Attack,
+                    GainDefense = ExtendedParams.Defence,
+                    GainMagicAttack = ExtendedParams.MagicAttack,
+                    GainMagicDefense = ExtendedParams.MagicDefence,
+                    GainStamina = ExtendedParams.StaminaMax,
+                    GainHP = ExtendedParams.HpMax,
+
+                    MaxHP = 760U,
+                    MaxStamina = 450U,
+                    HP = uint.MaxValue,
+                    WhiteHP = uint.MaxValue,
+                    Stamina = uint.MaxValue,
+                },
+                Job = Job,
+                HideEquipHead = HideEquipHead,
+                HideEquipLantern = HideEquipLantern,
+                CharacterJobDataList = [CharacterJobData],
+                Equipment = Equipment,
+                JewelrySlotNum = (byte)(1 + ExtendedParams.JewelrySlot),
+                LearnedNormalSkills = LearnedNormalSkills,
+                LearnedCustomSkills = [.. EquippedCustomSkills.Where(x => x is not null)],
+                EquippedCustomSkillsDictionary = new() { { Job, EquippedCustomSkills } },
+                LearnedAbilities = [.. EquippedAbilities.Where(x => x is not null)],
+                EquippedAbilitiesDictionary = new() { { Job, EquippedAbilities } },
+                ExtendedParams = ExtendedParams,
+                ExtendedJobParams = new() { { Job, new() } },
+                OrbRelease = [],
+                CharacterProfile = PawnProfile
             };
-
-            pawn.StatusInfo.GainAttack = this.ExtendedParams.Attack;
-            pawn.StatusInfo.GainDefense = this.ExtendedParams.Defence;
-            pawn.StatusInfo.GainMagicAttack = this.ExtendedParams.MagicAttack;
-            pawn.StatusInfo.GainMagicDefense = this.ExtendedParams.MagicDefence;
-            pawn.StatusInfo.GainStamina = this.ExtendedParams.StaminaMax;
-            pawn.StatusInfo.GainHP = this.ExtendedParams.HpMax;
-
-            pawn.StatusInfo.MaxHP = 760U;
-            pawn.StatusInfo.MaxStamina = 450U;
-            pawn.StatusInfo.HP = uint.MaxValue;
-            pawn.StatusInfo.WhiteHP = uint.MaxValue;
-            pawn.StatusInfo.Stamina = uint.MaxValue;
 
             return pawn;
         }


### PR DESCRIPTION
Fix rental history SQL for Postgres compatibility. 
Fix missing S2/S3 orb stat issue with rental pawns (requires rehiring). 
Additional chat messages for pawn adventure timer resetting. 
/pawntime command.
Fix issue where attempting to add a crest to an emblem current equipped to a pawn would corrupt its state.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
