### PR TITLE
dependencies: Update Arrowgene.Networking

### DIFF
--- a/Arrowgene.Ddon.Server/Arrowgene.Ddon.Server.csproj
+++ b/Arrowgene.Ddon.Server/Arrowgene.Ddon.Server.csproj
@@ -27,7 +27,7 @@
     <ItemGroup>
         <PackageReference Include="Arrowgene.Buffers" Version="1.0.2" />
         <PackageReference Include="Arrowgene.Logging" Version="1.2.1" />
-        <PackageReference Include="Arrowgene.Networking" Version="1.0.6" />
+        <PackageReference Include="Arrowgene.Networking" Version="1.1.7" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Arrowgene.Ddon.Database\Arrowgene.Ddon.Database.csproj" />


### PR DESCRIPTION
Updated the version of the Arrowgene.Networking dependency to 1.1.7

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
