### PR TITLE
log camellia key if server socket library is in debug mode

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/ClientChallengeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ClientChallengeHandler.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Logging;
 
@@ -22,6 +23,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 Logger.Error(client, "Failed CertChallenge");
                 throw new ResponseErrorException(Shared.Model.ErrorCode.ERROR_CODE_SYSTEM_INTERNAL);
+            }
+
+            if (Server.ServerSetting.ServerSetting.ServerSocketSettings.DebugMode)
+            {
+                Logger.Info(client, $"CamelliaKey: {Util.ToHexString(challenge.CamelliaKey)}");
             }
 
             return new S2CCertClientChallengeRes()


### PR DESCRIPTION
want to log cammelia key to decrypt traffic if needed for network troubleshooting

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
