### PR TITLE
Hotfix: Channel "Meltdown" Mitigation

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/HubManager.cs
@@ -113,12 +113,6 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             gatherClients.Add(otherClient);
                         }
                         client.Character.LastSeenLobby[otherId] = targetStageId;
-
-                        // Make sure you have their last data message to avoid invisible people?
-                        if (otherClient.LastLobbyDataMsg is not null)
-                        {
-                            client.Send(otherClient.LastLobbyDataMsg);
-                        }
                     }
                     HubMembers[targetStageId].Add(client.Character.CharacterId);
                 }
@@ -129,11 +123,25 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 targetClients.Add(client);
             }
 
-            if (targetClients.Any())
+            // HOTFIX: Seems to reduce the channel meltdown issues?
+            // Be really aggressive about making sure everybody has all the lobby contexts, even if it means sending extra packets.
+            // May cause people standing around in WDT oddly.
+            targetClients = [.. Server.ClientLookup.GetAll().Except([client])];
+            if (previousStageId == 0)
+            {
+                gatherClients = targetClients;
+            }
+            else
+            {
+                gatherClients = [];
+            }
+
+            if (targetClients.Count != 0)
             {
                 SendContext(client, targetClients);
             }
-            if (gatherClients.Any())
+
+            if (gatherClients.Count != 0)
             {
                 GatherContexts(gatherClients, client);
             }
@@ -157,6 +165,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             foreach (GameClient source in sourceClients)
             {
+                if (source.Character is null)
+                {
+                    continue;
+                }
+
                 S2CContextGetLobbyPlayerContextNtc contextNtc = source.Character.S2CContextGetLobbyPlayerContextNtc;
                 targetClient.Send(contextNtc);
             }

--- a/Arrowgene.Ddon.GameServer/Handler/InnHpRecoveryCompleteHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/InnHpRecoveryCompleteHandler.cs
@@ -11,7 +11,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override void Handle(GameClient client, StructurePacket<C2SInnHpRecoveryCompleteNtc> packet)
         {
-            //Unsure what CAPCOM wanted with this packet.
+            client.Character.WhiteHp = uint.MaxValue;
+            client.Character.GreenHp = uint.MaxValue;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/ItemSortGetItemSortDataBinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ItemSortGetItemSortDataBinHandler.cs
@@ -16,7 +16,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CItemSortGetItemSortdataBinRes Handle(GameClient client, C2SItemSortGetItemSortDataBinReq request)
         {
-            S2CItemSortGetItemSortdataBinRes res = new S2CItemSortGetItemSortdataBinRes();
+            S2CItemSortGetItemSortdataBinRes res = new();
+
             foreach (var item in request.SortList)
             {
                 StorageType storageType = (StorageType)item.Value; // why the hell is it U32 then
@@ -30,6 +31,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 res.SortData.Add(cdata);
             }
+
+            S2CItemSortGetItemSortdataBinNtc ntc = new()
+            {
+                SortData = res.SortData
+            };
+
+            client.Send(ntc);
 
             return res;
         }

--- a/Arrowgene.Ddon.Server/Network/Client.cs
+++ b/Arrowgene.Ddon.Server/Network/Client.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model.Quest;
@@ -38,6 +39,16 @@ namespace Arrowgene.Ddon.Server.Network
 
         public DateTime PingTime { get; set; }
 
+        public PacketId LastPacketSentToServer { get; set; }
+        public PacketId LastPacketSentToClient { get; set; }
+
+        ~Client()
+        {
+            // Something is funny in the event handling for disconnections, so I'm burying this logging here to make sure this absolutely gets called at some point.
+            // This may be divorced in the log from the actual event, but you can reconstruct this based on the IP address and the rough timing.
+            Logger.Debug(this, $"Final Packets: {this?.LastPacketSentToServer.Name ?? "NULL"} / {this?.LastPacketSentToClient.Name ?? "NULL"}");
+        }
+
         public void SetChallengeCompleted(bool challengeCompleted)
         {
             _challengeCompleted = challengeCompleted;
@@ -60,6 +71,11 @@ namespace Arrowgene.Ddon.Server.Network
             {
                 Logger.Exception(this, ex);
                 packets = new List<IPacket>();
+            }
+
+            if (Socket.IsAlive)
+            {
+                LastPacketSentToServer = packets.Last().Id;
             }
 
             foreach (IPacket packet in packets)
@@ -116,6 +132,11 @@ namespace Arrowgene.Ddon.Server.Network
             {
                 Logger.Exception(this, ex);
                 return;
+            }
+
+            if (Socket.IsAlive)
+            {
+                LastPacketSentToClient = packet.Id;
             }
 
             SendRaw(data);

--- a/Arrowgene.Ddon.Server/Network/PingRequestPacketHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/PingRequestPacketHandler.cs
@@ -29,7 +29,7 @@ namespace Arrowgene.Ddon.Server.Network
                     {
                         // Try messaging the client to ensure it is still alive
                         // If the client is dead, the send will fail and it'll be cleaned up
-                        Logger.Error(client, "\n[AUTOKICK] Suspected asleep client; sending wakeup ping.");
+                        Logger.Error(client, "[AUTOKICK] Suspected asleep client; sending wakeup ping.");
                         var pingRes = BuildPingResponse(client, now);
                         client.Send(pingRes);
                     }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SLobbyLobbyDataMsgReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SLobbyLobbyDataMsgReq.cs
@@ -8,16 +8,9 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
     {
         public PacketId Id => PacketId.C2S_LOBBY_LOBBY_DATA_MSG_REQ;
 
-        public C2SLobbyLobbyDataMsgReq()
-        {
-            Type = 0;
-            CharacterId = 0;
-            RpcPacket = new byte[0];
-        }
-
         public RpcMsgType Type { get; set; }
         public uint CharacterId { get; set; }
-        public byte[] RpcPacket { get; set; }
+        public byte[] RpcPacket { get; set; } = [];
 
         public class Serializer : PacketEntitySerializer<C2SLobbyLobbyDataMsgReq>
         {

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CLobbyLobbyDataMsgNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CLobbyLobbyDataMsgNtc.cs
@@ -8,17 +8,9 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
     {
         public PacketId Id => PacketId.S2C_LOBBY_LOBBY_DATA_MSG_NTC;
 
-        public S2CLobbyLobbyDataMsgNotice()
-        {
-            Type = 0;
-            CharacterId = 0;
-            RpcPacket = new byte[0];
-            OnlineStatus = 0;
-        }
-
         public RpcMsgType Type { get; set; }
         public uint CharacterId { get; set; }
-        public byte[] RpcPacket { get; set; }
+        public byte[] RpcPacket { get; set; } = [];
         public OnlineStatus OnlineStatus { get; set; }
 
         public class Serializer : PacketEntitySerializer<S2CLobbyLobbyDataMsgNotice>


### PR DESCRIPTION
Hotfix: Temporary patch for possible meltdown stability and item sort bug. Seems to be related to sending lobby data messages without the proper context. Investigating more, but pushing this as a temporary fix for server stability reasons.

Also addresses an item sort bug, because the notice is load bearing for some reason.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
