### PR TITLE
Fix/Feat: Small Fixes 10/1 + Valuable Item Recovery

### DIFF
--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -30,7 +30,6 @@ public interface IDatabase
     void Stop();
 
     // Generic functions for getting/setting
-    void AddParameter(DbCommand command, string name, object? value, DbType type);
     void AddParameter(DbCommand command, string name, string value);
     void AddParameter(DbCommand command, string name, int value);
     void AddParameter(DbCommand command, string name, float value);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbRentalPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbRentalPawn.cs
@@ -218,12 +218,12 @@ namespace Arrowgene.Ddon.Database.Sql.Core
                     AddParameter(command, "@adventure_count", pawn.MaxAdventureCount - pawn.AdventureCount);
                     AddParameter(command, "@craft_count", pawn.MaxCraftCount - pawn.CraftCount);
                     AddParameter(command, "@kill_count", pawn.KillCount);
-                    AddParameter(command, "@appearance_score", pawnFeedbacks.Where(x => x.Type == 0).FirstOrDefault()?.Value, System.Data.DbType.Byte);
-                    AddParameter(command, "@appearance_comment", pawnFeedbacks.Where(x => x.Type == 0).FirstOrDefault()?.CommentNo, System.Data.DbType.Byte);
-                    AddParameter(command, "@combat_score", pawnFeedbacks.Where(x => x.Type == 1).FirstOrDefault()?.Value, System.Data.DbType.Byte);
-                    AddParameter(command, "@combat_comment", pawnFeedbacks.Where(x => x.Type == 1).FirstOrDefault()?.CommentNo, System.Data.DbType.Byte);
-                    AddParameter(command, "@craft_score", pawnFeedbacks.Where(x => x.Type == 2).FirstOrDefault()?.Value, System.Data.DbType.Byte);
-                    AddParameter(command, "@craft_comment", pawnFeedbacks.Where(x => x.Type == 2).FirstOrDefault()?.CommentNo, System.Data.DbType.Byte);
+                    AddParameter(command, "@appearance_score", pawnFeedbacks.Where(x => x.Type == 0).FirstOrDefault()?.Value);
+                    AddParameter(command, "@appearance_comment", pawnFeedbacks.Where(x => x.Type == 0).FirstOrDefault()?.CommentNo);
+                    AddParameter(command, "@combat_score", pawnFeedbacks.Where(x => x.Type == 1).FirstOrDefault()?.Value);
+                    AddParameter(command, "@combat_comment", pawnFeedbacks.Where(x => x.Type == 1).FirstOrDefault()?.CommentNo);
+                    AddParameter(command, "@craft_score", pawnFeedbacks.Where(x => x.Type == 2).FirstOrDefault()?.Value);
+                    AddParameter(command, "@craft_comment", pawnFeedbacks.Where(x => x.Type == 2).FirstOrDefault()?.CommentNo);
                 }
                 ) == 1;
             });

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -144,16 +144,6 @@ public partial class DdonPostgresDb : DdonSqlDb
 
     #region: Parameter
 
-    protected override DbParameter Parameter(DbCommand command, string name, object? value, DbType type)
-    {
-        throw new Exception("Do not use the generic parameter mapping for PSQL as it introduces a performance overhead due to autoboxing.");
-    }
-
-    public override void AddParameter(DbCommand command, string name, object? value, DbType type)
-    {
-        throw new Exception("Do not use the generic parameter mapping for PSQL as it introduces a performance overhead due to autoboxing.");
-    }
-
     private static void AddTypedParameter<T>(DbCommand command, string name, T value)
     {
         command.Parameters.Add(new NpgsqlParameter<T>(name, value));
@@ -185,6 +175,11 @@ public partial class DdonPostgresDb : DdonSqlDb
     }
 
     public override void AddParameter(DbCommand command, string name, byte value)
+    {
+        AddTypedParameter(command, name, value);
+    }
+
+    public override void AddParameter(DbCommand command, string name, byte? value)
     {
         AddTypedParameter(command, name, value);
     }

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -75,7 +75,7 @@ public abstract class SqlDb : IDatabase
         }
     }
 
-    public int ExecuteNonQuery(DbConnection conn, string query, Action<DbCommand> nonQueryAction, bool rethrowException = false)
+    public int ExecuteNonQuery(DbConnection conn, string query, Action<DbCommand> nonQueryAction, bool rethrowException = true)
     {
         try
         {
@@ -158,7 +158,7 @@ public abstract class SqlDb : IDatabase
         }
     }
 
-    public virtual void AddParameter(DbCommand command, string name, object? value, DbType type)
+    private void AddParameter(DbCommand command, string name, object? value, DbType type)
     {
         DbParameter parameter = Parameter(command, name, value, type);
         command.Parameters.Add(parameter);
@@ -180,6 +180,11 @@ public abstract class SqlDb : IDatabase
     }
 
     public virtual void AddParameter(DbCommand command, string name, byte value)
+    {
+        AddParameter(command, name, value, DbType.Byte);
+    }
+
+    public virtual void AddParameter(DbCommand command, string name, byte? value)
     {
         AddParameter(command, name, value, DbType.Byte);
     }

--- a/Arrowgene.Ddon.GameServer/Characters/AchievementManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/AchievementManager.cs
@@ -288,6 +288,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             PacketQueue queue = new();
 
+            if (client.Character.GameMode != GameMode.Normal)
+            {
+                return queue;
+            }
+
             // Handle single jobs
             (AchievementType, uint) key = (AchievementType.MainLevel, (uint)client.Character.Job);
             uint progress = client.Character.ActiveCharacterJobData.Lv;
@@ -550,16 +555,40 @@ namespace Arrowgene.Ddon.GameServer.Characters
                         progress.Add((uint)(client.Character.AchievementUniqueCrafts.GetValueOrDefault((AchievementCraftTypeParam)asset.Param) ?? new()).Count);
                         break;
                     case AchievementType.LearnAugments:
+                        if (client.Character.GameMode != GameMode.Normal)
+                        {
+                            progress.Add(0);
+                            break;
+                        }
+
                         progress.Add((uint)client.Character.LearnedAbilities.Select(x => (int)x.AbilityLv).Sum());
                         break;
                     case AchievementType.LearnSkills:
+                        if (client.Character.GameMode != GameMode.Normal)
+                        {
+                            progress.Add(0);
+                            break;
+                        }
+
                         progress.Add((uint)client.Character.LearnedCustomSkills.Select(x => (int)x.SkillLv).Sum());
                         break;
                     case AchievementType.MainLevel:
+                        if (client.Character.GameMode != GameMode.Normal)
+                        {
+                            progress.Add(0);
+                            break;
+                        }
+
                         progress.Add(client.Character.CharacterJobDataList.Where(x => x.Job == (JobId)asset.Param).FirstOrDefault()?.Lv ?? 0);
                         break;
                     case AchievementType.MainLevelGroup:
                         {
+                            if (client.Character.GameMode != GameMode.Normal)
+                            {
+                                progress.Add(0);
+                                break;
+                            }
+
                             HashSet<JobId> group = LevelGroupMap.GetValueOrDefault((AchievementLevelGroupParam)asset.Param);
                             int lowestLevel = group.Select(job => client.Character.CharacterJobDataList.Where(x => x.Job == job).Select(x => (int)x.Lv).FirstOrDefault()).Min();
                             uint result = lowestLevel >= asset.Count ? 1u : 0u;

--- a/Arrowgene.Ddon.GameServer/Characters/BitterblackMazeManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/BitterblackMazeManager.cs
@@ -1,20 +1,16 @@
-using Arrowgene.Ddon.Database;
-using Arrowgene.Ddon.Database.Model;
-using Arrowgene.Ddon.GameServer.Scripting;
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Asset;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
-using Arrowgene.Ddon.Shared.Model.Appraisal;
 using Arrowgene.Ddon.Shared.Model.BattleContent;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.Entity.Core.Common.CommandTrees.ExpressionBuilder;
 using System.Linq;
+using System.Text;
 
 namespace Arrowgene.Ddon.GameServer.Characters
 {
@@ -35,7 +31,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         private static uint ShouldReportSearchResults(BitterblackMazeProgress progress, IEnumerable<BitterblackMazeMarkRewards> rewards)
         {
-            bool rewardPresent = rewards.Any(x => x.GoldMarks > 0 || x.SilverMarks > 0 || x.RedMarks > 0);
+            bool rewardPresent = rewards.Any(x => x.Any);
             return (uint)((rewardPresent && progress.Tier == 0 && progress.StartTime > 0) ? 1 : 0);
         }
 
@@ -63,17 +59,17 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
             var availableRewards = new List<CDataBattleContentAvailableRewards>();
 
-            foreach (var stage in server.AssetRepository.BitterblackMazeAsset.Stages)
+            foreach (var (mode, stageId, tier, contentId) in gBossStages)
             {
                 var closedChests = gSealedChestDrops
-                    .Where(x => x.Key.Item1.Equals(stage.Key) 
+                    .Where(x => x.Key.Item1.Id == stageId
                         && (x.Value == ChestType.Earring || x.Value == ChestType.Bracelet)
                         && !openedChests.Any(y => x.Key.Item1.Equals(y.LayoutId) && x.Key.Item2 == y.Index)
                     ).Select(x => x.Key);
 
                 availableRewards.Add(new CDataBattleContentAvailableRewards()
                 {
-                    Id = stage.Value.ContentId,
+                    Id = contentId,
                     Amount = (byte)closedChests.Count(),
                 });
             }
@@ -86,7 +82,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     ContentId = progress.ContentId,
                     StartTime = progress.StartTime,
                     RewardBonus = BattleContentRewardBonus.Normal, // This gets set to UP when resetting with GG.
-                    RewardReceived = rewards.Count > 0 && rewards.Sum(x => x.Value.RedMarks) == 0,
+                    RewardReceived = rewards.Count > 0 && !rewards.Values.Any(x => x.Any),
                     ReportSearchResults = ShouldReportSearchResults(progress, rewards.Values), // This needs to be set after killing last boss? (or maybe between tiers if you exit?)
                     ReportReset = ShouldReportProgress(progress),
                     Unk7 = 23, // Value from pcap, not sure what it does
@@ -241,6 +237,59 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return queue;
         }
 
+        public List<string> GenerateProgressReportString(GameClient client)
+        {
+            Dictionary<uint, BitterblackMazeMarkRewards> rewards = [];
+            HashSet<uint> openedChests = [];
+            Server.Database.ExecuteInTransaction(connectionIn =>
+            {
+                rewards = server.Database.SelectBBMRewards(client.Character.CharacterId, connectionIn);
+                openedChests = [.. server.Database.SelectBBMContentTreasure(client.Character.CharacterId, connectionIn).Select(x => x.LayoutId.Id)];
+            });
+
+            StringBuilder sbChests = new();
+            StringBuilder sbMarks = new();
+            StringBuilder sbTotalMarks = new();
+            sbChests.Append("==CHEST REWARDS==");
+            sbMarks.Append("==MARK REWARDS==");
+            foreach (var (mode, stageId, tier, contentId) in gBossStages)
+            {
+                string stageName = $"{mode} {tier}";
+
+                if (rewards.TryGetValue(stageId, out var markReward))
+                {
+                    if (markReward.Any)
+                    {
+                        sbMarks.Append($"\n{stageName}: Can Claim");
+                    }
+                    else
+                    {
+                        sbMarks.Append($"\n{stageName}: Claimed");
+                    }
+                }
+                else
+                {
+                    sbMarks.Append($"\n{stageName}: Can Earn");
+                }
+
+                if (openedChests.Contains(stageId))
+                {
+                    sbChests.Append($"\n{stageName}: Claimed");
+                }
+                else
+                {
+                    sbChests.Append($"\n{stageName}: Can Earn");
+                }
+            }
+
+            sbTotalMarks.Append("==PENDING MARKS==");
+            sbTotalMarks.Append($"\nGold Marks: {rewards.Sum(x => x.Value.GoldMarks)}");
+            sbTotalMarks.Append($"\nSilver Marks: {rewards.Sum(x => x.Value.SilverMarks)}");
+            sbTotalMarks.Append($"\nRed Marks: {rewards.Sum(x => x.Value.RedMarks)}");
+
+            return [sbChests.ToString(), sbMarks.ToString(), sbTotalMarks.ToString()];
+        }
+
         internal enum ChestType
         {
             Normal, // Random unsealed chests
@@ -344,6 +393,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
             [(new StageLayoutId(684, 0, 201), 1)] = ChestType.Purple,
             [(new StageLayoutId(685, 0, 200), 0)] = ChestType.Earring,
         };
+
+        private static List<(BattleContentMode Mode, uint StageId, uint Tier, uint ContentId)> gBossStages = [
+            (BattleContentMode.Rotunda, 603, 1, 2),
+            (BattleContentMode.Rotunda, 604, 2, 3),
+            (BattleContentMode.Rotunda, 605, 3, 4),
+            (BattleContentMode.Abyss, 682, 1, 10),
+            (BattleContentMode.Abyss, 683, 2, 11),
+            (BattleContentMode.Abyss, 684, 3, 12),
+            (BattleContentMode.Abyss, 685, 4, 13),
+        ];
 
         public static List<InstancedGatheringItem> RollChestLoot(DdonGameServer server, Character character, StageLayoutId stageId, uint pos)
         {

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -42,7 +42,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
         /// </summary>
         private static readonly HashSet<uint> KnownBadQuestScheduleIds = new HashSet<uint>()
         {
-            25077, 43645, 43646, 47734, 47736, 47737, 47738, 47739, 49692, 77644, 151381, 208640, 233576, 259411, 259412, 287378, 315624
+            25077, 43645, 43646, 47734, 47735, 47736, 47737, 47738, 47739, 49692, 77644, 151381, 208640, 233576, 259411, 259412, 287378, 315624
         };
 
         private static void AddQuestToCategory(Quest quest)
@@ -188,7 +188,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             if (!gQuests.ContainsKey(questScheduleId))
             {
-                if (!KnownBadQuestScheduleIds.Contains(questScheduleId))
+                if (!KnownBadQuestScheduleIds.Contains(questScheduleId) && !IsBoardQuest(questScheduleId))
                 {
                     Logger.Error($"GetQuestByScheduleId: Invalid questScheduleId {questScheduleId}");
                 }
@@ -3441,6 +3441,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
         public static bool IsBoardQuest(Quest quest)
         {
             return IsBoardQuest(quest.QuestId);
+        }
+
+        public static bool IsBoardQuest(uint questScheduleId)
+        {
+            return QuestScheduleId.GetType(questScheduleId) == QuestScheduleId.ScheduleIdType.Board;
         }
 
         public static bool IsTutorialQuest(QuestId questId)

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -450,6 +450,7 @@ namespace Arrowgene.Ddon.GameServer
             AddHandler(new ItemEmbodyItemsHandler(this));
             AddHandler(new ItemChangeAttrDiscardHandler(this));
             AddHandler(new ItemGetEquipRareTypeItemsHandler(this));
+            AddHandler(new ItemRecoveryValuableItemHandler(this));
 
             AddHandler(new JobChangeJobHandler(this));
             AddHandler(new JobChangePawnJobHandler(this));

--- a/Arrowgene.Ddon.GameServer/GameClient.cs
+++ b/Arrowgene.Ddon.GameServer/GameClient.cs
@@ -24,7 +24,7 @@ namespace Arrowgene.Ddon.GameServer
 
         public void UpdateIdentity()
         {
-            string newIdentity = $"[GameClient@{Socket.Identity}]";
+            string newIdentity = $"[GameClient#{Id}@{Socket.Identity}]";
             if (Account != null)
             {
                 newIdentity += $"[Acc:({Account.Id}){Account.NormalName}]";

--- a/Arrowgene.Ddon.GameServer/Handler/ItemGetValuableItemListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ItemGetValuableItemListHandler.cs
@@ -1,6 +1,12 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -18,10 +24,46 @@ namespace Arrowgene.Ddon.GameServer.Handler
             //TODO: Implement this properly.
             //This is enough to prevent the client from hanging if you accidentally use this menu.
             var res = new S2CItemGetValuableItemListRes();
-            res.Unk0 = 0;
-            res.Unk1 = 0;
+
+            foreach (var storageType in ItemManager.BothStorageTypes)
+            {
+                var storage = client.Character.Storage.GetStorage(storageType);
+                res.EmptySlotNumList.Add(new CDataStorageEmptySlotNum()
+                {
+                    StorageType = storageType,
+                    Slots = storage.EmptySlots()
+                });
+            }
+
+            foreach (var valuableItem in ValuableItemQuestRewards)
+            {
+                if (client.Character.HasQuestCompleted(valuableItem.QuestId) && client.Character.Storage.FindItemsByIdInStorage(ItemManager.EquipmentStorages, valuableItem.ItemId).Count == 0)
+                {
+                    res.ValuableItems.Add(new()
+                    {
+                        ItemId = valuableItem.ItemId,
+                        WalletType = WalletType.Gold,
+                        Price = (uint)(Server.AssetRepository.ClientItemInfos[valuableItem.ItemId].Price * 100)
+                    });
+                }
+            }
 
             return res;
         }
+
+        private static readonly List<(QuestId QuestId, ItemId ItemId)> ValuableItemQuestRewards =
+        [
+            (QuestId.VocationEmblemTrialFighter, ItemId.EmblemStoneFighter),
+            (QuestId.VocationEmblemTrialPriest, ItemId.EmblemStonePriest),
+            (QuestId.VocationEmblemTrialHunter, ItemId.EmblemStoneHunter),
+            (QuestId.VocationEmblemTrialShieldSage, ItemId.EmblemStoneShieldSage),
+            (QuestId.VocationEmblemTrialSeeker, ItemId.EmblemStoneSeeker),
+            (QuestId.VocationEmblemTrialSorcerer, ItemId.EmblemStoneSorcerer),
+            (QuestId.VocationEmblemTrialElementArcher, ItemId.EmblemStoneElementArcher),
+            (QuestId.VocationEmblemTrialWarrior, ItemId.EmblemStoneWarrior),
+            (QuestId.VocationEmblemTrialAlchemist, ItemId.EmblemStoneAlchemist),
+            (QuestId.VocationEmblemTrialSpiritLancer, ItemId.EmblemStoneSpiritLancer),
+            (QuestId.VocationEmblemTrialHighScepter, ItemId.EmblemStoneHighScepter),
+        ];
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/ItemRecoveryValuableItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ItemRecoveryValuableItemHandler.cs
@@ -1,0 +1,95 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Logging;
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer.Handler
+{
+    internal class ItemRecoveryValuableItemHandler : GameRequestPacketHandler<C2SItemRecoveryValuableItemReq, S2CItemRecoveryValuableItemRes>
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ItemGetValuableItemListHandler));
+
+
+        public ItemRecoveryValuableItemHandler(DdonGameServer server) : base(server)
+        {
+        }
+
+        public override S2CItemRecoveryValuableItemRes Handle(GameClient client, C2SItemRecoveryValuableItemReq request)
+        {
+            PacketQueue queue = new();
+
+            StorageType targetStorageType = StorageType.ItemPost;
+            ClientItemInfo itemInfo = Server.AssetRepository.ClientItemInfos[request.ItemId];
+
+            if (request.DestinationStorage == StorageType.ReceiveInItemBagCraft)
+            {
+                targetStorageType = itemInfo.StorageType;
+            }
+            else if (request.DestinationStorage == StorageType.ReceiveInStorageCraft)
+            {
+                if (client.Character.Storage.GetStorage(StorageType.StorageBoxNormal).EmptySlots() > 0)
+                {
+                    targetStorageType = StorageType.StorageBoxNormal;
+                }
+                else if (client.Character.Storage.GetStorage(StorageType.StorageBoxExpansion).EmptySlots() > 0)
+                {
+                    targetStorageType = StorageType.StorageBoxExpansion;
+                }
+                else
+                {
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_STORAGE_CAPACITY_OVER);
+                }
+            }
+            else if (request.DestinationStorage == StorageType.StorageChestDrawer1)
+            {
+                if (client.Character.Storage.GetStorage(StorageType.StorageChestDrawer1).EmptySlots() > 0)
+                {
+                    targetStorageType = StorageType.StorageChestDrawer1;
+                }
+                else if (client.Character.Storage.GetStorage(StorageType.StorageChestDrawer2).EmptySlots() > 0)
+                {
+                    targetStorageType = StorageType.StorageChestDrawer2;
+                }
+                else if (client.Character.Storage.GetStorage(StorageType.StorageChestDrawer3).EmptySlots() > 0)
+                {
+                    targetStorageType = StorageType.StorageChestDrawer3;
+                }
+                else
+                {
+                    throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_STORAGE_CAPACITY_OVER);
+                }
+            }
+            else
+            {
+                throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_INVALID_STORAGE_TYPE);
+            }
+
+            S2CItemUpdateCharacterItemNtc updateNtc = new()
+            {
+                UpdateType = ItemNoticeType.GetDispelItem // This probably uses one of the unknown updatetypes.
+            };
+
+            Server.Database.ExecuteInTransaction(connection =>
+            {
+                updateNtc.UpdateItemList.AddRange(Server.ItemManager.AddItem(Server, client.Character, targetStorageType, (uint)request.ItemId, 1, connectionIn: connection));
+
+                foreach (var priceElement in request.Price)
+                {
+                    updateNtc.UpdateWalletList.Add(Server.WalletManager.RemoveFromWallet(client.Character, priceElement.Type, priceElement.Value, connection));
+                }
+            });
+
+            // Recovering an emblem stone
+            if (itemInfo.SubCategory == ItemSubCategory.EmblemStone)
+            {
+                Server.JobEmblemManager.AddNewEmblemItem(client.Character, updateNtc.UpdateItemList.FirstOrDefault()?.ItemList.ItemUId);
+            }
+
+            client.Send(updateNtc);
+
+            return new();
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -343,7 +343,10 @@ namespace Arrowgene.Ddon.GameServer.Party
             {
                 if (!Clients.Contains(client))
                 {
-                    Logger.Error(client, $"[PartyId:{Id}][Leave(GameClient)] not part of this party");
+                    // TODO: Suppressing this log message for now; it spams the log and is usually not helpful.
+                    // This is partly due to an order of operations problem when quitting the game.
+
+                    //Logger.Error(client, $"[PartyId:{Id}][Leave(GameClient)] not part of this party");
                     return;
                 }
 

--- a/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
+++ b/Arrowgene.Ddon.LoginServer/Handler/ClientLoginHandler.cs
@@ -103,7 +103,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                     {
                         if (connections.Any())
                         {
-                            connections.ForEach(x => RequestKick(x));
+                            connections.ForEach(x => RequestKick(client, x));
                             Thread.Sleep(_setting.KickOnMultipleLoginTimer);
                             connections = Database.SelectConnectionsByAccountId(account.Id);
                         }
@@ -180,7 +180,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
             }
         }
 
-        private void RequestKick(Connection connection)
+        private void RequestKick(LoginClient client, Connection connection)
         {
             // Timing issues with loading files vs server process startup.
             if (!_httpReady)
@@ -190,7 +190,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                     ServerInfo serverInfo = Server.AssetRepository.ServerList.Find(x => x.LoginId == Server.Id);
                     if (serverInfo is null)
                     {
-                        Logger.Error($"[AUTOKICK] Login server with ID {Server.Id} was not found in the ServerList asset.");
+                        Logger.Error(client, $"[AUTOKICK] Login server with ID {Server.Id} was not found in the ServerList asset.");
                         return;
                     }
 
@@ -203,7 +203,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
             // Only one login server should be servicing requests, so it has to be this one.
             if (connection.Type == ConnectionType.LoginServer)
             {
-                Logger.Error($"[AUTOKICK] Clearing double login for account {connection.AccountId}.");
+                Logger.Error(client, $"[AUTOKICK] Clearing double login for account {connection.AccountId}.");
                 Database.DeleteConnection(connection.ServerId, connection.AccountId);
                 return;
             }
@@ -212,7 +212,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
             if (channel is null)
             {
                 // If the server can't be found, the entry in the DB is erroneous and should be cleared.
-                Logger.Info($"[AUTOKICK] Clearing bad connection record for account {connection.AccountId} from server {connection.ServerId}");
+                Logger.Info(client, $"[AUTOKICK] Clearing bad connection record for account {connection.AccountId} from server {connection.ServerId}");
                 Server.Database.DeleteConnection(connection.ServerId, connection.AccountId);
                 return;
             }
@@ -226,7 +226,7 @@ namespace Arrowgene.Ddon.LoginServer.Handler
                 Data = connection.AccountId
             };
 
-            Logger.Info($"[AUTOKICK] Attempting to auto kick account {connection.AccountId} from server {connection.ServerId}");
+            Logger.Info(client, $"[AUTOKICK] Attempting to auto kick account {connection.AccountId} from server {connection.ServerId}");
 
             var json = JsonSerializer.Serialize(wrappedObject);
             _ = _httpClient.PostAsync(route, new StringContent(json));

--- a/Arrowgene.Ddon.LoginServer/LoginClient.cs
+++ b/Arrowgene.Ddon.LoginServer/LoginClient.cs
@@ -13,7 +13,7 @@ namespace Arrowgene.Ddon.LoginServer
 
         public void UpdateIdentity()
         {
-            string newIdentity = $"[LoginClient@{Socket.Identity}]";
+            string newIdentity = $"[LoginClient#{Id}@{Socket.Identity}]";
             if (Account != null)
             {
                 newIdentity += $"[Acc:{Account.NormalName}]";

--- a/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
@@ -1,6 +1,7 @@
 using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Rpc.Command;
+using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Logging;
@@ -15,7 +16,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
     {
         public class InternalCommand : RpcBodyCommand<RpcUnwrappedObject>
         {
-            private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(InternalCommand));
+            private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(InternalCommand));
 
             public InternalCommand(RpcUnwrappedObject entry) : base(entry)
             {
@@ -68,6 +69,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                             {
                                 if (client.Account?.Id == target)
                                 {
+                                    Logger.Error(client, $"[AUTOKICK] Handling auto kick for account {target}");
                                     client.Close();
                                 }
                             }

--- a/Arrowgene.Ddon.Scripts/scripts/chat_commands/bbminfo.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/chat_commands/bbminfo.csx
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text;
+
+public class ChatCommand : IChatCommand
+{
+    public override AccountStateType AccountState => AccountStateType.User;
+    public override string CommandName => "bbminfo";
+    public override string HelpText => "usage: `/bbminfo` - Print details about your BBM progress.";
+
+    public override void Execute(DdonGameServer server, string[] command, GameClient client, ChatMessage message, List<ChatResponse> responses)
+    {
+        if (client.Character.GameMode != GameMode.BitterblackMaze)
+        {
+            responses.Add(ChatResponse.CommandError(client, $"You can only use this command while in Bitterblack Maze or the Cove."));
+            //return;
+        }
+        client.Send(new S2CConnectionInformationNtc()
+        {
+            ParagraphList = [.. server.BitterblackMazeManager.GenerateProgressReportString(client).Select((x, i) => new CDataInformationParagraph()
+                {
+                    Index = (uint)i,
+                    Text = x,
+                })]
+        });
+    }
+}
+
+return new ChatCommand();

--- a/Arrowgene.Ddon.Scripts/scripts/chat_commands/godmode.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/chat_commands/godmode.csx
@@ -8,7 +8,7 @@ public class ChatCommand : IChatCommand
     public override string CommandName => "godmode";
     public override string HelpText => "usage: `/godmode [true/false]` - Toggle high stats.";
 
-    private uint BoostedStat = 10000;
+    private uint BoostedStat = 50000;
 
     public override void Execute(DdonGameServer server, string[] command, GameClient client, ChatMessage message, List<ChatResponse> responses)
     {
@@ -23,7 +23,7 @@ public class ChatCommand : IChatCommand
             client.Send(new S2CCharacterGainCharacterParamNtc()
             {
                 CharacterId = client.Character.CharacterId,
-                //HpMaxGain = BoostedStat,
+                HpMaxGain = BoostedStat,
                 StaminaMaxGain = BoostedStat,
                 AttackGain = BoostedStat,
                 DefenseGain = BoostedStat,
@@ -36,6 +36,12 @@ public class ChatCommand : IChatCommand
             client.Character.StatusInfo.Stamina = uint.MaxValue;
 
             var ntc3 = client.Character.S2CContextGetLobbyPlayerContextNtc;
+            ntc3.Context.PlayerInfo.GainHp = BoostedStat;
+            ntc3.Context.PlayerInfo.GainStamina = BoostedStat;
+            ntc3.Context.PlayerInfo.GainAttack = BoostedStat;
+            ntc3.Context.PlayerInfo.GainDefense = BoostedStat;
+            ntc3.Context.PlayerInfo.GainMagicAttack = BoostedStat;
+            ntc3.Context.PlayerInfo.GainMagicDefense = BoostedStat;
 
             client.Send(ntc3);
 

--- a/Arrowgene.Ddon.Server/ClientLookup.cs
+++ b/Arrowgene.Ddon.Server/ClientLookup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Arrowgene.Ddon.Server.Network;
 
 namespace Arrowgene.Ddon.Server
@@ -21,7 +22,7 @@ namespace Arrowgene.Ddon.Server
         {
             lock (_lock)
             {
-                return new List<TClient>(_clients);
+                return [.. _clients.Where(x => x.IsAlive)];
             }
         }
 

--- a/Arrowgene.Ddon.Server/Network/Client.cs
+++ b/Arrowgene.Ddon.Server/Network/Client.cs
@@ -67,10 +67,19 @@ namespace Arrowgene.Ddon.Server.Network
             {
                 packets = _packetFactory.Read(data);
             }
+            catch (ResponseErrorException ex)
+            {
+                // Usually thrown by the Camelia cipher complaining about misshapen packets.
+                // We shouldn't tolerate these connections and just kick them.
+                Logger.Exception(this, ex);
+                packets = [];
+
+                this.Close();
+            }
             catch (Exception ex)
             {
                 Logger.Exception(this, ex);
-                packets = new List<IPacket>();
+                packets = [];
             }
 
             if (Socket.IsAlive && packets.Count > 0)

--- a/Arrowgene.Ddon.Server/Network/Client.cs
+++ b/Arrowgene.Ddon.Server/Network/Client.cs
@@ -1,17 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
-using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
 using Arrowgene.Networking.Tcp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.Server.Network
 {
     public class Client
     {
+        private static uint IncrementingId = 0;
+
         private readonly ServerLogger Logger;
 
         protected readonly ITcpSocket Socket;
@@ -33,14 +34,17 @@ namespace Arrowgene.Ddon.Server.Network
             _challenge = null;
             Identity = socket.Identity;
             _challengeCompleted = false;
+            Id = IncrementingId++;
         }
 
         public string Identity { get; protected set; }
+        public uint Id { get; protected set; }
 
         public DateTime PingTime { get; set; }
 
         public PacketId LastPacketSentToServer { get; set; }
         public PacketId LastPacketSentToClient { get; set; }
+        public bool IsAlive { get { return Socket.IsAlive; } }
 
         ~Client()
         {

--- a/Arrowgene.Ddon.Server/Network/RequestPacketHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/RequestPacketHandler.cs
@@ -2,6 +2,7 @@ using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using Npgsql;
 using System;
 using System.Data.SQLite;
 using System.Linq;
@@ -39,16 +40,30 @@ namespace Arrowgene.Ddon.Server.Network
             {
                 if (ex.ErrorCode == (int)SQLiteErrorCode.Busy)
                 {
-                    response = new TResStruct();
-                    response.Error = (uint)ErrorCode.ERROR_CODE_DB_DEAD_LOCK;
+                    response = new TResStruct
+                    {
+                        Error = (uint)ErrorCode.ERROR_CODE_DB_DEAD_LOCK
+                    };
                 }
                 else
                 {
-                    response = new TResStruct();
-                    response.Error = (uint)ErrorCode.ERROR_CODE_DB_FAILURE;
+                    response = new TResStruct
+                    {
+                        Error = (uint)ErrorCode.ERROR_CODE_DB_FAILURE
+                    };
                 }
                 client.Send(response);
                 client.Close(); // Do not tolerate SqLiteExceptions because of desync issues.
+                throw;
+            }
+            catch (PostgresException ex)
+            {
+                response = new TResStruct
+                {
+                    Error = (uint)ErrorCode.ERROR_CODE_DB_FAILURE
+                };
+                client.Send(response);
+                client.Close();
                 throw;
             }
             catch (NotImplementedException ex)

--- a/Arrowgene.Ddon.Server/Network/RequestPacketQueueHandler.cs
+++ b/Arrowgene.Ddon.Server/Network/RequestPacketQueueHandler.cs
@@ -2,6 +2,7 @@ using Arrowgene.Ddon.Shared.Entity;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using Arrowgene.Logging;
+using Npgsql;
 using System;
 using System.Data.SQLite;
 using System.Linq;
@@ -44,6 +45,16 @@ namespace Arrowgene.Ddon.Server.Network
                 }
                 client.Send(response);
                 client.Close(); // Do not tolerate SqLiteExceptions because of desync issues.
+                throw;
+            }
+            catch (PostgresException ex)
+            {
+                response = new TResStruct
+                {
+                    Error = (uint)ErrorCode.ERROR_CODE_DB_FAILURE
+                };
+                client.Send(response);
+                client.Close();
                 throw;
             }
             catch (NotImplementedException ex)

--- a/Arrowgene.Ddon.Shared/Crypto/Camellia.cs
+++ b/Arrowgene.Ddon.Shared/Crypto/Camellia.cs
@@ -28,7 +28,7 @@ namespace Arrowgene.Ddon.Shared.Crypto
             {
                 if (!pad)
                 {
-                    throw new Exception("Invalid PlainText Size");
+                    throw new ArgumentException("Invalid PlainText Size");
                 }
 
                 int padding = 16 - mod;
@@ -72,7 +72,7 @@ namespace Arrowgene.Ddon.Shared.Crypto
             {
                 if (!pad)
                 {
-                    throw new Exception("Invalid CipherText Size");
+                    throw new ArgumentException("Invalid CipherText Size");
                 }
 
                 int padding = 16 - mod;

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -504,6 +504,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataURLInfo.Serializer());
             Create(new CDataUpdateMatchingProfileInfo.Serializer());
             Create(new CDataUpdateWalletPoint.Serializer());
+            Create(new CDataValuableItem.Serializer());
 
             Create(new CDataWalletLimit.Serializer());
             Create(new CDataWalletPoint.Serializer());
@@ -768,6 +769,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SItemUseBagItemReq.Serializer());
             Create(new C2SItemUseJobItemsReq.Serializer());
             Create(new C2SItemGetEquipRareTypeItemsReq.Serializer());
+            Create(new C2SItemRecoveryValuableItemReq.Serializer());
 
             Create(new C2SJobChangeJobReq.Serializer());
             Create(new C2SJobChangePawnJobReq.Serializer());
@@ -1396,6 +1398,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2CItemUseBagItemRes.Serializer());
             Create(new S2CItemUseJobItemsRes.Serializer());
             Create(new S2CItemGetEquipRareTypeItemsRes.Serializer());
+            Create(new S2CItemRecoveryValuableItemRes.Serializer());
 
             Create(new S2CJobChangeJobNtc.Serializer());
             Create(new S2CJobChangeJobRes.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SItemRecoveryValuableItemReq.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SItemRecoveryValuableItemReq.cs
@@ -1,0 +1,37 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SItemRecoveryValuableItemReq : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_ITEM_RECOVERY_VALUABLE_ITEM_REQ;
+
+        public ItemId ItemId { get; set; }
+        public StorageType DestinationStorage { get; set; }
+        public List<CDataWalletPoint> Price { get; set; } = [];
+
+        public class Serializer : PacketEntitySerializer<C2SItemRecoveryValuableItemReq>
+        {
+            public override void Write(IBuffer buffer, C2SItemRecoveryValuableItemReq obj)
+            {
+                WriteUInt32(buffer, (uint)obj.ItemId);
+                WriteByte(buffer, (byte)obj.DestinationStorage);
+                WriteEntityList(buffer, obj.Price);
+            }
+
+            public override C2SItemRecoveryValuableItemReq Read(IBuffer buffer)
+            {
+                C2SItemRecoveryValuableItemReq obj = new C2SItemRecoveryValuableItemReq();
+                obj.ItemId = (ItemId)ReadUInt32(buffer);
+                obj.DestinationStorage = (StorageType)ReadByte(buffer);
+                obj.Price = ReadEntityList<CDataWalletPoint>(buffer);
+
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CItemGetValuableItemListRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CItemGetValuableItemListRes.cs
@@ -7,22 +7,10 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 {
     public class S2CItemGetValuableItemListRes : ServerResponse
     {
-        public S2CItemGetValuableItemListRes()
-        {
-            DummyEmptySlotNum = new List<CDataItemStorageIndicateNum>();
-            DummyValuableItems = new List<CDataItemStorageIndicateNum>();
-        }
-
         public override PacketId Id => PacketId.S2C_ITEM_GET_VALUABLE_ITEM_LIST_RES;
 
-        public int Unk0 { get; set; }
-        public int Unk1 { get; set; }
-
-        //TODO: Implement these CData objects properly.
-        //public List<CDataValuableItem> ValuableItems //int, byte, int, short
-        //public List<CDataStorageEmptySlotNum> EmptySlotNum //From the BBI PR.
-        public List<CDataItemStorageIndicateNum> DummyValuableItems { get; set; }
-        public List<CDataItemStorageIndicateNum> DummyEmptySlotNum { get; set; }
+        public List<CDataValuableItem> ValuableItems { get; set; } = [];
+        public List<CDataStorageEmptySlotNum> EmptySlotNumList { get; set; } = [];
 
         public class Serializer : PacketEntitySerializer<S2CItemGetValuableItemListRes>
         {
@@ -30,20 +18,16 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             public override void Write(IBuffer buffer, S2CItemGetValuableItemListRes obj)
             {
                 WriteServerResponse(buffer, obj);
-                WriteInt32(buffer, obj.Unk0);
-                WriteInt32(buffer, obj.Unk1);
-                WriteEntityList<CDataItemStorageIndicateNum>(buffer, obj.DummyValuableItems);
-                WriteEntityList<CDataItemStorageIndicateNum>(buffer, obj.DummyEmptySlotNum);
+                WriteEntityList(buffer, obj.ValuableItems);
+                WriteEntityList(buffer, obj.EmptySlotNumList);
             }
 
             public override S2CItemGetValuableItemListRes Read(IBuffer buffer)
             {
                 S2CItemGetValuableItemListRes obj = new S2CItemGetValuableItemListRes();
                 ReadServerResponse(buffer, obj);
-                obj.Unk0 = ReadInt32(buffer);
-                obj.Unk1 = ReadInt32(buffer);
-                obj.DummyValuableItems = ReadEntityList<CDataItemStorageIndicateNum>(buffer);
-                obj.DummyValuableItems = ReadEntityList<CDataItemStorageIndicateNum>(buffer);
+                obj.ValuableItems = ReadEntityList<CDataValuableItem>(buffer);
+                obj.EmptySlotNumList = ReadEntityList<CDataStorageEmptySlotNum>(buffer);
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CItemRecoveryValuableItemRes.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CItemRecoveryValuableItemRes.cs
@@ -1,0 +1,25 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CItemRecoveryValuableItemRes : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_ITEM_RECOVERY_VALUABLE_ITEM_RES;
+
+        public class Serializer : PacketEntitySerializer<S2CItemRecoveryValuableItemRes>
+        {
+            public override void Write(IBuffer buffer, S2CItemRecoveryValuableItemRes obj)
+            {
+                WriteServerResponse(buffer, obj);
+            }
+
+            public override S2CItemRecoveryValuableItemRes Read(IBuffer buffer)
+            {
+                S2CItemRecoveryValuableItemRes obj = new S2CItemRecoveryValuableItemRes();
+                ReadServerResponse(buffer, obj);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataValuableItem.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataValuableItem.cs
@@ -1,0 +1,35 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataValuableItem
+    {
+
+        public ItemId ItemId { get; set; }
+        public WalletType WalletType { get; set; }
+        public uint Price { get; set; }
+        public ushort Unk3 { get; set; }
+
+        public class Serializer : EntitySerializer<CDataValuableItem>
+        {
+            public override void Write(IBuffer buffer, CDataValuableItem obj)
+            {
+                WriteUInt32(buffer, (uint)obj.ItemId);
+                WriteByte(buffer, (byte)obj.WalletType);
+                WriteUInt32(buffer, obj.Price);
+                WriteUInt16(buffer, obj.Unk3);
+            }
+
+            public override CDataValuableItem Read(IBuffer buffer)
+            {
+                CDataValuableItem obj = new CDataValuableItem();
+                obj.ItemId = (ItemId)ReadUInt32(buffer);
+                obj.WalletType = (WalletType)ReadByte(buffer);
+                obj.Price = ReadUInt32(buffer);
+                obj.Unk3 = ReadUInt16(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/BattleContent/BitterblackMazeMarkRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/BattleContent/BitterblackMazeMarkRewards.cs
@@ -12,5 +12,13 @@ namespace Arrowgene.Ddon.Shared.Model.BattleContent
         public uint GoldMarks { get; set; }
         public uint SilverMarks { get; set; }
         public uint RedMarks { get; set; }
+
+        public bool Any
+        {
+            get
+            {
+                return GoldMarks > 0 || SilverMarks > 0 || RedMarks > 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
# Admin/Dev Stuff
* Fix /godmode so it works properly *and* heals you to full.
* Adjust some logging for annoying minor issues that make it harder than it needs to be to find actual issues:
  * Silences an "Error" when "leaving" a party that you're not a member of; this is rooted in some odd order of operations issue that fires whenever the client disconnects.
  * Silences an error when being unable to find a certain leftover questScheduleId from a pcap somewhere.
  * Handles an error when a client is for some reason having issues with packet padding/alignment; this is a critical error and the client should be immediately disconnected.
  * All client objects are assigned a strictly incrementing ID number when they're created; this appears in the log and should be helpful in tracing a single client object's lifetime.
  * Additional logging for when the AUTOKICK actually kicks someone.
* Clients whose socket is closed are not returned by the usual `ClientLookup.GetAll()` so we stop trying to send packets to and from clients who we've acknowledged as being dead, even if the event to remove them from the lookup hasn't fired yet.
* Fix an unreported but seemingly critical issue with Postgres and pawn feedback.
  * I have my suspicions that Postgres errors relating to this were causing bizarre DB rollbacks.

# Player Stuff
* You should no longer be able to earn certain achievements relating to job levels in BBM. Probably.
* If for whatever reason you sold or discarded your Job Emblem, you can get a new one from the blue chest in your Arisen's Room. The crests will be lost but the stats and progress will be retained.
* You can use `/bbminfo` to see the status of available BBM rewards.
* The logic that controls the BBM reward status message on the right side of the screen has been tweaked.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
