### PR TITLE
Hotfix: Follow up on BBM Resets and Emblem Recovery

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbBitterBlackMazeRewards.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbBitterBlackMazeRewards.cs
@@ -27,7 +27,7 @@ public partial class DdonSqlDb : SqlDb
         INSERT INTO ""ddon_bbm_reset_gg"" (character_id, reset_count)
         VALUES (@character_id, 1)
         ON CONFLICT (character_id)
-        DO UPDATE SET reset_count = reset_count + 1;
+        DO UPDATE SET reset_count = ddon_bbm_reset_gg.reset_count + 1;
     ";
     private readonly string SqlResetBBMGGReset = "DELETE FROM \"ddon_bbm_reset_gg\";";
     private readonly string SqlSelectBBMGGReset = "SELECT reset_count FROM \"ddon_bbm_reset_gg\" WHERE \"character_id\"=@character_id;";

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemGetEmblemListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemGetEmblemListHandler.cs
@@ -4,6 +4,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -25,7 +26,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 foreach (var uid in emblemData.UIDs)
                 {
-                    var item = client.Character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, uid).Item2.Item2;
+                    var item = client.Character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, uid)?.Item2.Item2;
+
+                    if (item is null)
+                    {
+                        continue;
+                    }
+
                     result.JobEmblemList.Add(new CDataJobEmblem()
                     {
                         Job = jobId,
@@ -42,46 +49,44 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             }
 
-            result.EmblemSettings.LevelingDataList = Server.GameSettings.EmblemSettings.LevelingData
+            result.EmblemSettings.LevelingDataList = [.. Server.GameSettings.EmblemSettings.LevelingData
                 .Select(x => new CDataJobEmblemLevelData()
                 {
                     Level = x.Level,
                     PPAmount = x.PPCost,
                     EPGain = x.EP,
-                }).ToList();
+                })];
 
-            result.EmblemSettings.StatCostList = Server.GameSettings.EmblemSettings.StatUpgradeCost
+            result.EmblemSettings.StatCostList = [.. Server.GameSettings.EmblemSettings.StatUpgradeCost
                 .Select(x => new CDataJobEmblemStatCostData()
                 {
                     StatLevel = x.Level,
                     EPAmount = x.EPAmount,
-                }).ToList();
+                })];
 
             result.EmblemSettings.StatUpgradeDataList = Server.ScriptManager.JobEmblemStatModule.GetData();
 
-            result.EmblemSettings.CrestSlotRestrictionList = Server.GameSettings.EmblemSettings.InheritanceUnlockLevels
+            result.EmblemSettings.CrestSlotRestrictionList = [.. Server.GameSettings.EmblemSettings.InheritanceUnlockLevels
                 .OrderBy(x => x.UnlockLevel)
                 .Select(x => new CDataJobEmblemSlotRestriction()
                 {
                     LevelUnlocked = x.UnlockLevel,
-                })
-                .ToList();
+                })];
 
-            result.EmblemSettings.EmblemCrestInheritanceBaseChanceList = Server.GameSettings.EmblemSettings.InheritanceUnlockLevels
+            result.EmblemSettings.EmblemCrestInheritanceBaseChanceList = [.. Server.GameSettings.EmblemSettings.InheritanceUnlockLevels
                 .Select((x, index) => new CDataJobEmblemCrestInheritanceBaseChance()
                 {
                     Slot = (byte)index,
                     BaseChanceAmount = x.BaseChance
-                })
-                .ToList();
+                })];
 
-            result.EmblemSettings.InheritanceIncreaseChanceItemList = Server.GameSettings.EmblemSettings.InheritanceChanceIncreaseItems
+            result.EmblemSettings.InheritanceIncreaseChanceItemList = [.. Server.GameSettings.EmblemSettings.InheritanceChanceIncreaseItems
                 .Select(x => new CDataJobEmblemInhertianceIncreaseChanceItem()
                 {
                     ItemId = x.ItemId,
                     AmountConsumed = x.AmountConsumed,
                     PercentIncrease = x.PercentIncrease,
-                }).ToList();
+                })];
 
 
             result.EmblemSettings.EmblemPointResetGGCostList = new()

--- a/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/JobEmblemUpdateParamLevelHandler.cs
@@ -42,7 +42,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 (StorageType storageType, Tuple<ushort, Item, uint> itemProps) = client.Character.Storage.FindItemByUIdInStorage(ItemManager.EquipmentStorages, uid);
                 var (slotNo, item, amount) = itemProps;
 
-                updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(client.Character, item, storageType, slotNo, 0, 0));
                 item.EquipStatParamList = Server.JobEmblemManager.GetEquipStatParamList(emblemData);
                 updateCharacterItemNtc.UpdateItemList.Add(Server.ItemManager.CreateItemUpdateResult(client.Character, item, storageType, slotNo, 1, 1));
             }

--- a/Arrowgene.Ddon.Shared/Files/Assets/ClientErrorCodes.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/ClientErrorCodes.json
@@ -4,6 +4,10 @@
         "en": "An internal server error has occured."
     },
     {
+        "code": "ERROR_CODE_DB_FAILURE",
+        "en": "An internal database error has occured; you will be disconnected."
+    },
+    {
         "code": "ERROR_CODE_NOT_IMPLEMENTED",
         "en": "This feature is not yet implemented."
     },


### PR DESCRIPTION
* Fix issue where using GG to reset BBM would cause an error on Postgres builds.
* Fix issue where attempting to discard a job emblem immediately after upgrading it would throw an error.
* Fix issue where attempting to upgrade a job emblem immediately after restoring it would throw an error.
* Add plaintext error for ERROR_CODE_DB_FAILURE denoting that it will disconnect the offending player.

# Checklist:
- [ ] The project compiles
- [ ] The PR targets `develop` branch
