### PR TITLE
Replace Console.ReadKey with Console.Read

### DIFF
--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -145,13 +145,23 @@ namespace Arrowgene.Ddon.Cli
             ShowCopyright();
             CommandResultType result = ProcessArguments(parameter);
 
-            if (result != CommandResultType.Exit)
+            /*if (result != CommandResultType.Exit)
             {
                 Logger.Info("Press `e'-key to exit.");
                 ConsoleKeyInfo keyInfo = Console.ReadKey();
                 while (keyInfo.Key != ConsoleKey.E)
                 {
                     keyInfo = Console.ReadKey();
+                }
+            }*/
+
+            if (result != CommandResultType.Exit)
+            {
+                Logger.Info("Press 'e' to exit.");
+                int input = Console.Read();
+                while (char.ToLower((char)input) != 'e')
+                {
+                    input = Console.Read();
                 }
             }
 

--- a/Arrowgene.Ddon.Cli/Program.cs
+++ b/Arrowgene.Ddon.Cli/Program.cs
@@ -145,19 +145,9 @@ namespace Arrowgene.Ddon.Cli
             ShowCopyright();
             CommandResultType result = ProcessArguments(parameter);
 
-            /*if (result != CommandResultType.Exit)
-            {
-                Logger.Info("Press `e'-key to exit.");
-                ConsoleKeyInfo keyInfo = Console.ReadKey();
-                while (keyInfo.Key != ConsoleKey.E)
-                {
-                    keyInfo = Console.ReadKey();
-                }
-            }*/
-
             if (result != CommandResultType.Exit)
             {
-                Logger.Info("Press 'e' to exit.");
+                Logger.Info("Type 'e' and press enter to exit.");
                 int input = Console.Read();
                 while (char.ToLower((char)input) != 'e')
                 {


### PR DESCRIPTION
I use a game hosting panel and the Arrowgene would crash as soon as it was done booting up. The issue was the panel couldn't interact with the press `e' key so I replaced the Console.ReadKey with Console.Read. I tested on a windows machine and the hosting panel and game has been working with the only difference of typing 'e' and pressing enter now. Hope you may consider this change.

# Checklist:
- [yes] The project compiles
- [yes] The PR targets `develop` branch
