### PR TITLE
World Quests Update

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/!BROKEN!q20990002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/!BROKEN!q20990002.json
@@ -26,14 +26,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Gleipnir",
           "item_id": 7959,
           "num": 1
         },
         {
+          "comment": "Strong Gala Extract",
           "item_id": 9363,
           "num": 3
         },
         {
+          "comment": "Panacea",
           "item_id": 41,
           "num": 1
         }
@@ -53,11 +56,19 @@
         "layer_no": 1
       },
       "npc_id": "Actaeon",
-      "message_id": 11372
+      "message_id": 13625
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 2300, 
+          "Param2": 13264,
+          "comment": "Idle dialogue"
+        }
+      ],
       "stage_id": {
         "id": 84,
         "group_id": 1,
@@ -539,7 +550,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Actaeon",
-      "message_id": 11842
+      "message_id": 13261
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
@@ -7,7 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
-  "news_image":  8,
+  "news_image": 8,
   "rewards": [
     {
       "type": "exp",
@@ -50,62 +50,51 @@
         "id": 85,
         "group_id": 7
       },
+      "starting_index": 7,
       "enemies": [
         {
-          "comment": "Skeleton Sorc",
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
+          "start_think_tbl_no": 1,
           "level": 21,
-          "exp": 510
+          "exp": 106
         },
         {
-          "comment": "Skeleton Knight",
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Skeleton Knight",
-          "enemy_id": "0x010301",
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Skeleton Knight",
-          "enemy_id": "0x010301",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Skeleton Knight",
-          "enemy_id": "0x010301",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Skeleton Knight",
-          "enemy_id": "0x010301",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
           "level": 21,
-          "exp": 510
+          "exp": 106
+        },
+        {
+          "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 18,
+          "exp": 85,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 18,
+          "exp": 85
+        },
+        {
+          "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 18,
+          "exp": 85,
+          "repop_count": 1,
+          "repop_wait_second": 5
         }
       ]
     }
@@ -119,7 +108,7 @@
         "layer_no": 1
       },
       "npc_id": "Gordon",
-      "message_id": 8620,
+      "message_id": 8619,
       "flags": [
         {
           "type": "QstLayout",
@@ -131,6 +120,14 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1309,
+          "Param2": 8625
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -148,8 +145,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gordon",
-      "message_id": 8623
+      "message_id": 8622
     }
   ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000_1.json
@@ -1,13 +1,13 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Calamity at the Cathedral Ruins",
+  "comment": "A Calamity at the Cathedral Ruins (II)",
   "quest_id": 20000000,
   "base_level": 25,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
-  "news_image":  8,
+  "news_image": 8,
   "variant_index": 1,
   "rewards": [
     {
@@ -28,19 +28,19 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Iron Ingot",
-          "item_id": 7874,
+          "comment": "Drilled Plate Sheet",
+          "item_id": 7881,
           "num": 1
         },
         {
-          "comment": "Superior Healing Potion",
-          "item_id": 35,
-          "num": 3
+          "comment": "Healing Elixir",
+          "item_id": 7552,
+          "num": 2
         },
         {
-          "comment": "Throwing Rock",
-          "item_id": 9396,
-          "num": 2
+          "comment": "Concoction of Light",
+          "item_id": 9376,
+          "num": 3
         }
       ]
     }
@@ -51,67 +51,46 @@
         "id": 85,
         "group_id": 7
       },
+      "starting_index": 7,
       "enemies": [
         {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 23,
-          "exp": 604
-        },
-        {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 23,
-          "exp": 604
-        },
-        {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 23,
-          "exp": 604
-        },
-        {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 23,
-          "is_manual_set": true,
-          "exp": 604
-        },
-        {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 23,
-          "is_manual_set": true,
-          "exp": 604
-        },
-        {
-          "comment": "Skeleton Sorc",
-          "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 23,
-          "is_manual_set": true,
-          "exp": 604
-        },
-        {
-          "comment": "Wight",
+          "comment": "Vigilant Wight",
           "enemy_id": "0x015600",
+          "named_enemy_params_id": 53,
           "start_think_tbl_no": 2,
-          "named_enemy_params_id": 54,
           "level": 25,
-          "is_boss": true,
-          "is_manual_set": false,
-          "exp": 1336
+          "exp": 1430,
+          "is_boss": true
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "level": 23,
+          "exp": 113,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "level": 23,
+          "exp": 113,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "level": 23,
+          "exp": 113,
+          "is_required": false,
+          "is_manual_set": true
         }
       ]
     }
@@ -125,7 +104,7 @@
         "layer_no": 1
       },
       "npc_id": "Gordon",
-      "message_id": 8620,
+      "message_id": 8619,
       "flags": [
         {
           "type": "QstLayout",
@@ -137,6 +116,14 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1309,
+          "Param2": 8625
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -154,8 +141,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gordon",
-      "message_id": 8623
+      "message_id": 8622
     }
   ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001.json
@@ -3,7 +3,7 @@
   "type": "World",
   "comment": "The Woes of A Merchant",
   "quest_id": 20000001,
-  "base_level": 8,
+  "base_level": 7,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
@@ -12,7 +12,7 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 400
+      "amount": 190
     },
     {
       "type": "wallet",
@@ -21,18 +21,20 @@
     },
     {
       "type": "exp",
-      "amount": 260
+      "amount": 230
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 426,
+          "comment": "Green Grass Ring",
+          "item_id": 8928,
           "num": 1
         },
         {
-          "item_id": 34,
-          "num": 2
+          "comment": "Leather Bracelet",
+          "item_id": 8929,
+          "num": 1
         }
       ]
     }
@@ -64,10 +66,19 @@
       },
       "npc_id": "Peddler",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 509,
+          "Param2": 10742
+        }
+      ],
       "items": [
         {
-          "id": 8928,
-          "amount": 2
+          "comment": "Leather Bracelet",
+          "id": 8929,
+          "amount": 1
         }
       ],
       "message_id": 10737

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001_1.json
@@ -1,0 +1,88 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Woes of A Merchant (II)",
+  "quest_id": 20000001,
+  "base_level": 8,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 10,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 400
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 20
+    },
+    {
+      "type": "exp",
+      "amount": 260
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Hide Armor",
+          "item_id": 426,
+          "num": 1
+        },
+        {
+          "comment": "Healing Potion",
+          "item_id": 34,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 25,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Peddler",
+      "message_id": 10734,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 985
+        }
+      ]
+    },
+    {
+      "type": "NewDeliverItems",
+      "stage_id": {
+        "id": 25,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Peddler",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 509,
+          "Param2": 10742
+        }
+      ],
+      "items": [
+        {
+          "comment": "Green Grass Ring",
+          "id": 8928,
+          "amount": 2
+        }
+      ],
+      "message_id": 10737
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001_2.json
@@ -1,0 +1,93 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Woes of A Merchant (III)",
+  "quest_id": 20000001,
+  "base_level": 12,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 10,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 600
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 30
+    },
+    {
+      "type": "exp",
+      "amount": 390
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mighty Gloves",
+          "item_id": 969,
+          "num": 1
+        },
+        {
+          "comment": "Healing Potion",
+          "item_id": 34,
+          "num": 3
+        },
+        {
+          "comment": "Gala Extract",
+          "item_id": 36,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 25,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Peddler",
+      "message_id": 10734,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 985
+        }
+      ]
+    },
+    {
+      "type": "NewDeliverItems",
+      "stage_id": {
+        "id": 25,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Peddler",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 509,
+          "Param2": 10742
+        }
+      ],
+      "items": [
+        {
+          "comment": "Green Grass Ring",
+          "id": 8928,
+          "amount": 3
+        }
+      ],
+      "message_id": 10737
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000001_3.json
@@ -1,0 +1,93 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Woes of A Merchant (IV)",
+  "quest_id": 20000001,
+  "base_level": 16,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 10,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 700
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 50
+    },
+    {
+      "type": "exp",
+      "amount": 520
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Poison",
+          "item_id": 9239,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Potion",
+          "item_id": 35,
+          "num": 2
+        },
+        {
+          "comment": "Lockpick",
+          "item_id": 59,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 25,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Peddler",
+      "message_id": 10734,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 985
+        }
+      ]
+    },
+    {
+      "type": "NewDeliverItems",
+      "stage_id": {
+        "id": 25,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Peddler",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 509,
+          "Param2": 10742
+        }
+      ],
+      "items": [
+        {
+          "comment": "Amethyst Pendant",
+          "id": 8978,
+          "amount": 2
+        }
+      ],
+      "message_id": 10737
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Combat Bottoms", 
           "item_id": 963,
           "num": 1
         },
         {
+          "comment": "Gala Extract",
           "item_id": 36,
           "num": 3
         }
@@ -49,7 +51,7 @@
             "layer_no": 1
           },
           "npc_id": "WhiteKnight0",
-          "message_id": 8629,
+          "message_id": 8627,
           "flags": [
             {
               "type": "QstLayout",
@@ -61,6 +63,14 @@
         {
           "type": "MyQstFlags",
           "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 504,
+              "Param2": 8634
+            }
+          ],
           "set_flags": [ 6 ],
           "check_flags": [ 1, 2, 3, 4, 5 ]
         },
@@ -72,7 +82,7 @@
             "layer_no": 1
           },
           "npc_id": "WhiteKnight0",
-          "message_id": 8633
+          "message_id": 8631
         }
       ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002_1.json
@@ -1,0 +1,262 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Transporter's Tragedy (II)",
+  "quest_id": 20000002,
+  "base_level": 12,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 5,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 470
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 470
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 40
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Noble Greaves", 
+          "item_id": 480,
+          "num": 1
+        },
+        {
+          "comment": "Superior Gala Extract",
+          "item_id": 61,
+          "num": 2
+        },
+        {
+          "comment": "Lumber Knife",
+          "item_id": 58,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "comment": "process 0",
+      "blocks": [
+        {
+          "type": "NewNpcTalkAndOrder",
+          "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "npc_id": "WhiteKnight0",
+          "message_id": 8627,
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 986
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 504,
+              "Param2": 8634
+            }
+          ],
+          "set_flags": [ 6 ],
+          "check_flags": [ 1, 2, 3, 4, 5 ]
+        },
+        {
+          "type": "NewTalkToNpc",
+          "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "npc_id": "WhiteKnight0",
+          "message_id": 8631
+        }
+      ]
+    },
+    {
+      "comment": "process 1",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 25
+          },
+          "npc_id": "Bob",
+          "message_id": 8630
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 1 ]
+        }
+      ]
+    },
+    {
+      "comment": "process 2",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 2,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1125
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1125
+            }
+          ],
+          "set_flags": [ 2 ]
+        }
+      ]
+    },
+    {
+      "comment": "process 3",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 3,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1126
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 3 ],
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1126
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "comment": "process 4",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 4,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1127
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 4 ],
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1127
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "comment": "process 5",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 5,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1128
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 5 ],
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1128
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000002_2.json
@@ -1,0 +1,262 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Transporter's Tragedy (III)",
+  "quest_id": 20000002,
+  "base_level": 14,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 5,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 550
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 690
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 50
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gaudy Greaves", 
+          "item_id": 433,
+          "num": 1
+        },
+        {
+          "comment": "Purifying Decoction",
+          "item_id": 9372,
+          "num": 2
+        },
+        {
+          "comment": "Pickaxe",
+          "item_id": 57,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "comment": "process 0",
+      "blocks": [
+        {
+          "type": "NewNpcTalkAndOrder",
+          "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "npc_id": "WhiteKnight0",
+          "message_id": 8627,
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 986
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 504,
+              "Param2": 8634
+            }
+          ],
+          "set_flags": [ 6 ],
+          "check_flags": [ 1, 2, 3, 4, 5 ]
+        },
+        {
+          "type": "NewTalkToNpc",
+          "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "npc_id": "WhiteKnight0",
+          "message_id": 8631
+        }
+      ]
+    },
+    {
+      "comment": "process 1",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 25
+          },
+          "npc_id": "Bob",
+          "message_id": 8630
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 1 ]
+        }
+      ]
+    },
+    {
+      "comment": "process 2",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 2,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1125
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1125
+            }
+          ],
+          "set_flags": [ 2 ]
+        }
+      ]
+    },
+    {
+      "comment": "process 3",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 3,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1126
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 3 ],
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1126
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "comment": "process 4",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 4,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1127
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 4 ],
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1127
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "comment": "process 5",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 6 ]
+        },
+        {
+          "type": "CollectItem",
+          "stage_id": {
+            "id": 1,
+            "group_id": 5,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1128
+            }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 5 ],
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Clear",
+              "value": 1128
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000003.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Apprentice's Coat",
           "item_id": 458,
           "num": 1
         },
         {
+          "comment": "Gala Extract",
           "item_id": 36,
           "num": 2
         }
@@ -53,6 +55,14 @@
         {
           "type": "MyQstFlags",
           "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 3,
+              "Param2": 10732
+            }
+          ],
           "set_flags": [ 9 ],
           "check_flags": [ 1, 2, 3, 4, 5, 6, 7, 8 ]
         },
@@ -68,6 +78,14 @@
         {
           "type": "TalkToNpc",
           "announce_type": "Update",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 3,
+              "Param2": 10732
+            }
+          ],
           "stage_id": {
             "id": 66,
             "group_id": 0

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004.json
@@ -45,70 +45,53 @@
         "id": 88,
         "group_id": 5
       },
+      "starting_index": 2,
       "enemies": [
         {
-          "comment": "Undead (Male)",
+          "comment": "Vigilant Undead (Male)",
           "enemy_id": "0x010500",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 13,
-          "exp": 214
+          "exp": 50,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
-          "comment": "Undead (Male)",
-          "enemy_id": "0x010500",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 53,
-          "level": 13,
-          "exp": 214
-        },
-        {
-          "comment": "Undead (Male)",
-          "enemy_id": "0x010501",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 53,
-          "level": 13,
-          "exp": 214
-        },
-        {
-          "comment": "Undead (Male)",
-          "enemy_id": "0x010501",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 13,
-          "exp": 214
-        },
-        {
-          "comment": "Undead (Male)",
+          "comment": "Vigilant Undead (Male)",
           "enemy_id": "0x010500",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 13,
-          "exp": 214
+          "exp": 50,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
-          "comment": "Undead (Male)",
+          "comment": "Vigilant Undead (Male)",
           "enemy_id": "0x010500",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 13,
-          "exp": 214
+          "exp": 50,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
-          "comment": "Undead (Male)",
-          "enemy_id": "0x010501",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 13,
-          "exp": 214
-        },
-        {
-          "comment": "Undead (Male)",
+          "comment": "Vigilant Undead (Male)",
           "enemy_id": "0x010500",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 13,
-          "exp": 214
+          "exp": 50
+        },
+        {
+          "comment": "Vigilant Undead (Male)",
+          "enemy_id": "0x010500",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 13,
+          "exp": 50
         }
       ]
     }
@@ -125,6 +108,14 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4,
+          "Param2": 10720
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -140,7 +131,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Joseph",
-      "message_id": 10718
+      "message_id": 10717
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Petition to Rid of Demons in Ruins",
+  "comment": "A Petition to Rid of Demons in Ruins (II)",
   "quest_id": 20000004,
   "base_level": 16,
   "minimum_item_rank": 0,
@@ -33,13 +33,14 @@
           "num": 3
         },
         {
-          "comment": "Recovery Decoction",
-          "item_id": 9373,
+          "comment": "Poison Flask",
+          "item_id": 9395,
           "num": 2
         },
         {
+          "comment": "Lantern Kindling",
           "item_id": 55,
-          "num": 2
+          "num": 3
       }
       ]
     }
@@ -50,69 +51,52 @@
         "id": 88,
         "group_id": 5
       },
+      "starting_index": 2,
       "enemies": [
         {
+          "comment": "Vigilant Skeleton",
           "enemy_id": "0x010300",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 54,
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 310
+          "exp": 60,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
+          "comment": "Vigilant Skeleton",
           "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 310
+          "exp": 60,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
+          "comment": "Vigilant Skeleton",
           "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 310
+          "exp": 60,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
+          "comment": "Vigilant Skeleton",
           "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 310
+          "exp": 60,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
+          "comment": "Vigilant Skeleton",
           "enemy_id": "0x010300",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 54,
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 310
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 54,
-          "level": 16,
-          "exp": 310
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 16,
-          "exp": 310
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 54,
-          "level": 16,
-          "exp": 310
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 16,
-          "exp": 310
+          "exp": 60,
+          "repop_count": 1,
+          "repop_wait_second": 5
         }
       ]
     }
@@ -129,6 +113,14 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4,
+          "Param2": 10720
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -144,7 +136,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Joseph",
-      "message_id": 10718
+      "message_id": 10717
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000004_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Petition to Rid of Demons in Ruins",
+  "comment": "A Petition to Rid of Demons in Ruins (III)",
   "quest_id": 20000004,
   "base_level": 55,
   "minimum_item_rank": 0,
@@ -28,17 +28,18 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Dull Iron Ingot",
+          "comment": "Sand of Reminiscence",
           "item_id": 9441,
-          "num": 2
+          "num": 1
         },
         {
-          "comment": "Recovery Decoction",
+          "comment": "Demonic Gem",
           "item_id": 7911,
           "num": 2
         },
         {
-          "item_id": 55,
+          "comment": "Cracked Black Horn",
+          "item_id": 7753,
           "num": 2
       }
       ]
@@ -50,76 +51,52 @@
         "id": 88,
         "group_id": 5
       },
+      "starting_index": 2,
       "enemies": [
         {
+          "comment": "Dangerous Shadow Goblin",
           "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 55,
-          "exp": 6476
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_time": 10
         },
         {
+          "comment": "Dangerous Shadow Goblin",
           "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 55,
-          "exp": 6476
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_time": 10
         },
         {
+          "comment": "Dangerous Shadow Goblin",
           "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 55,
-          "exp": 6476
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_time": 10
         },
         {
+          "comment": "Dangerous Shadow Goblin",
           "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 55,
-          "exp": 6476
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_time": 10
         },
         {
+          "comment": "Dangerous Shadow Goblin",
           "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 55,
-          "exp": 6476
-        },
-        {
-          "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 55,
-          "exp": 6476
-        },
-        {
-          "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 55,
-          "exp": 6476
-        },
-        {
-          "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 55,
-          "exp": 6476
-        },
-        {
-          "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 55,
-          "exp": 6476
-        },
-        {
-          "enemy_id": "0x011130",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 55,
-          "exp": 6476
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_time": 10
         }
       ]
     }
@@ -136,6 +113,14 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4,
+          "Param2": 10720
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -151,7 +136,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Joseph",
-      "message_id": 10718
+      "message_id": 10717
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
@@ -45,45 +45,49 @@
         "id": 146,
         "group_id": 8
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "comment": "Alchemized Goblin Fighter",
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 87
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 87
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 87
+        },
+        {
+          "comment": "Vigilant Alchemized Goblin Fighter",
           "enemy_id": "0x011121",
           "named_enemy_params_id": 53,
           "level": 18,
-          "exp": 384
+          "exp": 85
         },
         {
-          "comment": "Alchemized Goblin Fighter",
+          "comment": "Vigilant Alchemized Goblin Fighter",
           "enemy_id": "0x011121",
           "named_enemy_params_id": 53,
           "level": 18,
-          "exp": 384
+          "exp": 85
         },
         {
-          "comment": "Alchemized Goblin Fighter",
+          "comment": "Vigilant Alchemized Goblin Fighter",
           "enemy_id": "0x011121",
           "named_enemy_params_id": 53,
           "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Alchemized Wolf",
-          "enemy_id": "0x010207",
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Alchemized Wolf",
-          "enemy_id": "0x010207",
-          "level": 18,
-          "exp": 384
-        },
-        {
-          "comment": "Alchemized Wolf",
-          "enemy_id": "0x010207",
-          "level": 18,
-          "exp": 384
+          "exp": 85
         }
       ]
     }
@@ -109,7 +113,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 519,
+          "Param2": 10764
+        }
+      ]
     },
     {
       "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_1.json
@@ -1,0 +1,150 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Mysterious Monolith (II)",
+  "quest_id": 20000005,
+  "base_level": 20,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 555,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 920
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 660
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 70
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Executioner's Mask",
+          "item_id": 9539,
+          "num": 1
+        },
+        {
+          "comment": "Fortifier",
+          "item_id": 9377,
+          "num": 2
+        },
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 146,
+        "group_id": 8
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 95
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 95
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 95
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 95
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 95
+        },
+        {
+          "comment": "Vigilant Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 95
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Freya",
+      "message_id": 10756,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 987
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 519,
+          "Param2": 10764
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Freya",
+      "message_id": 10759
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_2.json
@@ -1,0 +1,153 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Mysterious Monolith (III)",
+  "quest_id": 20000005,
+  "base_level": 23,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 555,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 750
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 750
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mysterious Gold Lump",
+          "item_id": 8378,
+          "num": 3
+        },
+        {
+          "comment": "Quality Gala Extract",
+          "item_id": 61,
+          "num": 2
+        },
+        {
+          "comment": "Throwing Rock",
+          "item_id": 61,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 146,
+        "group_id": 8
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Alchemized Skeleton",
+          "enemy_id": "0x010302",
+          "named_enemy_params_id": 54,
+          "level": 23,
+          "exp": 270
+        },
+        {
+          "comment": "Brutal Alchemized Skeleton",
+          "enemy_id": "0x010302",
+          "named_enemy_params_id": 54,
+          "level": 23,
+          "exp": 270
+        },
+        {
+          "comment": "Brutal Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 54,
+          "level": 23,
+          "exp": 107,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Brutal Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 54,
+          "level": 23,
+          "exp": 107,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Brutal Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 54,
+          "level": 23,
+          "exp": 107
+        },
+        {
+          "comment": "Brutal Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "named_enemy_params_id": 54,
+          "level": 23,
+          "exp": 107
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Freya",
+      "message_id": 10756,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 987
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 519,
+          "Param2": 10764
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Freya",
+      "message_id": 10759
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_3.json
@@ -1,0 +1,156 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Mysterious Monolith (IV)",
+  "quest_id": 20000005,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 555,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1840
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1840
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Rainbow Eye Gem",
+          "item_id": 7731,
+          "num": 1
+        },
+        {
+          "comment": "Alkahest",
+          "item_id": 7833,
+          "num": 2
+        },
+        {
+          "comment": "Drilled Ore",
+          "item_id": 7863,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 146,
+        "group_id": 8
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Dangerous Alchemy Eye",
+          "enemy_id": "0x015420",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 400,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Alchemy Eye",
+          "enemy_id": "0x015420",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 400,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Alchemy Eye",
+          "enemy_id": "0x015420",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 400
+        },
+        {
+          "comment": "Dangerous Alchemized Skeleton",
+          "enemy_id": "0x011121",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 520,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Alchemized Skeleton",
+          "enemy_id": "0x011121",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 520
+        },
+        {
+          "comment": "Dangerous Alchemized Skeleton",
+          "enemy_id": "0x011121",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 520
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Freya",
+      "message_id": 10756,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 987
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 519,
+          "Param2": 10764
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Freya",
+      "message_id": 10759
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
@@ -21,7 +21,7 @@
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 130
+      "amount": 190
     },
     {
       "type": "select",
@@ -50,54 +50,61 @@
         "id": 238,
         "group_id": 9
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "comment": "Wight",
+          "comment": "Brutal Wight",
           "enemy_id": "0x015600",
           "named_enemy_params_id": 54,
-          "level": 30,
           "start_think_tbl_no": 2,
-          "is_boss": true,
-          "is_manual_set": false,
-          "exp": 5446
+          "level": 30,
+          "exp": 1664,
+          "is_boss": true
         },
         {
-          "comment": "Stout Undead",
-          "enemy_id": "0x010502",
-          "is_manual_set": true,
-          "level": 28,
-          "exp": 874
-        },
-        {
-          "comment": "Wight",
+          "comment": "Brutal Wight",
           "enemy_id": "0x015600",
           "named_enemy_params_id": 54,
-          "level": 30,
           "start_think_tbl_no": 2,
-          "is_boss": true,
-          "is_manual_set": false,
-          "exp": 5446
+          "level": 30,
+          "exp": 1664,
+          "is_boss": true
         },
         {
           "comment": "Stout Undead",
           "enemy_id": "0x010502",
-          "is_manual_set": true,
+          "start_think_tbl_no": 8,
           "level": 28,
-          "exp": 874
+          "exp": 134,
+          "is_required": false,
+          "is_manual_set": true
         },
         {
           "comment": "Stout Undead",
           "enemy_id": "0x010502",
-          "is_manual_set": true,
+          "start_think_tbl_no": 8,
           "level": 28,
-          "exp": 874
+          "exp": 134,
+          "is_required": false,
+          "is_manual_set": true
         },
         {
           "comment": "Stout Undead",
           "enemy_id": "0x010502",
-          "is_manual_set": true,
+          "start_think_tbl_no": 8,
           "level": 28,
-          "exp": 874
+          "exp": 134,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Stout Undead",
+          "enemy_id": "0x010502",
+          "start_think_tbl_no": 8,
+          "level": 28,
+          "exp": 134,
+          "is_required": false,
+          "is_manual_set": true
         }
       ]
     }
@@ -111,7 +118,7 @@
         "layer_no": 1
       },
       "npc_id": "Christoph",
-      "message_id": 11011,
+      "message_id": 11010,
       "flags": [
         {
           "type": "QstLayout",
@@ -123,7 +130,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 513,
+          "Param2": 11016
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -140,7 +155,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Christoph",
-      "message_id": 11014
+      "message_id": 11013
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Evil Lurking in the Tombs",
+  "comment": "The Evil Lurking in the Tombs (II)",
   "quest_id": 20000006,
   "base_level": 34,
   "minimum_item_rank": 0,
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "fire proved crest",
+          "comment": "Crest of Burn Warding",
           "item_id": 9314,
           "num": 1
         },
         {
-          "comment": "Healing Elixir",
+          "comment": "Superior Healing Elixir",
           "item_id": 7553,
-          "num": 3
+          "num": 2
         },
         {
-          "comment": "Sprite's Amulet",
+          "comment": "Conqueror's Amulet",
           "item_id": 9381,
           "num": 2
         }
@@ -51,16 +51,15 @@
         "id": 238,
         "group_id": 9
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "comment": "Chim",
+          "comment": "Brutal Chimera",
           "enemy_id": "0x015200",
-          "named_enemy_params_id": 556,
+          "named_enemy_params_id": 54,
           "level": 34,
-          "start_think_tbl_no": 1,
-          "is_boss": true,
-          "is_manual_set": false,
-          "exp": 5834
+          "exp": 3240,
+          "is_boss": true
         }
       ]
     }
@@ -74,7 +73,7 @@
         "layer_no": 1
       },
       "npc_id": "Christoph",
-      "message_id": 11011,
+      "message_id": 11010,
       "flags": [
         {
           "type": "QstLayout",
@@ -86,7 +85,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 513,
+          "Param2": 11016
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -103,7 +110,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Christoph",
-      "message_id": 11014
+      "message_id": 11013
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Evil Lurking in the Tombs",
+  "comment": "The Evil Lurking in the Tombs (III)",
   "quest_id": 20000006,
   "base_level": 58,
   "minimum_item_rank": 0,
@@ -22,23 +22,23 @@
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 1340
+      "amount": 190
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "spirit crys",
+          "comment": "Spirit Crystal",
           "item_id": 7909,
           "num": 1
         },
         {
-          "comment": "ancient emblem",
+          "comment": "Ancient Knight's Emblem",
           "item_id": 8021,
           "num": 1
         },
         {
-          "comment": "sinister cloth",
+          "comment": "Sinister Black Cloth",
           "item_id": 7947,
           "num": 1
         }
@@ -51,46 +51,36 @@
         "id": 238,
         "group_id": 9
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "comment": "DK",
+          "comment": "Dangerous Death Knight",
           "enemy_id": "0x010310",
-          "named_enemy_params_id": 551,
+          "named_enemy_params_id": 56,
           "level": 58,
-          "start_think_tbl_no": 1,
-          "is_boss": true,
-          "is_manual_set": false,
-          "exp": 26700
+          "exp": 1660,
+          "is_boss": true
         },
         {
-          "comment": "livin rmor",
+          "comment": "Dangerous Living Armor",
           "enemy_id": "0x010306",
-          "named_enemy_params_id": 551,
+          "named_enemy_params_id": 56,
           "level": 57,
-          "start_think_tbl_no": 1,
-          "is_boss": false,
-          "is_manual_set": false,
-          "exp": 6706
+          "exp": 1148
         },
         {
-          "comment": "livin rmor",
+          "comment": "Dangerous Living Armor",
           "enemy_id": "0x010306",
-          "named_enemy_params_id": 551,
+          "named_enemy_params_id": 56,
           "level": 57,
-          "start_think_tbl_no": 1,
-          "is_boss": false,
-          "is_manual_set": false,
-          "exp": 6706
+          "exp": 1148
         },
         {
-          "comment": "livin rmor",
+          "comment": "Dangerous Living Armor",
           "enemy_id": "0x010306",
-          "named_enemy_params_id": 551,
+          "named_enemy_params_id": 56,
           "level": 57,
-          "start_think_tbl_no": 1,
-          "is_boss": false,
-          "is_manual_set": false,
-          "exp": 6706
+          "exp": 1148
         }
       ]
     }
@@ -116,7 +106,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 513,
+          "Param2": 11016
+        }
+      ]
     },
     {
       "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_3.json
@@ -1,0 +1,150 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Evil Lurking in the Tombs (Twelve Calamities)",
+  "quest_id": 20000006,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 541,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5080
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Dismantling II",
+          "item_id": 9230,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Exorcism",
+          "item_id": 9227,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 238,
+        "group_id": 9
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Impure Giant Demon (Geo Golem)",
+          "enemy_id": "0x015104",
+          "named_enemy_params_id": 527,
+          "start_think_tbl_no": 1,
+          "level": 55,
+          "exp": 4000,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Dangerous Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 56,
+          "repop_count": 2,
+          "repop_wait_second": 5,
+          "level": 55,
+          "exp": 235,
+          "index": 9
+        },
+        {
+          "comment": "Dangerous Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 56,
+          "repop_count": 2,
+          "repop_wait_second": 5,
+          "level": 55,
+          "exp": 235,
+          "index": 10
+        },
+        {
+          "comment": "Dangerous Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 56,
+          "repop_count": 2,
+          "repop_wait_second": 5,
+          "level": 55,
+          "exp": 235,
+          "index": 11
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Christoph",
+      "message_id": 11012,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 988
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 513,
+          "Param2": 11016
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Christoph",
+      "message_id": 11015
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_4.json
@@ -1,0 +1,162 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Evil Lurking in the Tombs (Twelve Calamities II)",
+  "quest_id": 20000006,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 541,
+  "variant_index": 4,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5220
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 310
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Unburdening (Armour)",
+          "item_id": 9286,
+          "num": 1
+        },
+        {
+          "comment": "Flame Crystal",
+          "item_id": 7913,
+          "num": 1
+        },
+        {
+          "comment": "High Quality Magick Medal",
+          "item_id": 7870,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 238,
+        "group_id": 9
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Great Demon Statue of Hellfire (Geo Golem)",
+          "enemy_id": "0x015104",
+          "named_enemy_params_id": 584,
+          "level": 60,
+          "exp": 4250,
+          "is_boss": true
+        },
+        {
+          "comment": "Sludge Puppet (Sludgeman)",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 551,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "level": 60,
+          "exp": 275
+        },
+        {
+          "comment": "Sludge Puppet (Sludgeman)",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 551,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "level": 60,
+          "exp": 275
+        },
+        {
+          "comment": "Sludge Puppet (Sludgeman)",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 551,
+          "level": 60,
+          "exp": 275
+        },
+        {
+          "comment": "Sludge Puppet (Sludgeman)",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 551,
+          "level": 60,
+          "exp": 275
+        },
+        {
+          "comment": "Sludge Puppet (Sludgeman)",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 551,
+          "level": 60,
+          "exp": 275
+        },
+        {
+          "comment": "Sludge Puppet (Sludgeman)",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 551,
+          "level": 60,
+          "exp": 275
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Christoph",
+      "message_id": 11012,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 988
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 513,
+          "Param2": 11016
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Christoph",
+      "message_id": 11015
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Wind Cloak",
           "item_id": 9739,
           "num": 1
         },
         {
+          "comment": "Antidote",
           "item_id": 37,
           "num": 2
         }
@@ -44,26 +46,23 @@
         "id": 161,
         "group_id": 0
       },
+      "starting_index": 2,
       "enemies": [
         {
-          "enemy_id": "0x011002",
-          "level": 3,
-          "exp": 140,
-          "is_boss": false,
-          "hm_present_no": 47
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 9,
+          "exp": 55
         },
         {
-          "enemy_id": "0x011002",
-          "level": 3,
-          "exp": 140,
-          "is_boss": false,
-          "hm_present_no": 47
-        },
-        {
-          "enemy_id": "0x010200",
-          "level": 3,
-          "exp": 94,
-          "is_boss": false
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 9,
+          "exp": 55
         }
       ]
     },
@@ -73,20 +72,39 @@
         "id": 161,
         "group_id": 2
       },
+      "starting_index": 2,
       "enemies": [
         {
-          "enemy_id": "0x011002",
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
           "level": 9,
-          "exp": 140,
-          "is_boss": false,
-          "hm_present_no": 47
+          "exp": 55
         },
         {
-          "enemy_id": "0x011002",
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
           "level": 9,
-          "exp": 140,
-          "is_boss": false,
-          "hm_present_no": 47
+          "exp": 55
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 47,
+          "level": 9,
+          "exp": 55
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 47,
+          "level": 9,
+          "exp": 55
         }
       ]
     }
@@ -104,7 +122,15 @@
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1303,
+          "Param2": 10986
+        }
+      ]
     },
     {
       "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007_1.json
@@ -1,0 +1,164 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Crackdown on Store Vandals (II)",
+  "quest_id": 20000007,
+  "base_level": 12,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 9,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 470
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 390
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 40
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Rough Thread",
+          "item_id": 7952,
+          "num": 2
+        },
+        {
+          "comment": "Herb Salad",
+          "item_id": 9407,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 0",
+      "stage_id": {
+        "id": 161,
+        "group_id": 0
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 12,
+          "exp": 66
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 12,
+          "exp": 66
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 1",
+      "stage_id": {
+        "id": 161,
+        "group_id": 2
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 12,
+          "exp": 66
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 12,
+          "exp": 66
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 47,
+          "level": 12,
+          "exp": 66
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 47,
+          "level": 12,
+          "exp": 66
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 23,
+        "group_id": 0
+      },
+      "npc_id": "Eterna",
+      "message_id": 10980
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1303,
+          "Param2": 10986
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 23,
+        "group_id": 0
+      },
+      "announce_type": "Update",
+      "npc_id": "Eterna",
+      "message_id": 10983
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000007_2.json
@@ -1,0 +1,172 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Crackdown on Store Vandals (III)",
+  "quest_id": 20000007,
+  "base_level": 15,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 9,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 590
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 490
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 50
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Rough Thread",
+          "item_id": 7952,
+          "num": 2
+        },
+        {
+          "comment": "Mushroom Sauté",
+          "item_id": 1351,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 0",
+      "stage_id": {
+        "id": 161,
+        "group_id": 0
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 15,
+          "exp": 77,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 15,
+          "exp": 77,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        }
+      ]
+    },
+    {
+      "comment": "GroupId: 1",
+      "stage_id": {
+        "id": 161,
+        "group_id": 2
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 15,
+          "exp": 77,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 46,
+          "level": 15,
+          "exp": 77,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Mage",
+          "enemy_id": "0x011005",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 50,
+          "level": 15,
+          "exp": 77
+        },
+        {
+          "comment": "Vigilant Rogue Mage",
+          "enemy_id": "0x011005",
+          "named_enemy_params_id": 53,
+          "hm_present_no": 50,
+          "level": 15,
+          "exp": 77
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 23,
+        "group_id": 0
+      },
+      "npc_id": "Eterna",
+      "message_id": 10980
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1303,
+          "Param2": 10986
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 23,
+        "group_id": 0
+      },
+      "announce_type": "Update",
+      "npc_id": "Eterna",
+      "message_id": 10983
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008.json
@@ -45,41 +45,42 @@
         "id": 1,
         "group_id": 22
       },
+      "starting_index": 7,
       "enemies": [
         {
-          "comment": "Orc Soldier",
-          "enemy_id": "0x015800",
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160
-        },
-        {
-          "comment": "Orc Soldier",
-          "enemy_id": "0x015800",
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160
-        },
-        {
-          "comment": "Orc Banger",
+          "comment": "Vigilant Orc Vanguard",
           "enemy_id": "0x015802",
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160
+          "exp": 80
         },
         {
-          "comment": "Orc Soldier",
-          "enemy_id": "0x015800",
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160
-        },
-        {
-          "comment": "Orc Banger",
+          "comment": "Vigilant Orc Vanguard",
           "enemy_id": "0x015802",
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160
+          "exp": 80
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 11,
+          "exp": 80
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 11,
+          "exp": 80
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 11,
+          "exp": 80
         }
       ]
     },
@@ -88,41 +89,42 @@
         "id": 1,
         "group_id": 36
       },
+      "starting_index": 6,
       "enemies": [
         {
-          "comment": "Orc Soldier",
-          "enemy_id": "0x015800",
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160
-        },
-        {
-          "comment": "Orc Soldier",
-          "enemy_id": "0x015800",
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160
-        },
-        {
-          "comment": "Orc Banger",
+          "comment": "Vigilant Orc Vanguard",
           "enemy_id": "0x015802",
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160
+          "exp": 80
         },
         {
-          "comment": "Orc Banger",
+          "comment": "Vigilant Orc Vanguard",
           "enemy_id": "0x015802",
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160
+          "exp": 80
         },
         {
-          "comment": "Orc Soldier",
+          "comment": "Vigilant Orc Soldier",
           "enemy_id": "0x015800",
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160
+          "exp": 80
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 11,
+          "exp": 80
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 11,
+          "exp": 80
         }
       ]
     }
@@ -148,7 +150,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 531,
+          "Param2": 10823
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -176,7 +186,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier8",
-      "message_id": 10821
+      "message_id": 10820
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008_1.json
@@ -1,0 +1,206 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Raiding Orc Platoon (II)",
+  "quest_id": 20000008,
+  "base_level": 16,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 11,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 730
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 520
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 80
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Staff of Magickal Restraint",
+          "item_id": 85,
+          "num": 1
+        },
+        {
+          "comment": "Interventive",
+          "item_id": 9374,
+          "num": 2
+        },
+        {
+          "comment": "Purifying Decoction",
+          "item_id": 9374,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 22
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 36
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103
+        },
+        {
+          "comment": "Vigilant Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 103
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "ArisenCorpsRegimentalSoldier8",
+      "message_id": 10817,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 989
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 531,
+          "Param2": 10823
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "ArisenCorpsRegimentalSoldier8",
+      "message_id": 10820
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000008_2.json
@@ -1,0 +1,212 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Raiding Orc Platoon (III)",
+  "quest_id": 20000008,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 11,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1810
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1810
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Demon's Prized Liquor",
+          "item_id": 9443,
+          "num": 1
+        },
+        {
+          "comment": "Pigeon Blood",
+          "item_id": 7910,
+          "num": 1
+        },
+        {
+          "comment": "Orc Decoration",
+          "item_id": 8020,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 22
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Brutal Orc General",
+          "enemy_id": "0x015830",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 1505,
+          "is_boss": true
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 36
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Brutal Orc General",
+          "enemy_id": "0x015830",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 1505,
+          "is_boss": true
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Brutal Orc Blitzer",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 54,
+          "level": 55,
+          "exp": 304
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "ArisenCorpsRegimentalSoldier8",
+      "message_id": 10817,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 989
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 531,
+          "Param2": 10823
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "ArisenCorpsRegimentalSoldier8",
+      "message_id": 10820
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000009.json
@@ -3,7 +3,7 @@
   "type": "World",
   "comment": "Request For Medicine",
   "quest_id": 20000009,
-  "base_level": 8,
+  "base_level": 7,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
@@ -12,7 +12,7 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 350
+      "amount": 300
     },
     {
       "type": "wallet",
@@ -21,17 +21,19 @@
     },
     {
       "type": "exp",
-      "amount": 290
+      "amount": 260
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 478,
+          "comment": "Battle Greaves",
+          "item_id": 430,
           "num": 1
         },
         {
-          "item_id": 59,
+          "comment": "Pickaxe",
+          "item_id": 57,
           "num": 2
         }
       ]
@@ -45,7 +47,7 @@
         "group_id": 0
       },
       "npc_id": "Henry",
-      "message_id": 10924
+      "message_id": 10922
     },
     {
       "type": "TalkToNpc",
@@ -55,7 +57,15 @@
       },
       "announce_type": "Accept",
       "npc_id": "Vicelot",
-      "message_id": 10930
+      "message_id": 10930,
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1305,
+          "Param2": 10928
+        }
+      ]
     },
     {
       "type": "CollectItem",
@@ -92,6 +102,14 @@
           "action": "Set",
           "value": 1133
         }
+      ],
+      "result_commands": [
+        {
+          "comment": "Quest idle dialog",
+          "type": "QstTalkChg",
+          "Param1": 1006,
+          "Param2": 10932
+        }
       ]
     },
     {
@@ -119,7 +137,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Henry",
-      "message_id": 10927
+      "message_id": 10925
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000009_1.json
@@ -1,0 +1,144 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Request For Medicine (II)",
+  "quest_id": 20000009,
+  "base_level": 8,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 9,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 20
+    },
+    {
+      "type": "exp",
+      "amount": 290
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Entry Boots",
+          "item_id": 478,
+          "num": 1
+        },
+        {
+          "comment": "Lockpick",
+          "item_id": 59,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 0
+      },
+      "npc_id": "Henry",
+      "message_id": 10922
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 2,
+        "group_id": 1
+      },
+      "announce_type": "Accept",
+      "npc_id": "Vicelot",
+      "message_id": 10930,
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1305,
+          "Param2": 10928
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "stage_id": {
+        "id": 1,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 2216
+        }
+      ],
+      "result_commands": [
+        {
+          "comment": "Quest idle dialog",
+          "type": "QstTalkChg",
+          "Param1": 1006,
+          "Param2": 10932
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Clear",
+          "value": 2216
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1133
+        }
+      ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 2,
+        "group_id": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Clear",
+          "value": 1133
+        }
+      ],
+      "announce_type": "Update",
+      "npc_id": "Vicelot",
+      "message_id": 10931
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 0
+      },
+      "announce_type": "Update",
+      "npc_id": "Henry",
+      "message_id": 10925
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010.json
@@ -50,59 +50,61 @@
         "id": 1,
         "group_id": 38
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 11,
-          "exp": 160,
-          "hm_present_no": 45
+          "exp": 62,
+          "index": 4
         },
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 11,
-          "exp": 160,
-          "hm_present_no": 45
+          "exp": 62,
+          "index": 5
         },
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 11,
-          "exp": 160,
-          "hm_present_no": 45
+          "exp": 62,
+          "index": 6
         },
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 11,
-          "exp": 160,
-          "hm_present_no": 45
+          "exp": 62,
+          "index": 7
         },
         {
-          "comment": "Rogue Fighter",
-          "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
           "named_enemy_params_id": 53,
+          "hm_present_no": 46,
           "level": 11,
-          "exp": 160,
-          "hm_present_no": 45
+          "exp": 62,
+          "index": 9
         },
-        {"comment": "Rogue Fighter",
-          "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
           "named_enemy_params_id": 53,
+          "hm_present_no": 46,
           "level": 11,
-          "exp": 160,
-          "hm_present_no": 45
+          "exp": 62,
+          "index": 10
         }        
      ]
     }
@@ -128,7 +130,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 512,
+          "Param2": 11008
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -145,7 +155,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Woman0",
-      "message_id": 11005
+      "message_id": 11003
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Traveler's Scout",
+  "comment": "The Traveler's Scout (II)",
   "quest_id": 20000010,
   "base_level": 16,
   "minimum_item_rank": 0,
@@ -28,18 +28,18 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Battle Shield",
-          "item_id": 94,
+          "comment": "Nostalgia Waistguard",
+          "item_id": 8353,
           "num": 1
         },
         {
-          "comment": "Lestania Wine",
-          "item_id": 9409,
-          "num": 1
+          "comment": "Concoction of Light",
+          "item_id": 9376,
+          "num": 2
         },
         {
-          "comment": "Water Flask",
-          "item_id": 9393,
+          "comment": "Recovery Decoction",
+          "item_id": 9373,
           "num": 3
         }
       ]
@@ -51,76 +51,66 @@
         "id": 1,
         "group_id": 38
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
+          "exp": 81,
+          "index": 4
         },
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
+          "exp": 81,
+          "index": 5
         },
         {
-          "comment": "Rogue Seeker",
-          "enemy_id": "0x011001",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Rogue Fighter",
+          "enemy_id": "0x011000",
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
+          "exp": 81,
+          "repop_count": 1,
+          "repop_wait_second": 5,
+          "index": 6
         },
         {
-          "comment": "Rogue Fighter",
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 45,
           "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
+          "exp": 81,
+          "index": 7
         },
         {
-          "comment": "Rogue Seeker",
+          "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 46,
           "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
+          "exp": 81,
+          "repop_count": 1,
+          "repop_wait_second": 5,
+          "index": 9
         },
-        {"comment": "Rogue Seeker",
+        {
+          "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "hm_present_no": 46,
           "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
-        },
-        {"comment": "Rogue Seeker",
-          "enemy_id": "0x011001",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
-        },
-        {"comment": "Rogue fighter",
-          "enemy_id": "0x011000",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 16,
-          "exp": 310,
-          "hm_present_no": 45
-        }                   
+          "exp": 81,
+          "index": 10
+        }                      
      ]
     }
   ],
@@ -145,7 +135,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 512,
+          "Param2": 11008
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -162,7 +160,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Woman0",
-      "message_id": 11005
+      "message_id": 11003
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000010_2.json
@@ -1,0 +1,170 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Traveler's Scout (III)",
+  "quest_id": 20000010,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 6,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 680
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 520
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Nostalgia Waistguard",
+          "item_id": 8353,
+          "num": 1
+        },
+        {
+          "comment": "Concoction of Light",
+          "item_id": 9376,
+          "num": 2
+        },
+        {
+          "comment": "Recovery Decoction",
+          "item_id": 9373,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 38
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Brutal Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 47,
+          "level": 21,
+          "exp": 100,
+          "repop_count": 1,
+          "repop_wait_second": 5,
+          "index": 4
+        },
+        {
+          "comment": "Brutal Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 47,
+          "level": 21,
+          "exp": 100,
+          "index": 5
+        },
+        {
+          "comment": "Brutal Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 47,
+          "level": 21,
+          "exp": 100,
+          "repop_count": 1,
+          "repop_wait_second": 5,
+          "index": 6
+        },
+        {
+          "comment": "Brutal Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 47,
+          "level": 21,
+          "exp": 100,
+          "index": 7
+        },
+        {
+          "comment": "Brutal Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 46,
+          "level": 21,
+          "exp": 100,
+          "repop_count": 1,
+          "repop_wait_second": 5,
+          "index": 9
+        },
+        {
+          "comment": "Brutal Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 46,
+          "level": 21,
+          "exp": 100,
+          "repop_count": 1,
+          "repop_wait_second": 5,
+          "index": 10
+        }               
+     ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Woman0",
+      "message_id": 11000,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 990
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 512,
+          "Param2": 11008
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Woman0",
+      "message_id": 11003
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000011.json
@@ -1,0 +1,180 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Concern For Artifacts",
+  "quest_id": 20000011,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1260
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 200
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sinister Carrion",
+          "item_id": 7741,
+          "num": 3
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 2
+        },
+        {
+          "comment": "Strong Gala Extract",
+          "item_id": 9363,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 455
+      },
+      "starting_index": 6,
+      "comment": "Innacurate indexes, needs video evidence",
+      "enemies": [
+        {
+          "comment": "Vigilant Frost Corpse Torturer",
+          "enemy_id": "0x010512",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 241
+        },
+        {
+          "comment": "Vigilant Frost Corpse Torturer",
+          "enemy_id": "0x010512",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 241
+        },
+        {
+          "comment": "Vigilant Frost Corpse Torturer",
+          "enemy_id": "0x010512",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 241,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Frost Corpse Torturer",
+          "enemy_id": "0x010512",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 241,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 199,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 199,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        }
+     ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 3,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Klaus0",
+      "message_id": 11361,
+      "flags": [
+        {
+          "comment": "Spawns Bandit NPC",
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 991
+        }
+      ]
+    },
+    {
+      "type": "NewTalkToNPC",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 3,
+          "Param2": 11365
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Bandit0",
+      "message_id": 11366
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Bandit0",
+      "message_id": 11367
+    },
+    {
+      "type": "TalkToNpc",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 3,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Klaus0",
+      "message_id": 11364
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
@@ -50,57 +50,157 @@
         "id": 1,
         "group_id": 290
       },
-      "starting_index": 2,
+      "starting_index": 8,
       "enemies": [
         {
-          "comment": "Armored Cyclops (Club)",
+          "comment": "Brutal Cyclops (Club)",
           "enemy_id": "0x015003",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
-          "level": 42,
-          "exp": 6706,
+          "level": 40,
+          "exp": 3445,
           "is_boss": true
         }
       ]
     }
   ],
-  "blocks": [
+  "processes": [
     {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 3
-      },
-      "npc_id": "Joseph",
-      "message_id": 11368
+      "comments": "Process 0",
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 3
+          },
+          "npc_id": "Joseph",
+          "message_id": 11368
+        },
+        {
+          "type": "DiscoverEnemy",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue - Joseph",
+              "type": "QstTalkChg",
+              "Param1": 4,
+              "Param2": 11815
+            },
+            {
+              "comment": "Idle dialogue - Jordan",
+              "type": "QstTalkChg",
+              "Param1": 1707,
+              "Param2": 11807
+            }
+          ],
+          "groups": [ 0 ]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 5 ],
+          "check_flags": [ 1 , 2 , 3 , 4 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 3
+          },
+          "announce_type": "Update",
+          "npc_id": "Joseph",
+          "message_id": 11812
+        }
+      ]
     },
     {
-      "type": "DiscoverEnemy",
-      "announce_type": "Accept",
-      "groups": [ 0 ]
+      "comments": "Process 1",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 50
+          },
+          "npc_id": "Brandon",
+          "message_id": 11809
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 1 ]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [ 0 ]
+      "comments": "Process 2",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 53
+          },
+          "npc_id": "Emporio",
+          "message_id": 11810
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 2 ]
+        }
+      ]
     },
     {
-      "type": "TalkToNpc",
-      "stage_id": {
-        "id": 50
-      },
-      "announce_type": "Update",
-      "npc_id": "Brandon",
-      "message_id": 11809
+      "comments": "Process 3",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 53
+          },
+          "npc_id": "Sunny",
+          "message_id": 11811
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 3 ]
+        }
+      ]
     },
     {
-      "type": "TalkToNpc",
-      "stage_id": {
-        "id": 3
-      },
-      "announce_type": "Update",
-      "npc_id": "Joseph",
-      "message_id": 11812
+      "comments": "Process 4",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 53
+          },
+          "npc_id": "Johann",
+          "message_id": 11940
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 4 ]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012_1.json
@@ -1,0 +1,207 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Seeking Peace (II)",
+  "quest_id": 20000012,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 13,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1730
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1480
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 190
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mithril Ingot",
+          "item_id": 9196,
+          "num": 2
+        },
+        {
+          "comment": "Enhanced Pickaxe",
+          "item_id": 9401,
+          "num": 3
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 290
+      },
+      "starting_index": 8,
+      "enemies": [
+        {
+          "comment": "Brutal Cyclops (Club)",
+          "enemy_id": "0x015001",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 45,
+          "exp": 3710,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "comments": "Process 0",
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 3
+          },
+          "npc_id": "Joseph",
+          "message_id": 11368
+        },
+        {
+          "type": "DiscoverEnemy",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue - Joseph",
+              "type": "QstTalkChg",
+              "Param1": 4,
+              "Param2": 11815
+            },
+            {
+              "comment": "Idle dialogue - Jordan",
+              "type": "QstTalkChg",
+              "Param1": 1707,
+              "Param2": 11807
+            }
+          ],
+          "groups": [ 0 ]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [ 5 ],
+          "check_flags": [ 1 , 2 , 3 , 4 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 3
+          },
+          "announce_type": "Update",
+          "npc_id": "Joseph",
+          "message_id": 11812
+        }
+      ]
+    },
+    {
+      "comments": "Process 1",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 50
+          },
+          "npc_id": "Brandon",
+          "message_id": 11809
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 1 ]
+        }
+      ]
+    },
+    {
+      "comments": "Process 2",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 53
+          },
+          "npc_id": "Emporio",
+          "message_id": 11810
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 2 ]
+        }
+      ]
+    },
+    {
+      "comments": "Process 3",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 53
+          },
+          "npc_id": "Sunny",
+          "message_id": 11811
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 3 ]
+        }
+      ]
+    },
+    {
+      "comments": "Process 4",
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [ 5 ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 53
+          },
+          "npc_id": "Johann",
+          "message_id": 11940
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [ 4 ]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Leather Bottoms",
           "item_id": 446,
           "num": 1
         },
         {
+          "comment": "Healing Potion",
           "item_id": 34,
           "num": 2
         }
@@ -55,13 +57,28 @@
       },
       "npc_id": "Mayleaf0",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Mayleaf",
+          "type": "QstTalkChg",
+          "Param1": 14,
+          "Param2": 11829
+        },
+        {
+          "comment": "Idle dialogue - Pamela",
+          "type": "QstTalkChg",
+          "Param1": 1003,
+          "Param2": 11824
+        }
+      ],
       "items": [
         {
+          "comment": "Fluorite Earrings",
           "id": 8931,
           "amount": 1
         }
       ],
-      "message_id": 11826
+      "message_id": 11825
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_1.json
@@ -1,0 +1,85 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Heart Throbs Once More (II)",
+  "quest_id": 20000014,
+  "base_level": 8,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 14,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 920
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1600
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Hard Leather Cloth",
+          "item_id": 7937,
+          "num": 3
+        },
+        {
+          "comment": "Throwblast",
+          "item_id": 52,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 2,
+        "group_id": 1
+      },
+      "npc_id": "Mayleaf0",
+      "message_id": 11370
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 1
+      },
+      "npc_id": "Mayleaf0",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Mayleaf",
+          "type": "QstTalkChg",
+          "Param1": 14,
+          "Param2": 11829
+        },
+        {
+          "comment": "Idle dialogue - Pamela",
+          "type": "QstTalkChg",
+          "Param1": 1003,
+          "Param2": 11824
+        }
+      ],
+      "items": [
+        {
+          "comment": "Crystal Pendant",
+          "id": 8979,
+          "amount": 1
+        }
+      ],
+      "message_id": 11825
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_2.json
@@ -1,0 +1,90 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Heart Throbs Once More (III)",
+  "quest_id": 20000014,
+  "base_level": 8,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 14,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1320
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 8000
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 130
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Iron Thread",
+          "item_id": 7955,
+          "num": 3
+        },
+        {
+          "comment": "Healing Elixir",
+          "item_id": 7552,
+          "num": 3
+        },
+        {
+          "comment": "Quality Gala Extract",
+          "item_id": 9361,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 2,
+        "group_id": 1
+      },
+      "npc_id": "Mayleaf0",
+      "message_id": 11370
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 1
+      },
+      "npc_id": "Mayleaf0",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Mayleaf",
+          "type": "QstTalkChg",
+          "Param1": 14,
+          "Param2": 11829
+        },
+        {
+          "comment": "Idle dialogue - Pamela",
+          "type": "QstTalkChg",
+          "Param1": 1003,
+          "Param2": 11824
+        }
+      ],
+      "items": [
+        {
+          "comment": "Wanderer's Wrist Ring",
+          "id": 9007,
+          "amount": 1
+        }
+      ],
+      "message_id": 11825
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017.json
@@ -26,10 +26,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Green Grass Ring",
           "item_id": 8928,
           "num": 1
         },
         {
+          "comment": "Gala Extract",
           "item_id": 36,
           "num": 2
         }
@@ -54,8 +56,17 @@
       },
       "npc_id": "Fabio0",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
       "items": [
         {
+          "comment": "Bronze Ore",
           "id": 7858,
           "amount": 2
         }
@@ -70,8 +81,17 @@
       },
       "npc_id": "Fabio0",
       "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
       "items": [
         {
+          "comment": "Fluorite",
           "id": 7893,
           "amount": 2
         }
@@ -86,8 +106,17 @@
       },
       "npc_id": "Fabio0",
       "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
       "items": [
         {
+          "comment": "Copper Ore",
           "id": 7854,
           "amount": 2
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_1.json
@@ -1,0 +1,128 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Fabio's Collectibles (II)",
+  "quest_id": 20000017,
+  "base_level": 13,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 240
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 80
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 40
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Amethyst",
+          "item_id": 7890,
+          "num": 3
+        },
+        {
+          "comment": "Sprite's Periapt",
+          "item_id": 45,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "message_id": 11373
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
+      "items": [
+        {
+          "comment": "Bronze Ingot",
+          "id": 7876,
+          "amount": 2
+        }
+      ],
+      "message_id": 11848
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
+      "items": [
+        {
+          "comment": "Copper Ingot",
+          "id": 7873,
+          "amount": 1
+        }
+      ],
+      "message_id": 11849
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
+      "items": [
+        {
+          "comment": "Dull Iron Ingot",
+          "id": 7872,
+          "amount": 1
+        }
+      ],
+      "message_id": 11853
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_2.json
@@ -1,0 +1,128 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Fabio's Collectibles (III)",
+  "quest_id": 20000017,
+  "base_level": 24,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 120
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 50
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Monster Gallstone",
+          "item_id": 7865,
+          "num": 3
+        },
+        {
+          "comment": "Interventive",
+          "item_id": 9374,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "message_id": 11373
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
+      "items": [
+        {
+          "comment": "Scroll of Fire",
+          "id": 8011,
+          "amount": 1
+        }
+      ],
+      "message_id": 11848
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
+      "items": [
+        {
+          "comment": "Scroll of Ice",
+          "id": 8012,
+          "amount": 1
+        }
+      ],
+      "message_id": 11849
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 11856
+        }
+      ],
+      "items": [
+        {
+          "comment": "Scroll of Thunder",
+          "id": 8013,
+          "amount": 1
+        }
+      ],
+      "message_id": 11853
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000018.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Cleric's Cap",
           "item_id": 8143,
           "num": 1
         },
         {
+          "comment": "Bottled Haste",
           "item_id": 9365,
           "num": 2
         }
@@ -43,23 +45,26 @@
         "id": 1,
         "group_id": 21
       },
+      "starting_index": 2,
       "enemies": [
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
-          "level": 11,
-          "exp": 260,
+          "named_enemy_params_id": 53,
+          "level": 9,
+          "exp": 104,
+          "repop_count": 1,
+          "repop_wait_time": 10,
           "is_boss": false
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
-          "level": 11,
-          "exp": 260,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015504",
-          "level": 11,
-          "exp": 260,
+          "named_enemy_params_id": 53,
+          "level": 9,
+          "exp": 104,
+          "repop_count": 1,
+          "repop_wait_time": 10,
           "is_boss": false
         }
       ]
@@ -78,7 +83,15 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 10823
+        }
+      ]
     },
     {
       "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000018_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000018_1.json
@@ -1,0 +1,118 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Fabio and Monster-Slaying (II)",
+  "quest_id": 20000018,
+  "base_level": 18,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 1,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 830
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 590
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Ranger Cuisses",
+          "item_id": 679,
+          "num": 1
+        },
+        {
+          "comment": "Conqueror's Periapt",
+          "item_id": 42,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 21
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Vigilant Dread Ape",
+          "enemy_id": "0x015502",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 1358,
+          "is_boss": true
+        },
+        {
+          "comment": "Vigilant Brute Ape",
+          "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 141,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Brute Ape",
+          "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 141,
+          "is_boss": false
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "message_id": 11862
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 10823
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "announce_type": "Update",
+      "npc_id": "Fabio0",
+      "message_id": 11865
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000018_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000018_2.json
@@ -1,0 +1,107 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Fabio and Monster-Slaying (III)",
+  "quest_id": 20000018,
+  "base_level": 24,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "news_image": 1,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1100
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 790
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 120
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Pyrite",
+          "item_id": 9061,
+          "num": 5
+        },
+        {
+          "comment": "Conqueror's Amulet",
+          "item_id": 9381,
+          "num": 1
+        },
+        {
+          "comment": "Purifying Decoction",
+          "item_id": 9372,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 21
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Brutal Armored Cyclops",
+          "enemy_id": "0x015002",
+          "named_enemy_params_id": 54,
+          "level": 24,
+          "exp": 2597,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "npc_id": "Fabio0",
+      "message_id": 11862
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 12,
+          "Param2": 10823
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 2,
+        "group_id": 0
+      },
+      "announce_type": "Update",
+      "npc_id": "Fabio0",
+      "message_id": 11865
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Wizard's Ring",
           "item_id": 8948,
           "num": 1
         },
         {
+          "comment": "Sphinx Hair",
           "item_id": 7810,
           "num": 1
         },
         {
+          "comment": "Herb Salad",
           "item_id": 9407,
           "num": 2
         }
@@ -49,11 +52,12 @@
       },
       "enemies": [
         {
+          "comment": "Young Sphinx",
           "enemy_id": "0x015302",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 459,
+          "start_think_tbl_no": 1,
           "level": 14,
-          "exp": 934,
+          "exp": 2116,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Sky Concealing Wings",
+  "comment": "Sky Concealing Wings (II)",
   "quest_id": 20005000,
   "base_level": 16,
   "minimum_item_rank": 0,
@@ -28,16 +28,19 @@
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 8329,
+          "comment": "Copper Sabatons",
+          "item_id": 8328,
           "num": 1
         },
         {
+          "comment": "Small Thief's Key",
           "item_id": 9429,
           "num": 2
         },
         {
-          "item_id": 9409,
-          "num": 2
+          "comment": "Poison Flask",
+          "item_id": 9395,
+          "num": 3
         }
       ]
     }
@@ -50,11 +53,12 @@
       },
       "enemies": [
         {
+          "comment": "Vigilant Sphinx",
           "enemy_id": "0x015302",
+          "named_enemy_params_id": 53,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 2298,
           "level": 16,
-          "exp": 1060,
+          "exp": 2254,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_2.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Sky Concealing Wings",
+  "comment": "Sky Concealing Wings (III)",
   "quest_id": 20005000,
-  "base_level": 34,
+  "base_level": 20,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "HidellPlains",
@@ -13,30 +13,33 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1120
+      "amount": 660
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 220
+      "amount": 130
     },
     {
       "type": "exp",
-      "amount": 1960
+      "amount": 1150
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 9320,
+          "comment": "Buster Knuckles",
+          "item_id": 917,
           "num": 1
         },
         {
-          "item_id": 9398,
-          "num": 2
+          "comment": "Angel's Amulet",
+          "item_id": 9382,
+          "num": 1
         },
         {
-          "item_id": 9383,
+          "comment": "Recovery Decoction",
+          "item_id": 9373,
           "num": 3
         }
       ]
@@ -50,11 +53,12 @@
       },
       "enemies": [
         {
+          "comment": "Brutal Sphinx",
           "enemy_id": "0x015302",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 142,
-          "level": 34,
-          "exp": 5834,
+          "level": 20,
+          "exp": 2530,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_3.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Sky Concealing Wings (IV)",
+  "quest_id": 20005000,
+  "base_level": 34,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "HidellPlains",
+  "news_image": 6,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1120
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 220
+    },
+    {
+      "type": "exp",
+      "amount": 1960
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Shock Warding",
+          "item_id": 9320,
+          "num": 1
+        },
+        {
+          "comment": "Throwing Knife",
+          "item_id": 9398,
+          "num": 2
+        },
+        {
+          "comment": "Demon's Amulet",
+          "item_id": 9383,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 30
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Sphinx",
+          "enemy_id": "0x015302",
+          "named_enemy_params_id": 54,
+          "start_think_tbl_no": 1,
+          "level": 34,
+          "exp": 3496,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001.json
@@ -60,12 +60,12 @@
     },
     {
       "type": "exp",
-      "amount": 510
+      "amount": 310
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 420
+      "amount": 260
     },
     {
       "type": "wallet",
@@ -82,28 +82,28 @@
       "starting_index": 6,
       "enemies": [
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Fighter",
+          "enemy_id": "0x011111",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         },
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         },
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         }
       ]
     },
@@ -112,31 +112,31 @@
         "id": 1,
         "group_id": 28
       },
-      "starting_index": 6,
+      "starting_index": 10,
       "enemies": [
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Fighter",
+          "enemy_id": "0x011111",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         },
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         },
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         }
       ]
     },
@@ -145,47 +145,31 @@
         "id": 1,
         "group_id": 6
       },
-      "starting_index": 6,
+      "starting_index": 7,
       "enemies": [
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Fighter",
+          "enemy_id": "0x011111",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         },
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         },
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
           "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "exp": 50
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_1.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Confrontation With Scouts",
+  "comment": "Confrontation With Scouts (II)",
   "quest_id": 20005001,
-  "base_level": 8,
+  "base_level": 18,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "HidellPlains",
@@ -32,47 +32,35 @@
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 8163,
+          "item_id": 8203,
           "num": 1,
-          "comment": "Blue-Edged Helm"
+          "comment": "Chain Hood"
         },
         {
-          "item_id": 9366,
+          "item_id": 9373,
+          "num": 3,
+          "comment": "Recovery Decoction"
+        },
+        {
+          "item_id": 1351,
           "num": 2,
-          "comment": "Waking Draught"
-        }
-      ]
-    },
-    {
-      "type": "random",
-      "loot_pool": [
-        {
-          "item_id": 34,
-          "num": 3,
-          "chance": 0.5,
-          "comment": "Healing Potion"
-        },
-        {
-          "item_id": 36,
-          "num": 3,
-          "chance": 0.5,
-          "comment": "Gala Extract"
+          "comment": "Mushroom Sauté"
         }
       ]
     },
     {
       "type": "exp",
-      "amount": 510
+      "amount": 710
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 420
+      "amount": 590
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 30
+      "amount": 70
     }
   ],
   "enemy_groups": [
@@ -81,31 +69,23 @@
         "id": 1,
         "group_id": 8
       },
-      "starting_index": 6,
+      "starting_index": 7,
       "enemies": [
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Redcap Fighter",
           "enemy_id": "0x011111",
+          "named_enemy_params_id": 53,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "level": 18,
+          "exp": 84
+        },
+        {
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 18,
+          "exp": 84
         }
       ]
     },
@@ -114,31 +94,23 @@
         "id": 1,
         "group_id": 28
       },
-      "starting_index": 6,
+      "starting_index": 11,
       "enemies": [
         {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011110",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Redcap Fighter",
           "enemy_id": "0x011111",
+          "named_enemy_params_id": 53,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "level": 18,
+          "exp": 84
+        },
+        {
+          "comment": "Vigilant Redcap Sling",
+          "enemy_id": "0x011112",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 18,
+          "exp": 84
         }
       ]
     },
@@ -147,47 +119,40 @@
         "id": 1,
         "group_id": 6
       },
-      "starting_index": 6,
+      "starting_index": 7,
       "enemies": [
         {
-          "enemy_id": "0x011110",
+          "comment": "Brutal Redcap Sling",
+          "enemy_id": "0x011112",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "level": 18,
+          "exp": 84
         },
         {
-          "enemy_id": "0x011110",
+          "comment": "Brutal Redcap Sling",
+          "enemy_id": "0x011112",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "level": 18,
+          "exp": 84
         },
         {
-          "enemy_id": "0x011111",
+          "comment": "Brutal Redcap Sling",
+          "enemy_id": "0x011112",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "level": 18,
+          "exp": 84
         },
         {
-          "enemy_id": "0x011111",
+          "comment": "Brutal Cyclops",
+          "enemy_id": "0x015000",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x011111",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 8,
-          "exp": 94,
-          "is_boss": false
+          "level": 18,
+          "exp": 2064,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_2.json
@@ -1,0 +1,219 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Confrontation With Scouts (Bounty)",
+  "quest_id": 20005001,
+  "base_level": 8,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "HidellPlains",
+  "news_image": 6,
+  "variant_index": 2,
+  "quest_layout_set_info_flags": [
+    {
+      "flag_no": 346,
+      "stage_no": 100,
+      "group_id": 8
+    },
+    {
+      "flag_no": 2213,
+      "stage_no": 100,
+      "group_id": 28
+
+    },
+    {
+      "flag_no": 886,
+      "stage_no": 100,
+      "group_id": 6
+    }
+  ],
+  "rewards": [
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": 9529,
+          "num": 1,
+          "comment": "Leather Stole"
+        },
+        {
+          "item_id": 9367,
+          "num": 2,
+          "comment": "Terry Cloth"
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "item_id": 7962,
+          "num": 3,
+          "chance": 1.0,
+          "comment": "Brown Wood"
+        }
+      ]
+    },
+    {
+      "type": "exp",
+      "amount": 510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 30
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 8
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Bounty Redcap Fighter",
+          "enemy_id": "0x011111",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        },
+        {
+          "comment": "Bounty Redcap",
+          "enemy_id": "0x011110",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        },
+        {
+          "comment": "Bounty Redcap",
+          "enemy_id": "0x011110",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 28
+      },
+      "starting_index": 10,
+      "enemies": [
+        {
+          "comment": "Bounty Redcap Fighter",
+          "enemy_id": "0x011111",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        },
+        {
+          "comment": "Bounty Redcap",
+          "enemy_id": "0x011110",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        },
+        {
+          "comment": "Bounty Redcap",
+          "enemy_id": "0x011110",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 6
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Bounty Redcap Fighter",
+          "enemy_id": "0x011111",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Bounty Redcap Fighter",
+          "enemy_id": "0x011111",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        },
+        {
+          "comment": "Bounty Redcap",
+          "enemy_id": "0x011110",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Bounty Redcap",
+          "enemy_id": "0x011110",
+          "named_enemy_params_id": 458,
+          "start_think_tbl_no": 1,
+          "level": 8,
+          "exp": 50
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Update",
+      "groups": [ 2 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 2 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Ambush In The Wells Depths",
+  "comment": "Ambush In The Well's Depths",
   "quest_id": 20005002,
   "base_level": 11,
   "minimum_item_rank": 0,
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Thief's Mask",
           "item_id": 489,
           "num": 1
         },
         {
+          "comment": "Absorbent Cloth",
           "item_id": 9368,
           "num": 2
         }
@@ -44,54 +46,42 @@
         "group_id": 0
       },
       "enemies": [
-        
         {
-          "enemy_id": "0x015801",
-          "StartThinkTblNo": 1,
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Orc Soldier",
           "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160,
-          "is_boss": false
+          "exp": 80
         },
         {
-          "enemy_id": "0x015801",
-          "StartThinkTblNo": 1,
-          "named_enemy_params_id": 53,
-          "level": 11,
-          "exp": 160,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Orc Soldier",
           "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160,
-          "is_boss": false
+          "exp": 80
         },
         {
+          "comment": "Vigilant Orc Soldier",
           "enemy_id": "0x015800",
-          "StartThinkTblNo": 1,
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160,
-          "is_boss": false
+          "exp": 80
         },
         {
+          "comment": "Vigilant Orc Tosser",
           "enemy_id": "0x015801",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 160,
-          "is_boss": false
+          "exp": 80,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Orc Tosser",
+          "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
+          "level": 11,
+          "exp": 80
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_1.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Ambush In The Wells Depths",
+  "comment": "Ambush In The Well's Depths (II)",
   "quest_id": 20005002,
-  "base_level": 11,
+  "base_level": 15,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "HidellPlains",
@@ -13,27 +13,29 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 520
+      "amount": 410
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 30
+      "amount": 70
     },
     {
       "type": "exp",
-      "amount": 660
+      "amount": 740
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 489,
-          "num": 1
+          "comment": "Iron Ore Fragment",
+          "item_id": 7853,
+          "num": 5
         },
         {
-          "item_id": 9368,
-          "num": 2
+          "comment": "Lantern Kindling",
+          "item_id": 55,
+          "num": 3
         }
       ]
     }
@@ -46,52 +48,50 @@
       },
       "enemies": [
         {
-          "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 12,
-          "exp": 186,
-          "is_boss": false
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 15,
+          "exp": 98
         },
         {
-          "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 12,
-          "exp": 186,
-          "is_boss": false
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 15,
+          "exp": 98,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
-          "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 12,
-          "exp": 186,
-          "is_boss": false
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 15,
+          "exp": 98
         },
         {
-          "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 12,
-          "exp": 186,
-          "is_boss": false
+          "comment": "Vigilant Orc Tosser",
+          "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
+          "level": 15,
+          "exp": 98,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
-          "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 12,
-          "exp": 186,
-          "is_boss": false
+          "comment": "Vigilant Orc Tosser",
+          "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
+          "level": 15,
+          "exp": 98
         },
         {
-          "enemy_id": "0x015800",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 458,
-          "level": 12,
-          "exp": 186,
-          "is_boss": false
+          "comment": "Vigilant Orc Tosser",
+          "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
+          "level": 15,
+          "exp": 98
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_2.json
@@ -1,0 +1,107 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Ambush In The Well's Depths (Bounty)",
+  "quest_id": 20005002,
+  "base_level": 12,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "HidellPlains",
+  "news_image": 501,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 520
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 30
+    },
+    {
+      "type": "exp",
+      "amount": 660
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Healing Potion",
+          "item_id": 34,
+          "num": 3
+        },
+        {
+          "comment": "Gala Extract",
+          "item_id": 36,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 134,
+        "group_id": 0
+      },
+      "enemies": [
+        {
+          "comment": "Bounty Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 458,
+          "level": 12,
+          "exp": 85
+        },
+        {
+          "comment": "Bounty Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 458,
+          "level": 12,
+          "exp": 85
+        },
+        {
+          "comment": "Bounty Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 458,
+          "level": 12,
+          "exp": 85
+        },
+        {
+          "comment": "Bounty Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 458,
+          "level": 12,
+          "exp": 85
+        },
+        {
+          "comment": "Bounty Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 458,
+          "level": 12,
+          "exp": 85
+        },
+        {
+          "comment": "Bounty Orc Soldier",
+          "enemy_id": "0x015800",
+          "named_enemy_params_id": 458,
+          "level": 12,
+          "exp": 85
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003.json
@@ -27,16 +27,19 @@
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 845,
+          "comment": "Leader's Vest",
+          "item_id": 492,
           "num": 1
         },
         {
-          "item_id": 631,
-          "num": 1
+          "comment": "Quality Gala Extract",
+          "item_id": 9361,
+          "num": 5
         },
         {
-          "item_id": 9403,
-          "num": 2
+          "comment": "Black Dye",
+          "item_id": 8140,
+          "num": 1
         }
       ]
     }
@@ -49,9 +52,11 @@
       },
       "enemies": [
         {
+          "comment": "Brutal Dread Ape",
           "enemy_id": "0x015502",
+          "named_enemy_params_id": 54,
           "level": 15,
-          "exp": 996,
+          "exp": 1184,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Dweller In The Darkness",
+  "comment": "Dweller In The Darkness (II)",
   "quest_id": 20005003,
   "base_level": 30,
   "minimum_item_rank": 0,
@@ -28,14 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Advance Helm",
           "item_id": 845,
           "num": 1
         },
         {
-          "item_id": 2243,
+          "comment": "Vagrant's Mask",
+          "item_id": 631,
           "num": 1
         },
         {
+          "comment": "Enhanced Lockpick",
           "item_id": 9403,
           "num": 2
         }
@@ -50,10 +53,12 @@
       },
       "enemies": [
         {
+          "comment": "Brutal Ogre",
           "enemy_id": "0x015500",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 2,
           "level": 30,
-          "exp": 5446,          
+          "exp": 2300,          
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
@@ -50,13 +50,14 @@
         "id": 88,
         "group_id": 4
       },
+      "starting_index": 6,
       "enemies": [
         {
-          "comment": "Wight",
+          "comment": "Vigilant Wight",
           "enemy_id": "0x015600",
           "named_enemy_params_id": 53,
           "level": 13,
-          "exp": 874,
+          "exp": 868,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Whispers of the Dark",
+  "comment": "Whispers of the Dark (II)",
   "quest_id": 20005004,
   "base_level": 25,
   "minimum_item_rank": 0,
@@ -28,19 +28,19 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "rock rmor",
-          "item_id": 547,
+          "comment": "Grand Surcoat",
+          "item_id": 550,
           "num": 1
         },
         {
-          "comment": "sorc coat",
+          "comment": "Sorcerer's Coat",
           "item_id": 761,
           "num": 1
         },
         {
-          "comment": "demon amulet",
-          "item_id": 9383,
-          "num": 2
+          "comment": "Black Skull",
+          "item_id": 7769,
+          "num": 1
         }
       ]
     }
@@ -51,14 +51,56 @@
         "id": 88,
         "group_id": 4
       },
+      "starting_index": 6,
       "enemies": [
         {
-          "comment": "Wight",
+          "comment": "Brutal Wight",
           "enemy_id": "0x015600",
-          "named_enemy_params_id": 56,
+          "named_enemy_params_id": 54,
+          "start_think_tbl_no": 2,
           "level": 25,
-          "exp": 3742,
+          "exp": 1430,
           "is_boss": true
+        },
+        {
+          "comment": "Skeleton Knight",
+          "enemy_id": "0x010301",
+          "start_think_tbl_no": 8,
+          "repop_count": 2,
+          "level": 23,
+          "exp": 102,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Skeleton Knight",
+          "enemy_id": "0x010301",
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "level": 23,
+          "exp": 102,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Skeleton Knight",
+          "enemy_id": "0x010301",
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "level": 23,
+          "exp": 102,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Skeleton Knight",
+          "enemy_id": "0x010301",
+          "start_think_tbl_no": 8,
+          "repop_count": 2,
+          "level": 23,
+          "exp": 102,
+          "is_required": false,
+          "is_manual_set": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010.json
@@ -27,16 +27,19 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Knight's Honor",
                     "item_id": 95,
                     "num": 1
                 },
                 {
-                    "item_id": 58,
-                    "num": 3
-                },
-                {
+                    "comment": "Cathedral Fire",
                     "item_id": 10047,
                     "num": 1
+                },
+                {
+                    "comment": "Lumber Knife",
+                    "item_id": 58,
+                    "num": 3
                 }
             ]
         }
@@ -47,19 +50,16 @@
                 "id": 1,
                 "group_id": 26
             },
-            "placement_type": "manual",
+            "starting_index": 1,
             "enemies": [
                 {
                     "comment": "Vigilant Cyclops",
                     "enemy_id": "0x015000",
-                    "start_think_tbl_no": 1,
                     "named_enemy_params_id": 53,
+                    "start_think_tbl_no": 1,
                     "level": 12,
-                    "exp": 816,
-                    "is_boss": true,
-                    "is_manual_set": false,
-                    "index": 0
-
+                    "exp": 1776,
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_1.json
@@ -1,79 +1,81 @@
 {
-  "state_machine": "GenericStateMachine",
-  "type": "World",
-  "comment": "The Knights' Bitter Enemy",
-  "quest_id": 20005010,
-  "base_level": 20,
-  "minimum_item_rank": 0,
-  "discoverable": false,
-  "area_id": "HidellPlains",
-  "news_image": 5,
-  "variant_index": 1,
-  "rewards": [
-    {
-      "type": "wallet",
-      "wallet_type": "Gold",
-      "amount": 990
-    },
-    {
-      "type": "wallet",
-      "wallet_type": "RiftPoints",
-      "amount": 130
-    },
-    {
-      "type": "exp",
-      "amount": 1480
-    },
-    {
-      "type": "select",
-      "loot_pool": [
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Knights' Bitter Enemy (II)",
+    "quest_id": 20005010,
+    "base_level": 28,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "HidellPlains",
+    "news_image": 5,
+    "variant_index": 1,
+    "rewards": [
         {
-          "item_id": 95,
-          "num": 1
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 920
         },
         {
-          "item_id": 58,
-          "num": 3
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 180
         },
         {
-          "item_id": 10047,
-          "num": 1
-        }
-      ]
-    }
-  ],
-  "enemy_groups": [
-    {
-      "stage_id": {
-        "id": 1,
-        "group_id": 26
-      },
-      "placement_type": "manual",
-      "enemies": [
+            "type": "exp",
+            "amount": 1380
+        },
         {
-          "comment": "Bounty Cyclops",
-          "enemy_id": "0x015000",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 458,
-          "level": 20,
-          "exp": 1336,
-          "is_boss": true,
-          "is_manual_set": false,
-          "index": 0
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Over Guard",
+                    "item_id": 628,
+                    "num": 1
+                },
+                {
+                    "comment": "Three-Herb Salad",
+                    "item_id": 9410,
+                    "num": 1
+                },
+                {
+                    "comment": "Concoction of Light",
+                    "item_id": 9376,
+                    "num": 3
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "blocks": [
-    {
-      "type": "DiscoverEnemy",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [ 0 ]
-    }
-  ]
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 26
+            },
+            "starting_index": 1,
+            "enemies": [
+                {
+                    "comment": "Brutal Colossus",
+                    "enemy_id": "0x015020",
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 1,
+                    "level": 28,
+                    "exp": 2968,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "show_marker": false,
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_2.json
@@ -1,0 +1,81 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Knights' Bitter Enemy (Bounty)",
+    "quest_id": 20005010,
+    "base_level": 20,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "HidellPlains",
+    "news_image": 5,
+    "variant_index": 2,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 990
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 130
+        },
+        {
+            "type": "exp",
+            "amount": 1480
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Soldier's Ring",
+                    "item_id": 8947,
+                    "num": 1
+                },
+                {
+                    "comment": "Herb Salad",
+                    "item_id": 9407,
+                    "num": 1
+                },
+                {
+                    "comment": "Lestania Wine",
+                    "item_id": 9409,
+                    "num": 2
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 26
+            },
+            "starting_index": 1,
+            "enemies": [
+                {
+                    "comment": "Bounty Cyclops",
+                    "enemy_id": "0x015000",
+                    "named_enemy_params_id": 458,
+                    "start_think_tbl_no": 1,
+                    "level": 20,
+                    "exp": 2160,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "show_marker": false,
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
@@ -34,12 +34,12 @@
         {
           "comment": "Wine-Boiled Mushroom",
           "item_id": 9411,
-          "num": 3
+          "num": 1
         },
         {
           "comment": "Throwing Rock",
           "item_id": 9396,
-          "num": 2
+          "num": 3
         }
       ]
     }
@@ -50,13 +50,14 @@
         "id": 1,
         "group_id": 11
       },
+      "starting_index": 11,
       "enemies": [
         {
-          "comment": "Ogre",
+          "comment": "Brutal Ogre",
           "enemy_id": "0x015500",
           "named_enemy_params_id": 54,
           "level": 26,
-          "exp": 7600,
+          "exp": 2060,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011_1.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Man-Eating Ogre Appears! (II)",
+  "quest_id": 20005011,
+  "base_level": 30,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "HidellPlains",
+  "news_image": 7,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1280
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 990
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 170
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gooseneck Arm",
+          "item_id": 605,
+          "num": 1
+        },
+        {
+          "comment": "Iron Bangles",
+          "item_id": 818,
+          "num": 1
+        },
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 11
+      },
+      "starting_index": 11,
+      "enemies": [
+        {
+          "comment": "Brutal Ogre",
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 54,
+          "level": 30,
+          "exp": 2300,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010000.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Trooper's Vest",
           "item_id": 9604,
           "num": 1
         },
         {
+          "comment": "Thief's Mask",
           "item_id": 489,
           "num": 1
         }
@@ -41,27 +43,34 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 85
+        "group_id": 86
       },
+      "position_index": 5,
       "enemies": [
         {
+          "comment": "Vigilant Rogue Hunter",
           "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 140,
+          "exp": 62,
           "is_boss": false,
           "hm_present_no": 47
         },
         {
+          "comment": "Vigilant Rogue Hunter",
           "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 140,
+          "exp": 62,
           "is_boss": false,
           "hm_present_no": 47
         },
         {
+          "comment": "Vigilant Rogue Hunter",
           "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
           "level": 11,
-          "exp": 140,
+          "exp": 62,
           "is_boss": false,
           "hm_present_no": 47
         }
@@ -89,11 +98,18 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1207,
+          "Param2": 10788
+        }
+      ],
       "groups": [ 0 ]
     },
     {
       "type": "KillGroup",
-
       "announce_type": "Update",
       "reset_group": false,
       "groups": [ 0 ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010000_1.json
@@ -1,0 +1,134 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Beach Bandits (II)",
+  "quest_id": 20010000,
+  "base_level": 13,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 21,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 40
+    },
+    {
+      "type": "exp",
+      "amount": 420
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Grass-Green Shoes",
+          "item_id": 464,
+          "num": 1
+        },
+        {
+          "comment": "Lockpick",
+          "item_id": 59,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 86
+      },
+      "position_index": 5,
+      "enemies": [
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 13,
+          "exp": 70,
+          "is_boss": false,
+          "hm_present_no": 47,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 13,
+          "exp": 70,
+          "is_boss": false,
+          "hm_present_no": 47,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 13,
+          "exp": 70,
+          "is_boss": false,
+          "hm_present_no": 47
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "npc_id": "Yuni",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "message_id": 10782,
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 992
+        }
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1207,
+          "Param2": 10788
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "announce_type": "Update",
+      "npc_id": "Yuni",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "message_id": 10785
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001.json
@@ -1,7 +1,7 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "Boats Buddy",
+    "comment": "Boat's Buddy",
     "quest_id": 20010001,
     "base_level": 9,
     "minimum_item_rank": 0,
@@ -12,7 +12,7 @@
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 240
+            "amount": 150
         },
         {
             "type": "wallet",
@@ -27,10 +27,12 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Fisherman's Shirt",
                     "item_id": 502,
                     "num": 1
                 },
                 {
+                    "comment": "Fireproof Draught",
                     "item_id": 9370,
                     "num": 2
                 }
@@ -43,35 +45,39 @@
                 "id": 1,
                 "group_id": 83
             },
-            "placement_type": "Manual",
+            "starting_index": 4,
             "enemies": [
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 4
+                    "exp": 43,
+                    "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 5
+                    "exp": 43,
+                    "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 6
+                    "exp": 43,
+                    "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 7
+                    "exp": 43,
+                    "is_boss": false
                 }
             ]
         },
@@ -80,35 +86,39 @@
                 "id": 1,
                 "group_id": 83
             },
-            "placement_type": "Manual",
+            "starting_index": 8,
             "enemies": [
                 {
+                    "comment": "Vigilant Saurian",
                     "enemy_id": "0x010400",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 8
+                    "exp": 45,
+                    "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Saurian",
                     "enemy_id": "0x010400",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 9
+                    "exp": 45,
+                    "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Saurian",
                     "enemy_id": "0x010400",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 94,
-                    "is_boss": false,
-                    "index": 10
+                    "exp": 45,
+                    "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Giant Saurian",
                     "enemy_id": "0x010401",
+                    "named_enemy_params_id": 53,
                     "level": 9,
-                    "exp": 190,
-                    "is_boss": false,
-                    "index": 11
+                    "exp": 84,
+                    "is_boss": false
                 }
             ]
         }
@@ -126,7 +136,15 @@
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
-            "groups": [ 0 ]
+            "groups": [ 0 ],
+            "result_commands": [
+                {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 1200,
+                    "Param2": 10806
+                }
+            ]
         },
         {
             "type": "KillGroup",
@@ -146,7 +164,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Walter",
-            "message_id": 10805
+            "message_id": 10803
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001_1.json
@@ -1,0 +1,171 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Boat's Buddy (II)",
+    "quest_id": 20010001,
+    "base_level": 14,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "BreyaCoast",
+    "news_image": 22,
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 380
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 60
+        },
+        {
+            "type": "exp",
+            "amount": 500
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Copper Greaves",
+                    "item_id": 432,
+                    "num": 1
+                },
+                {
+                    "comment": "Antidote",
+                    "item_id": 37,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 55,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 55,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 55,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 55,
+                    "is_boss": false
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "starting_index": 8,
+            "enemies": [
+                {
+                    "comment": "Vigilant Saurian",
+                    "enemy_id": "0x010400",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 58,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Saurian",
+                    "enemy_id": "0x010400",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 58,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Saurian",
+                    "enemy_id": "0x010400",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 58,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Giant Saurian",
+                    "enemy_id": "0x010401",
+                    "named_enemy_params_id": 53,
+                    "level": 14,
+                    "exp": 101,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1,
+                "group_id": 0
+            },
+            "npc_id": "Walter",
+            "message_id": 10800
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [ 0 ],
+            "result_commands": [
+                {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 1200,
+                    "Param2": 10806
+                }
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [ 1 ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Walter",
+            "message_id": 10803
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001_2.json
@@ -1,0 +1,171 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Boat's Buddy (III)",
+    "quest_id": 20010001,
+    "base_level": 26,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "BreyaCoast",
+    "news_image": 22,
+    "variant_index": 2,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 710
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 130
+        },
+        {
+            "type": "exp",
+            "amount": 850
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Showdown Helm",
+                    "item_id": 843,
+                    "num": 1
+                },
+                {
+                    "comment": "Enamel Hood",
+                    "item_id": 629,
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 82,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 82,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 82,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 82,
+                    "is_boss": false
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "starting_index": 8,
+            "enemies": [
+                {
+                    "comment": "Vigilant Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 132,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 132,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 132,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Giant Sulfur Saurian",
+                    "enemy_id": "0x010411",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 165,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1,
+                "group_id": 0
+            },
+            "npc_id": "Walter",
+            "message_id": 10800
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [ 0 ],
+            "result_commands": [
+                {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 1200,
+                    "Param2": 10806
+                }
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [ 1 ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Walter",
+            "message_id": 10803
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010001_3.json
@@ -1,0 +1,171 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Boat's Buddy (Bounty)",
+    "quest_id": 20010001,
+    "base_level": 10,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "BreyaCoast",
+    "news_image": 22,
+    "variant_index": 3,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 440
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 30
+        },
+        {
+            "type": "exp",
+            "amount": 550
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Superior Healing Potion",
+                    "item_id": 35,
+                    "num": 2
+                },
+                {
+                    "comment": "Superior Gala Extract",
+                    "item_id": 61,
+                    "num": 2
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Bounty Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 43,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Bounty Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 43,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Bounty Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 43,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Bounty Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 43,
+                    "is_boss": false
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 83
+            },
+            "starting_index": 8,
+            "enemies": [
+                {
+                    "comment": "Bounty Saurian",
+                    "enemy_id": "0x010400",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 45,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Bounty Saurian",
+                    "enemy_id": "0x010400",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 45,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Bounty Saurian",
+                    "enemy_id": "0x010400",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 45,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Bounty Giant Saurian",
+                    "enemy_id": "0x010401",
+                    "named_enemy_params_id": 468,
+                    "level": 9,
+                    "exp": 84,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 1,
+                "group_id": 0
+            },
+            "npc_id": "Walter",
+            "message_id": 10801
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "groups": [ 0 ],
+            "result_commands": [
+                {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 1200,
+                    "Param2": 10806
+                }
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [ 1 ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Walter",
+            "message_id": 10804
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010002.json
@@ -61,11 +61,19 @@
         "layer_no": 1
       },
       "npc_id": "Akim",
-      "message_id": 11372
+      "message_id": 10808
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1206,
+          "Param2": 10815
+        }
+      ],
       "stage_id": {
         "id": 98,
         "group_id": 1,
@@ -123,7 +131,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Akim",
-      "message_id": 11842
+      "message_id": 10812
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010003.json
@@ -32,7 +32,7 @@
           "num": 1
         },
         {
-          "comment": "Eyedrop",
+          "comment": "Eyedrops",
           "item_id": 39,
           "num": 3
         }
@@ -46,7 +46,7 @@
         "id": 1
       },
       "npc_id": "Rosa",
-      "message_id": 11000
+      "message_id": 11378
     },
     {
       "type": "TalkToNpc",
@@ -54,8 +54,16 @@
         "id": 47
       },
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1201,
+          "Param2": 11874
+        }
+      ],
       "npc_id": "Rudolfo",
-      "message_id": 10915
+      "message_id": 11870
     },
     {
       "type": "TalkToNpc",
@@ -64,8 +72,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Rosa",
-      "message_id": 11005
+      "message_id": 11871
     }
   ]
 }
-

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010003_1.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Sea-Watcher’s Hand (II)",
+  "quest_id": 20010003,
+  "base_level": 13,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 24,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 470
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 40
+    },
+    {
+      "type": "exp",
+      "amount": 420
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Walker Tights",
+          "item_id": 8683,
+          "num": 1
+        },
+        {
+          "comment": "Trooper Suit",
+          "item_id": 947,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Rosa",
+      "message_id": 11378
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 47
+      },
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1201,
+          "Param2": 11874
+        }
+      ],
+      "npc_id": "Rudolfo",
+      "message_id": 11870
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Rosa",
+      "message_id": 11871
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010004.json
@@ -48,10 +48,11 @@
       "starting_index": 5,
       "enemies": [
         {
-          "comment": "Mist Fighter",
+          "comment": "Vigilant Mist Fighter",
           "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
           "level": 15,
-          "exp": 94,
+          "exp": 88,
           "hm_present_no": 68
         }
       ]
@@ -64,11 +65,19 @@
         "id": 47
       },
       "npc_id": "Rudolfo",
-      "message_id": 10800
+      "message_id": 11379
     },
     {
       "type": "KillGroup",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4500,
+          "Param2": 11883
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -78,7 +87,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Rudolfo",
-      "message_id": 10805
+      "message_id": 11877
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010004_1.json
@@ -1,0 +1,102 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Malice in the Dark (II)",
+  "quest_id": 20010004,
+  "base_level": 18,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 24,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 590
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 70
+    },
+    {
+      "type": "exp",
+      "amount": 590
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sacred Hood",
+          "item_id": 730,
+          "num": 1
+        },
+        {
+          "comment": "Sorel Helm",
+          "item_id": 520,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 91
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Vigilant Mist Fighter",
+          "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 68
+        },
+        {
+          "comment": "Vigilant Mist Fighter",
+          "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 68
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 47
+      },
+      "npc_id": "Rudolfo",
+      "message_id": 11379
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4500,
+          "Param2": 11883
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 47
+      },
+      "announce_type": "Update",
+      "npc_id": "Rudolfo",
+      "message_id": 11877
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005.json
@@ -50,34 +50,39 @@
         "id": 34,
         "group_id": 0
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "comment": "Mist Fighter",
-          "enemy_id": "0x011030",
-          "level": 19,
-          "exp": 85,
-          "hm_present_no": 68
-        },
-        {
-          "comment": "Mist Fighter",
-          "enemy_id": "0x011030",
-          "level": 19,
-          "exp": 85,
-          "hm_present_no": 68
-        },
-        {
-          "comment": "Mist Priest",
+          "comment": "Vigilant Mist Priest",
           "enemy_id": "0x011032",
+          "named_enemy_params_id": 53,
           "level": 19,
-          "exp": 85,
+          "exp": 106,
           "hm_present_no": 70
         },
         {
-          "comment": "Mist Priest",
+          "comment": "Vigilant Mist Priest",
           "enemy_id": "0x011032",
+          "named_enemy_params_id": 53,
           "level": 19,
-          "exp": 85,
+          "exp": 106,
           "hm_present_no": 70
+        },
+        {
+          "comment": "Vigilant Mist Fighter",
+          "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 106,
+          "hm_present_no": 68
+        },
+        {
+          "comment": "Vigilant Mist Fighter",
+          "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 106,
+          "hm_present_no": 68
         }
       ]
     }
@@ -89,11 +94,19 @@
         "id": 1
       },
       "npc_id": "Freud",
-      "message_id": 10800
+      "message_id": 11380
     },
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1210,
+          "Param2": 11889
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -109,7 +122,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Freud",
-      "message_id": 10805
+      "message_id": 11886
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005_1.json
@@ -1,0 +1,133 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Mystery of the Wasted Ruins (II)",
+  "quest_id": 20010005,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 515,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 690
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "exp",
+      "amount": 690
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mist Gem",
+          "item_id": 7912,
+          "num": 2
+        },
+        {
+          "comment": "Sprite's Amulet",
+          "item_id": 9384,
+          "num": 1
+        },
+        {
+          "comment": "Herb Salad",
+          "item_id": 9407,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 34,
+        "group_id": 0
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Fighter",
+          "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 68,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Mist Fighter",
+          "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 68,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Freud",
+      "message_id": 11380
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1210,
+          "Param2": 11889
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Freud",
+      "message_id": 11886
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010005_2.json
@@ -1,0 +1,137 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Mystery of the Wasted Ruins (III)",
+  "quest_id": 20010005,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 515,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1010
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 200
+    },
+    {
+      "type": "exp",
+      "amount": 1260
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sinister Black Cloth",
+          "item_id": 7947,
+          "num": 2
+        },
+        {
+          "comment": "Strong Gala Extract",
+          "item_id": 9636,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 34,
+        "group_id": 0
+      },
+      "starting_index": 8,
+      "enemies": [
+        {
+          "comment": "Vigilant Mist Sorcerer",
+          "enemy_id": "0x011033",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 223,
+          "hm_present_no": 71
+        },
+        {
+          "comment": "Vigilant Mist Sorcerer",
+          "enemy_id": "0x011033",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 223,
+          "hm_present_no": 71
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 223,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 223,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Warrior",
+          "enemy_id": "0x011034",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 223,
+          "hm_present_no": 72
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Freud",
+      "message_id": 11380
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1210,
+          "Param2": 11889
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Freud",
+      "message_id": 11886
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010006.json
@@ -37,7 +37,7 @@
           "num": 3
         },
         {
-          "comment": "Eyedrop",
+          "comment": "Eyedrops",
           "item_id": 39,
           "num": 3
         }
@@ -61,11 +61,19 @@
         "layer_no": 1
       },
       "npc_id": "TravelingFemaleHunter",
-      "message_id": 11372
+      "message_id": 11381
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 542,
+          "Param2": 11896
+        }
+      ],
       "stage_id": {
         "id": 1,
         "group_id": 2,
@@ -123,7 +131,7 @@
       },
       "announce_type": "Update",
       "npc_id": "TravelingFemaleHunter",
-      "message_id": 11842
+      "message_id": 11893
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007.json
@@ -50,25 +50,28 @@
         "id": 1,
         "group_id": 97
       },
-      "starting_index": 1,
+      "starting_index": 3,
       "enemies": [
         {
-          "comment": "Hobgoblin Fighter",
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 72
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
           "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
           "level": 19,
-          "exp": 85
+          "exp": 89
         },
         {
-          "comment": "Sling Hobgoblin (Oil flask)",
-          "enemy_id": "0x010112",
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
           "level": 19,
-          "exp": 85
-        },
-        {
-          "comment": "Hobgoblin Leader",
-          "enemy_id": "0x010113",
-          "level": 19,
-          "exp": 85
+          "exp": 89
         }
       ]
     },
@@ -77,31 +80,42 @@
         "id": 1,
         "group_id": 104
       },
-      "starting_index": 7,
+      "starting_index": 6,
       "enemies": [
         {
-          "comment": "Hobgoblin Fighter",
-          "enemy_id": "0x010111",
-          "level": 19,
-          "exp": 85
-        },
-        {
-          "comment": "Sling Hobgoblin (Oil flask)",
-          "enemy_id": "0x010112",
-          "level": 19,
-          "exp": 85
-        },
-        {
-          "comment": "Hobgoblin Fighter",
-          "enemy_id": "0x010111",
-          "level": 19,
-          "exp": 85
-        },
-        {
-          "comment": "Hobgoblin Leader",
+          "comment": "Brutal Hobgoblin Leader",
           "enemy_id": "0x010113",
+          "named_enemy_params_id": 54,
           "level": 21,
-          "exp": 150
+          "exp": 113
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 93
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 93
+        },
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 72
+        },
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 19,
+          "exp": 82
         }
       ]
     }
@@ -113,11 +127,19 @@
         "id": 26
       },
       "npc_id": "Persimmon",
-      "message_id": 10817
+      "message_id": 14777
     },
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1203,
+          "Param2": 14783
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -144,7 +166,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Persimmon",
-      "message_id": 10821
+      "message_id": 14780
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007_1.json
@@ -1,0 +1,174 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Shadow from the South Shore (II)",
+  "quest_id": 20010007,
+  "base_level": 24,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 23,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 790
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 660
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 70
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sorcerer's Coat",
+          "item_id": 761,
+          "num": 1
+        },
+        {
+          "comment": "Grand Surcoat",
+          "item_id": 550,
+          "num": 2
+        },
+        {
+          "comment": "Meatloaf",
+          "item_id": 1351,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 97
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 81,
+          "repop_count": 1
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 103
+        },        
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 103
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 104
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Brutal Hobgoblin Leader",
+          "enemy_id": "0x010113",
+          "named_enemy_params_id": 54,
+          "level": 24,
+          "exp": 125
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 103
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 103
+        },
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 81
+        },
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 81
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 26
+      },
+      "npc_id": "Persimmon",
+      "message_id": 14777
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1203,
+          "Param2": 14783
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 26
+      },
+      "announce_type": "Update",
+      "npc_id": "Persimmon",
+      "message_id": 14780
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007_2.json
@@ -1,0 +1,174 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Shadow from the South Shore (III)",
+  "quest_id": 20010007,
+  "base_level": 32,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 23,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1260
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1050
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 160
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Faerie Band",
+          "item_id": 9564,
+          "num": 1
+        },
+        {
+          "comment": "Five-Herb Salad",
+          "item_id": 9414,
+          "num": 1
+        },
+        {
+          "comment": "Sprite's Amulet",
+          "item_id": 9384,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 97
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 104,
+          "repop_count": 1
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 133
+        },        
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 133
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 104
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Brutal Hobgoblin Leader",
+          "enemy_id": "0x010113",
+          "named_enemy_params_id": 54,
+          "level": 32,
+          "exp": 159
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 133
+        },
+        {
+          "comment": "Vigilant Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 133
+        },
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 104
+        },
+        {
+          "comment": "Vigilant Sling Goblin (Rock)",
+          "enemy_id": "0x010103",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 104
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 26
+      },
+      "npc_id": "Persimmon",
+      "message_id": 14777
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1203,
+          "Param2": 14783
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 26
+      },
+      "announce_type": "Update",
+      "npc_id": "Persimmon",
+      "message_id": 14780
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010007_3.json
@@ -1,0 +1,177 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Shadow from the South Shore (IV)",
+  "quest_id": 20010007,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "news_image": 23,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sand of Reminiscence",
+          "item_id": 9441,
+          "num": 1
+        },
+        {
+          "comment": "Demonic Gem",
+          "item_id": 7911,
+          "num": 1
+        },
+        {
+          "comment": "Cracked Black Horn",
+          "item_id": 7753,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 97
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Vigilant Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Shadow Goblin Fighter",
+          "enemy_id": "0x011131",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 236
+        },
+        {
+          "comment": "Vigilant Shadow Goblin Fighter",
+          "enemy_id": "0x011131",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 236
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 104
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Vigilant Shadow Goblin Fighter",
+          "enemy_id": "0x011131",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 235,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Shadow Goblin Fighter",
+          "enemy_id": "0x011131",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 235
+        },
+        {
+          "comment": "Vigilant Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 223
+        },
+        {
+          "comment": "Vigilant Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 223
+        },
+        {
+          "comment": "Vigilant Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 223
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 26
+      },
+      "npc_id": "Persimmon",
+      "message_id": 14777
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1203,
+          "Param2": 14783
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 26
+      },
+      "announce_type": "Update",
+      "npc_id": "Persimmon",
+      "message_id": 14780
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "From the Waters Depths",
+  "comment": "From the Water's Depths",
   "quest_id": 20015000,
   "base_level": 15,
   "minimum_item_rank": 0,
@@ -47,34 +47,39 @@
       },
       "enemies": [
         {
-          "comment": "Giant Saurian",
+          "comment": "Vigilant Giant Saurian",
           "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
           "level": 15,
-          "exp": 65
+          "exp": 104
         },
         {
-          "comment": "Giant Saurian",
+          "comment": "Vigilant Giant Saurian",
           "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
           "level": 15,
-          "exp": 65
+          "exp": 104
         },
         {
-          "comment": "Giant Saurian",
+          "comment": "Vigilant Giant Saurian",
           "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
           "level": 15,
-          "exp": 65
+          "exp": 104
         },
         {
-          "comment": "Giant Saurian",
+          "comment": "Vigilant Giant Saurian",
           "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
           "level": 15,
-          "exp": 65
+          "exp": 104
         },
         {
-          "comment": "Giant Saurian",
+          "comment": "Vigilant Giant Saurian",
           "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
           "level": 15,
-          "exp": 65
+          "exp": 104
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_1.json
@@ -1,0 +1,111 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "From the Water's Depths (II)",
+  "quest_id": 20015000,
+  "base_level": 17,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 22,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 560
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 460
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 70
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Iron Ingot",
+          "item_id": 7872,
+          "num": 1
+        },
+        {
+          "comment": "Eyedrops",
+          "item_id": 39,
+          "num": 3
+        },
+        {
+          "comment": "Bottled Haste",
+          "item_id": 9365,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 95
+      },
+      "enemies": [
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 17,
+          "exp": 111,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 17,
+          "exp": 111,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 17,
+          "exp": 111,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 17,
+          "exp": 111
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 17,
+          "exp": 111
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_2.json
@@ -1,0 +1,115 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "From the Water's Depths (III)",
+  "quest_id": 20015000,
+  "base_level": 20,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 22,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 660
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 550
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 80
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Leather Cord",
+          "item_id": 7953,
+          "num": 4
+        },
+        {
+          "comment": "Bottled Haste",
+          "item_id": 9365,
+          "num": 3
+        },
+        {
+          "comment": "Waking Draught",
+          "item_id": 9366,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 95
+      },
+      "enemies": [
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 121,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 121,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 121,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 121,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 20,
+          "exp": 121,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_3.json
@@ -1,0 +1,105 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "From the Water's Depths (Bounty)",
+  "quest_id": 20015000,
+  "base_level": 18,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 22,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 890
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 740
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 70
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "High-Grade Bottoms",
+          "item_id": 9689,
+          "num": 1
+        },
+        {
+          "comment": "Waking Draught",
+          "item_id": 7845,
+          "num": 3
+        },
+        {
+          "comment": "Terry Cloth",
+          "item_id": 9367,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 95
+      },
+      "enemies": [
+        {
+          "comment": "Bounty Hobgoblin",
+          "named_enemy_params_id": 458,
+          "enemy_id": "0x010110",
+          "level": 18,
+          "exp": 89
+        },
+        {
+          "comment": "Bounty Hobgoblin",
+          "named_enemy_params_id": 458,
+          "enemy_id": "0x010110",
+          "level": 18,
+          "exp": 89
+        },
+        {
+          "comment": "Bounty Hobgoblin",
+          "named_enemy_params_id": 458,
+          "enemy_id": "0x010110",
+          "level": 18,
+          "exp": 89
+        },
+        {
+          "comment": "Bounty Hobgoblin",
+          "named_enemy_params_id": 458,
+          "enemy_id": "0x010110",
+          "level": 18,
+          "exp": 89
+        },
+        {
+          "comment": "Bounty Hobgoblin",
+          "named_enemy_params_id": 458,
+          "enemy_id": "0x010110",
+          "level": 18,
+          "exp": 89
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001.json
@@ -52,8 +52,9 @@
       },
       "enemies": [
         {
-          "comment": "Armored Cyclops",
+          "comment": "Vigilant Armored Cyclops",
           "enemy_id": "0x015002",
+          "named_enemy_params_id": 53,
           "level": 15,
           "exp": 2120,
           "is_boss": true

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_1.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "That Which Tramples the Ground (II)",
+  "quest_id": 20015001,
+  "base_level": 24,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 21,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1200
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 790
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 170
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Majesty Drapes",
+          "item_id": 865,
+          "num": 1
+        },
+        {
+          "comment": "Interventive",
+          "item_id": 9374,
+          "num": 3
+        },
+        {
+          "comment": "Lestania Wine",
+          "item_id": 9409,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 84
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Armored Cyclops (Club)",
+          "enemy_id": "0x015003",
+          "named_enemy_params_id": 54,
+          "level": 24,
+          "exp": 2597,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_2.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "That Which Tramples the Ground (Bounty)",
+  "quest_id": 20015001,
+  "base_level": 15,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 21,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1180
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 820
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 50
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Superior Healing Potion",
+          "item_id": 35,
+          "num": 2
+        },
+        {
+          "comment": "Superior Gala Extract",
+          "item_id": 61,
+          "num": 2
+        },
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 84
+      },
+      "enemies": [
+        {
+          "comment": "Bounty Armored Cyclops",
+          "enemy_id": "0x015002",
+          "named_enemy_params_id": 458,
+          "level": 15,
+          "exp": 2120,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002.json
@@ -45,40 +45,46 @@
         "id": 1,
         "group_id": 85
       },
+      "starting_index": 4,
       "enemies": [
         {
-          "comment": "Mist Fighter",
+          "comment": "Vigilant Mist Fighter",
           "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
           "level": 14,
-          "exp": 79,
+          "exp": 83,
           "hm_present_no": 68
         },
         {
-          "comment": "Mist Fighter",
+          "comment": "Vigilant Mist Fighter",
           "enemy_id": "0x011030",
+          "named_enemy_params_id": 53,
           "level": 14,
-          "exp": 79,
+          "exp": 83,
           "hm_present_no": 68
         },
         {
-          "comment": "Mist Hunter",
+          "comment": "Vigilant Mist Hunter",
           "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
           "level": 14,
-          "exp": 79,
+          "exp": 83,
           "hm_present_no": 69
         },
         {
-          "comment": "Mist Hunter",
+          "comment": "Vigilant Mist Hunter",
           "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
           "level": 14,
-          "exp": 79,
+          "exp": 83,
           "hm_present_no": 69
         },
         {
-          "comment": "Mist Hunter",
+          "comment": "Vigilant Mist Hunter",
           "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
           "level": 14,
-          "exp": 79,
+          "exp": 83,
           "hm_present_no": 69
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_1.json
@@ -1,0 +1,106 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Phantoms in the Moonlight (II)",
+  "quest_id": 20015002,
+  "base_level": 18,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 25,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 710
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 490
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sorel Helm",
+          "item_id": 520,
+          "num": 1
+        },
+        {
+          "comment": "Sacred Hood",
+          "item_id": 730,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 85
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Vigilant Mist Priest",
+          "enemy_id": "0x011032",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 68
+        },
+        {
+          "comment": "Vigilant Mist Priest",
+          "enemy_id": "0x011032",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 68
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 18,
+          "exp": 101,
+          "hm_present_no": 69
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_2.json
@@ -1,0 +1,111 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Phantoms in the Moonlight (III)",
+  "quest_id": 20015002,
+  "base_level": 21,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "news_image": 25,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 830
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 570
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 110
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sorcery Bangles",
+          "item_id": 812,
+          "num": 1
+        },
+        {
+          "comment": "Murg Armguards",
+          "item_id": 599,
+          "num": 1
+        },
+        {
+          "comment": "Healing Elixir",
+          "item_id": 7552,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 85
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Vigilant Mist Sorcerer",
+          "enemy_id": "0x011033",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 68
+        },
+        {
+          "comment": "Vigilant Mist Sorcerer",
+          "enemy_id": "0x011033",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 68
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 69
+        },
+        {
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
+          "named_enemy_params_id": 53,
+          "level": 21,
+          "exp": 114,
+          "hm_present_no": 69
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003.json
@@ -47,16 +47,19 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Oldies Pants",
           "item_id": 8693,
           "num": 1,
           "chance": 0.4
         },
         {
-          "item_id": 8693,
+          "comment": "Peridot",
+          "item_id": 7895,
           "num": 1,
           "chance": 0.4
         },
         {
+          "comment": "Double Fang Earrings",
           "item_id": 8955,
           "num": 1,
           "chance": 0.4
@@ -68,9 +71,8 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 105
+        "group_id": 99
       },
-      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Young Chimera",
@@ -78,9 +80,8 @@
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 459,
           "level": 19,
-          "exp": 1264,
-          "is_boss": true,
-          "index": 3
+          "exp": 2340,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "An Unexpected Encounter",
+  "comment": "An Unexpected Encounter (II)",
   "quest_id": 20015003,
   "base_level": 36,
   "minimum_item_rank": 0,
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Nostalgia Waistguard",
+          "comment": "Protective Cloth",
           "item_id": 7940,
           "num": 1
         },
         {
-          "comment": "Absorbent Cloth",
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 3
         },
         {
-          "comment": "Superior Healing Potion",
+          "comment": "Special Mushroom Dip",
           "item_id": 9419,
           "num": 1
         }
@@ -48,6 +48,7 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Fancy Dress: Ryu B",
           "item_id": 10812,
           "num": 1,
           "chance": 0.4
@@ -59,19 +60,17 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 105
+        "group_id": 99
       },
-      "placement_type": "manual",
       "enemies": [
         {
-          
+          "comment": "Brutal Lindwurm",
           "enemy_id": "0x015707",
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
+          "named_enemy_params_id": 54,
           "level": 36,
-          "exp": 6040,
-          "is_boss": true,
-          "index": 3
+          "exp": 6466,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "An Unexpected Encounter",
+  "comment": "An Unexpected Encounter (III)",
   "quest_id": 20015003,
   "base_level": 60,
   "minimum_item_rank": 0,
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          
+          "comment": "Azure Dragonscale",
           "item_id": 7931,
           "num": 1
         },
         {
-          
+          "comment": "Huge Dragon Bone Lump",
           "item_id": 7806,
           "num": 1
         },
         {
-         
+          "comment": "Dragon Hide",
           "item_id": 7928,
           "num": 5
         }
@@ -49,19 +49,17 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 105
+        "group_id": 99
       },
-      "placement_type": "manual",
       "enemies": [
         {
-          
+          "comment": "Dangerous Wyrm",
           "enemy_id": "0x015701",
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
+          "named_enemy_params_id": 56,
           "level": 60,
-          "exp": 34700,
-          "is_boss": true,
-          "index": 3
+          "exp": 9860,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015004.json
@@ -52,28 +52,32 @@
       },
       "enemies": [
         {
-          "comment": "Blue Newt",
+          "comment": "Vigilant Blue Newt",
           "enemy_id": "0x010460",
+          "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 463
+          "exp": 167
         },
         {
-          "comment": "Blue Newt",
+          "comment": "Vigilant Blue Newt",
           "enemy_id": "0x010460",
+          "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 463
+          "exp": 167
         },
         {
-          "comment": "Blue Newt",
+          "comment": "Vigilant Blue Newt",
           "enemy_id": "0x010460",
+          "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 463
+          "exp": 167
         },
         {
-          "comment": "Blue Newt",
+          "comment": "Vigilant Blue Newt",
           "enemy_id": "0x010460",
+          "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 463
+          "exp": 167
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005.json
@@ -1,7 +1,7 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "Dispatch A Clamor of Harpies",
+    "comment": "Dispatch A Clamor of Harpies!",
     "quest_id": 20015005,
     "base_level": 8,
     "minimum_item_rank": 0,
@@ -27,10 +27,12 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Cotton Hose",
                     "item_id": 506,
                     "num": 1
                 },
                 {
+                    "comment": "Linen Tunic",
                     "item_id": 8543,
                     "num": 1
                 }
@@ -45,27 +47,35 @@
             },
             "enemies": [
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
-                    "level": 4,
-                    "exp": 94,
+                    "named_enemy_params_id": 53,
+                    "level": 8,
+                    "exp": 41,
                     "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
-                    "level": 4,
-                    "exp": 94,
+                    "named_enemy_params_id": 53,
+                    "level": 8,
+                    "exp": 41,
                     "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
-                    "level": 4,
-                    "exp": 94,
+                    "named_enemy_params_id": 53,
+                    "level": 8,
+                    "exp": 41,
                     "is_boss": false
                 },
                 {
+                    "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
-                    "level": 4,
-                    "exp": 94,
+                    "named_enemy_params_id": 53,
+                    "level": 8,
+                    "exp": 41,
                     "is_boss": false
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_1.json
@@ -1,0 +1,113 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Dispatch A Clamor of Harpies! (II)",
+    "quest_id": 20015005,
+    "base_level": 11,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "BreyaCoast",
+    "news_image": 25,
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 300
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 50
+        },
+        {
+            "type": "exp",
+            "amount": 390
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Leaf Signet Ring",
+                    "item_id": 8938,
+                    "num": 1
+                },
+                {
+                    "comment": "Lockpick",
+                    "item_id": 59,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 94
+            },
+            "enemies": [
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 62,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 62,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 62,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 62,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 62,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 11,
+                    "exp": 62,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_2.json
@@ -1,0 +1,118 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Dispatch A Clamor of Harpies! (III)",
+    "quest_id": 20015005,
+    "base_level": 26,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "BreyaCoast",
+    "news_image": 25,
+    "variant_index": 2,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 710
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 120
+        },
+        {
+            "type": "exp",
+            "amount": 940
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Combat Guard",
+                    "item_id": 655,
+                    "num": 1
+                },
+                {
+                    "comment": "Throwing Rock",
+                    "item_id": 8543,
+                    "num": 3
+                },
+                {
+                    "comment": "Quality Gala Extract",
+                    "item_id": 9361,
+                    "num": 2
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 94
+            },
+            "enemies": [
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 105,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 105,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 105,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 105,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 105,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 26,
+                    "exp": 105,
+                    "is_boss": false
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [ 0 ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [ 0 ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020002.json
@@ -1,0 +1,129 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Unexpected Training",
+  "quest_id": 20020002,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2120
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 200
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Chipped Gold Lump",
+          "item_id": 8025,
+          "num": 2
+        },
+        {
+          "comment": "Enhanced Lumber Knife",
+          "item_id": 9402,
+          "num": 3
+        },
+        {
+          "comment": "Strong Gala Extract",
+          "item_id": 9363,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 147,
+        "group_id": 13
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Vigilant Damned Golem",
+          "enemy_id": "0x015103",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 4429,
+          "is_boss": true
+        },
+        {
+          "comment": "Vigilant Alchemized Sling Goblin",
+          "enemy_id": "0x011122",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 184
+        },
+        {
+          "comment": "Vigilant Alchemized Sling Goblin",
+          "enemy_id": "0x011122",
+          "named_enemy_params_id": 53,
+          "level": 46,
+          "exp": 184
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 997,
+          "comment": "Spawns Gurdolin3"
+        }
+      ],
+      "stage_id": {
+        "id": 147,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Gurdolin3",
+      "message_id": 11116
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 501,
+          "Param2": 11122
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 147,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Gurdolin3",
+      "message_id": 11119
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001.json
@@ -1,0 +1,91 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Curious Gourmand",
+  "quest_id": 20030001,
+  "base_level": 28,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 920
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 360
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 120
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Iron Thread",
+          "item_id": 7955,
+          "num": 3
+        },
+        {
+          "comment": "Conqueror's Amulet",
+          "item_id": 9381,
+          "num": 2
+        },
+        {
+          "comment": "Mushroom Sauté",
+          "item_id": 1351,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1036,
+          "comment": "Spawns August NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 306,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "August",
+      "message_id": 11167
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 306,
+        "group_id": 1
+      },
+      "npc_id": "August",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 515,
+          "Param2": 11173
+        }
+      ],
+      "items": [
+        {
+          "comment": "Coconut-Scented Milkcap",
+          "id": 8036,
+          "amount": 8
+        }
+      ],
+      "message_id": 11170
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001_1.json
@@ -1,0 +1,92 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Curious Gourmand (II)",
+  "quest_id": 20030001,
+  "base_level": 28,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DoweValley",
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 920
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 450
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 120
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Red Chromium",
+          "item_id": 7879,
+          "num": 3
+        },
+        {
+          "comment": "Angel's Amulet",
+          "item_id": 9382,
+          "num": 2
+        },
+        {
+          "comment": "Enhanced Lumber Knife",
+          "item_id": 9401,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1036,
+          "comment": "Spawns August NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 306,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "August",
+      "message_id": 11168
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 306,
+        "group_id": 1
+      },
+      "npc_id": "August",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 515,
+          "Param2": 11173
+        }
+      ],
+      "items": [
+        {
+          "comment": "Coconut-Scented Milkcap",
+          "id": 8036,
+          "amount": 10
+        }
+      ],
+      "message_id": 11171
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003.json
@@ -42,22 +42,24 @@
           "num": 2
         }
       ]
-  },
-  {
+    },
+    {
       "type": "random",
       "loot_pool": [
-          {
-              "item_id": 8990,
-              "num": 1,
-              "chance": 0.6
-          },
-          {
-            "item_id": 9001,
-            "num": 1,
-            "chance": 0.6
+        {
+          "comment": "Wolf Insignia Ring",
+          "item_id": 8990,
+          "num": 1,
+          "chance": 0.6
+        },
+        {
+          "comment": "Icebreaker's Earrings",
+          "item_id": 9001,
+          "num": 1,
+          "chance": 0.6
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
@@ -67,13 +69,13 @@
       },
       "placement_type": "manual",
       "enemies": [
-        
         {
+          "comment": "Brutal Behemoth",
           "enemy_id": "0x015709",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 40,
-          "exp": 13500,
+          "exp": 7280,
           "is_boss": true,
           "index": 2
         }
@@ -89,11 +91,19 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11372
+      "message_id": 11196
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1502,
+          "Param2": 11202
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -111,7 +121,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11842
+      "message_id": 11199
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_1.json
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Crest of Incineration",
+          "comment": "Sacred Blessed Cloth",
           "item_id": 7943,
           "num": 1
         },
         {
-          "comment": "Exquisite Fried Meat",
+          "comment": "Enhanced Lockpick",
           "item_id": 9403,
           "num": 3
         },
         {
-          "comment": "Three-Herb Salad",
+          "comment": "Strong Gala Extract",
           "item_id": 9363,
           "num": 3
         }
@@ -47,11 +47,12 @@
   {
       "type": "random",
       "loot_pool": [
-          {
-              "item_id": 7959,
-              "num": 1,
-              "chance": 1.0
-          }
+        {
+          "comment": "Gleipnir",
+          "item_id": 7959,
+          "num": 1,
+          "chance": 1.0
+        }
       ]
   }
   ],
@@ -63,13 +64,13 @@
       },
       "placement_type": "manual",
       "enemies": [
-        
         {
+          "comment": "Dangerous Angules",
           "enemy_id": "0x015708",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 51,
-          "exp": 15278,
+          "exp": 8664,
           "is_boss": true,
           "index": 2
         }
@@ -85,11 +86,19 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11372
+      "message_id": 11196
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1502,
+          "Param2": 11202
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -107,7 +116,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11842
+      "message_id": 11199
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Timeless Castle",
+  "comment": "The Timeless Castle (III)",
   "quest_id": 20030003,
   "base_level": 58,
   "minimum_item_rank": 0,
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Crest of Incineration",
+          "comment": "Dragon Horn",
           "item_id": 7754,
           "num": 1
         },
         {
-          "comment": "Exquisite Fried Meat",
+          "comment": "Smooth Dragonleather",
           "item_id": 7927,
           "num": 1
         },
         {
-          "comment": "Three-Herb Salad",
+          "comment": "Angules Horn",
           "item_id": 7756,
           "num": 1
         }
@@ -54,13 +54,13 @@
       },
       "placement_type": "manual",
       "enemies": [
-        
         {
+          "comment": "Dangerous Angules",
           "enemy_id": "0x015708",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
           "level": 58,
-          "exp": 26700,
+          "exp": 9462,
           "is_boss": true,
           "index": 2
         }
@@ -76,11 +76,19 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11372
+      "message_id": 11198
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1502,
+          "Param2": 11202
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -98,7 +106,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11842
+      "message_id": 11201
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_3.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Timeless Castle",
+  "comment": "The Timeless Castle (IV)",
   "quest_id": 20030003,
   "base_level": 58,
   "minimum_item_rank": 0,
@@ -28,23 +28,22 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Crest of Incineration",
+          "comment": "Dragon Fang",
           "item_id": 7763,
           "num": 1
         },
         {
-          "comment": "Exquisite Fried Meat",
+          "comment": "Thick Dragonscale",
           "item_id": 7929,
           "num": 1
         },
         {
-          "comment": "Three-Herb Salad",
+          "comment": "Behemoth Fang",
           "item_id": 7799,
           "num": 1
         }
       ]
-  
-  }
+    }
   ],
   "enemy_groups": [
     {
@@ -54,13 +53,13 @@
       },
       "placement_type": "manual",
       "enemies": [
-        
         {
+          "comment": "Legendary Behemoth",
           "enemy_id": "0x015709",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 57,
           "level": 58,
-          "exp": 26700,
+          "exp": 9296,
           "is_boss": true,
           "index": 2
         }
@@ -76,11 +75,19 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11372
+      "message_id": 11198
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1502,
+          "Param2": 11202
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -98,7 +105,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11842
+      "message_id": 11201
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_4.json
@@ -1,0 +1,111 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Timeless Castle (Rare Species)",
+  "quest_id": 20030003,
+  "base_level": 58,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DoweValley",
+  "news_image": 71,
+  "variant_index": 4,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2870
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1590
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 380
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 2
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 2
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 69,
+        "group_id": 19
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Big Fang Behemoth (Behemoth)",
+          "enemy_id": "0x015709",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 595,
+          "level": 58,
+          "exp": 9296,
+          "is_boss": true,
+          "index": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 42,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Urda",
+      "message_id": 11198
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1502,
+          "Param2": 11202
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 42,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Urda",
+      "message_id": 11201
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040000.json
@@ -12,7 +12,7 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 200
+      "amount": 120
     },
     {
       "type": "wallet",
@@ -21,7 +21,7 @@
     },
     {
       "type": "exp",
-      "amount": 370
+      "amount": 270
     },
     {
       "type": "select",
@@ -35,11 +35,6 @@
           "comment": "Small Thief Key",
           "item_id": 9429,
           "num": 3
-        },
-        {
-          "comment": "Sorcerer Hat",
-          "item_id": 8153,
-          "num": 1
         }
       ]
     }
@@ -51,7 +46,7 @@
         "id": 52
       },
       "npc_id": "Livian",
-      "message_id": 10800
+      "message_id": 11055
     },
     {
       "type": "DeliverItems",
@@ -61,13 +56,22 @@
       },
       "npc_id": "Livian",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1603,
+          "Param2": 11061
+        }
+      ],
       "items": [
         {
+          "comment": "Angelica",
           "id": 7982,
           "amount": 8
         }
       ],
-      "message_id": 10737
+      "message_id": 11058
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040000_1.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Stylish Consideration (II)",
+  "quest_id": 20040000,
+  "base_level": 25,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 68,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 120
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 80
+    },
+    {
+      "type": "exp",
+      "amount": 310
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Combat Fabric",
+          "item_id": 7938,
+          "num": 2
+        },
+        {
+          "comment": "Purifying Decoction",
+          "item_id": 9372,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 52
+      },
+      "npc_id": "Livian",
+      "message_id": 11055
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 52,
+        "group_id": 1
+      },
+      "npc_id": "Livian",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1603,
+          "Param2": 11061
+        }
+      ],
+      "items": [
+        {
+          "comment": "Yellow Thyme",
+          "id": 7977,
+          "amount": 5
+        }
+      ],
+      "message_id": 11058
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040001.json
@@ -48,31 +48,56 @@
     {
       "stage_id": {
         "id": 72,
-        "group_id": 18
+        "group_id": 19
       },
+      "starting_index": 7,
       "enemies": [
         {
-          "enemy_id": "0x010450",
+          "comment": "Vigilant Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 500,
+          "exp": 246,
           "is_boss": false
         },
         {
-          "enemy_id": "0x010450",
+          "comment": "Vigilant Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 500,
+          "exp": 246,
           "is_boss": false
         },
         {
-          "enemy_id": "0x010450",
+          "comment": "Vigilant Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 500,
+          "exp": 246,
           "is_boss": false
         },
         {
-          "enemy_id": "0x010450",
+          "comment": "Vigilant Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 500,
+          "exp": 246,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 246,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 246,
           "is_boss": false
         }
       ]
@@ -87,11 +112,19 @@
         "layer_no": 1
       },
       "npc_id": "Cromwell",
-      "message_id": 11372
+      "message_id": 11063
     },
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1619,
+          "Param2": 11069
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -109,7 +142,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Cromwell",
-      "message_id": 11842
+      "message_id": 11066
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Battle Sallet",
           "item_id": 524,
           "num": 1
         },
         {
+          "comment": "Concoction of Light",
           "item_id": 9376,
           "num": 3
         },
         {
+          "comment": "Forest Dweller's Old Key",
           "item_id": 9066,
           "num": 1
         }
@@ -44,11 +47,13 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Ogre Fur",
           "item_id": 7776,
           "num": 1,
           "chance": 0.6
         },
         {
+          "comment": "Throwblast",
           "item_id": 52,
           "num": 3,
           "chance": 0.6
@@ -62,16 +67,15 @@
         "id": 1,
         "group_id": 185
       },
-      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Vigilant Griffin",
           "enemy_id": "0x015300",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+          "named_enemy_params_id": 53,
           "level": 26,
-          "exp": 4200,
-          "is_boss": true,
-          "index": 0
+          "exp": 3450,
+          "is_boss": true
         }
       ]
     }
@@ -85,11 +89,19 @@
         "layer_no": 1
       },
       "npc_id": "Gilstan",
-      "message_id": 11830
+      "message_id": 11071
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 2000,
+          "Param2": 11077
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -107,7 +119,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gilstan",
-      "message_id": 11835
+      "message_id": 11074
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_1.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Territorial Dispute",
+  "comment": "A Territorial Dispute (II)",
   "quest_id": 20040002,
-  "base_level": 30,
+  "base_level": 33,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "VoldenMines",
@@ -13,31 +13,34 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1780
+      "amount": 1080
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 190
+      "amount": 210
     },
     {
       "type": "exp",
-      "amount": 2490
+      "amount": 1520
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 9429,
-          "num": 3
-        },
-        {
-          "item_id": 9374,
-          "num": 3
-        },
-        {
-          "item_id": 9413,
+          "comment": "Crest of Holy Drain Warding",
+          "item_id": 9323,
           "num": 1
+        },
+        {
+          "comment": "Exquisite Fried Meat",
+          "item_id": 9416,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Elixir",
+          "item_id": 7553,
+          "num": 2
         }
       ]
     }
@@ -48,16 +51,15 @@
         "id": 1,
         "group_id": 185
       },
-      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015100",
-          "start_think_tbl_no": 2,
-		      "named_enemy_params_id": 470,
-          "level": 30,
-          "exp": 5446,
-          "is_boss": true,
-          "index": 0
+          "comment": "Brutal Chimera",
+          "enemy_id": "0x015200",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 33,
+          "exp": 3180,
+          "is_boss": true
         }
       ]
     }
@@ -71,11 +73,19 @@
         "layer_no": 1
       },
       "npc_id": "Gilstan",
-      "message_id": 11830
+      "message_id": 11071
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 2000,
+          "Param2": 11077
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -93,7 +103,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gilstan",
-      "message_id": 11835
+      "message_id": 11074
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_2.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Territorial Dispute",
+  "comment": "A Territorial Dispute (III)",
   "quest_id": 20040002,
-  "base_level": 33,
+  "base_level": 38,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "VoldenMines",
@@ -13,31 +13,34 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1080
+      "amount": 1250
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 210
+      "amount": 250
     },
     {
       "type": "exp",
-      "amount": 1520
+      "amount": 1750
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 9323,
+          "comment": "Crest of Permafrost",
+          "item_id": 9260,
           "num": 1
         },
         {
-          "item_id": 9416,
-          "num": 1
-        },
-        {
-          "item_id": 7553,
+          "comment": "Forest Dweller's Old Key",
+          "item_id": 9066,
           "num": 2
+        },
+        {
+          "comment": "Sprite's Talisman",
+          "item_id": 9390,
+          "num": 1
         }
       ]
     }
@@ -48,16 +51,15 @@
         "id": 1,
         "group_id": 185
       },
-      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015200",
+          "comment": "Dangerous Griffin",
+          "enemy_id": "0x015300",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
-          "level": 33,
-          "exp": 5734,
-          "is_boss": true,
-          "index": 0
+          "named_enemy_params_id": 56,
+          "level": 38,
+          "exp": 4350,
+          "is_boss": true
         }
       ]
     }
@@ -71,11 +73,19 @@
         "layer_no": 1
       },
       "npc_id": "Gilstan",
-      "message_id": 11830
+      "message_id": 11071
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 2000,
+          "Param2": 11077
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -93,7 +103,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gilstan",
-      "message_id": 11835
+      "message_id": 11074
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_3.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Territorial Dispute",
+  "comment": "A Territorial Dispute (Bounty)",
   "quest_id": 20040002,
-  "base_level": 38,
+  "base_level": 30,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "VoldenMines",
@@ -13,31 +13,34 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1250
+      "amount": 1780
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 250
+      "amount": 190
     },
     {
       "type": "exp",
-      "amount": 1750
+      "amount": 2490
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 9260,
-          "num": 1
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 3
         },
         {
-          "item_id": 9390,
-          "num": 1
+          "comment": "Interventive",
+          "item_id": 9374,
+          "num": 3
         },
         {
-          "item_id": 9066,
-          "num": 2
+          "comment": "Mellow Ale",
+          "item_id": 9413,
+          "num": 1
         }
       ]
     }
@@ -48,16 +51,15 @@
         "id": 1,
         "group_id": 185
       },
-      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015300",
+          "comment": "Bounty Golem",
+          "enemy_id": "0x015100",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
-          "level": 38,
-          "exp": 6254,
-          "is_boss": true,
-          "index": 0
+          "named_enemy_params_id": 470,
+          "level": 30,
+          "exp": 2750,
+          "is_boss": true
         }
       ]
     }
@@ -71,11 +73,19 @@
         "layer_no": 1
       },
       "npc_id": "Gilstan",
-      "message_id": 11830
+      "message_id": 11072
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 2000,
+          "Param2": 11077
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -93,7 +103,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gilstan",
-      "message_id": 11835
+      "message_id": 11075
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040003.json
@@ -56,11 +56,19 @@
         "layer_no": 1
       },
       "npc_id": "Eugene",
-      "message_id": 11372
+      "message_id": 11079
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1607,
+          "Param2": 11085
+        }
+      ],
       "stage_id": {
         "id": 101,
         "group_id": 2,
@@ -280,7 +288,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Eugene",
-      "message_id": 11842
+      "message_id": 11082
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040003_1.json
@@ -1,0 +1,300 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Burden of Procurement (II)",
+  "quest_id": 20040003,
+  "base_level": 28,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 93,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 770
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 920
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 120
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Endurance Ring",
+          "item_id": 8971,
+          "num": 1
+        },
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9373,
+          "num": 3
+        },
+        {
+          "comment": "Conqueror's Amulet",
+          "item_id": 9381,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1046,
+          "comment": "Spawns Eugene NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 101,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Eugene",
+      "message_id": 11079
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1607,
+          "Param2": 11085
+        }
+      ],
+      "stage_id": {
+        "id": 101,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1160,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1161,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1162,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1163,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1164,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1165,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1839,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1840,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1841,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1842,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 101,
+        "group_id": 3,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1160,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1161,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1162,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1163,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1164,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1165,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1839,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1840,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1841,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1842,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 101,
+        "group_id": 4,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1160,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1161,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1162,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1163,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1164,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1165,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1839,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1840,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1841,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1842,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 101,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Eugene",
+      "message_id": 11082
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Shaman's Robe",
           "item_id": 758,
           "num": 1
         },
         {
+          "comment": "Poison Flask",
           "item_id": 9395,
           "num": 3
         },
         {
+          "comment": "Refreshing Remedy",
           "item_id": 9375,
           "num": 2
         }
@@ -44,6 +47,7 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Gala Extract",
           "item_id": 36,
           "num": 9,
           "chance": 1.0
@@ -57,11 +61,14 @@
         "id": 152,
         "group_id": 5
       },
+      "starting_index": 7,
       "enemies": [
         {
+          "comment": "Vigilant Armored Cyclops",
           "enemy_id": "0x015002",
+          "named_enemy_params_id": 53,
           "level": 22,
-          "exp": 4500,
+          "exp": 2491,
           "is_boss": true
         }
       ]
@@ -76,11 +83,19 @@
         "layer_no": 1
       },
       "npc_id": "Miles",
-      "message_id": 11830
+      "message_id": 11087
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1612,
+          "Param2": 11093
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -98,7 +113,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Miles",
-      "message_id": 11835
+      "message_id": 11090
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_1.json
@@ -1,0 +1,109 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Cause of the Hot Springs Blockage (II)",
+  "quest_id": 20040004,
+  "base_level": 28,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 91,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 920
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 140
+    },
+    {
+      "type": "exp",
+      "amount": 1290
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Artisan's Boots",
+          "item_id": 9699,
+          "num": 1
+        },
+        {
+          "comment": "Healing Elixir",
+          "item_id": 7552,
+          "num": 3
+        },
+        {
+          "comment": "Angel's Amulet",
+          "item_id": 9382,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 152,
+        "group_id": 5
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Brutal Colossus",
+          "enemy_id": "0x015020",
+          "named_enemy_params_id": 54,
+          "level": 28,
+          "exp": 2968,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 80,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Miles",
+      "message_id": 11087
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1612,
+          "Param2": 11093
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 80,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Miles",
+      "message_id": 11090
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_2.json
@@ -1,0 +1,109 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Cause of the Hot Springs Blockage (Bounty)",
+  "quest_id": 20040004,
+  "base_level": 22,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 91,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1370
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 80
+    },
+    {
+      "type": "exp",
+      "amount": 1650
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Healing Elixir",
+          "item_id": 7552,
+          "num": 2
+        },
+        {
+          "comment": "Quality Gala Extract",
+          "item_id": 9361,
+          "num": 2
+        },
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 152,
+        "group_id": 5
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Bounty Cyclops",
+          "enemy_id": "0x015000",
+          "named_enemy_params_id": 458,
+          "level": 25,
+          "exp": 2400,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 80,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Miles",
+      "message_id": 11088
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1612,
+          "Param2": 11093
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 80,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Miles",
+      "message_id": 11091
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005.json
@@ -56,11 +56,19 @@
         "layer_no": 1
       },
       "npc_id": "Nelson",
-      "message_id": 11372
+      "message_id": 11095
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1608,
+          "Param2": 11101
+        }
+      ],
       "stage_id": {
         "id": 104,
         "group_id": 2,
@@ -316,7 +324,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Nelson",
-      "message_id": 11842
+      "message_id": 11098
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005_1.json
@@ -1,0 +1,336 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Tempting Lights (II)",
+  "quest_id": 20040005,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 535,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 990
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 190
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gold Ore",
+          "item_id": 7859,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1048,
+          "comment": "Spawns Nelson NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 104,
+        "group_id": 13,
+        "layer_no": 1
+      },
+      "npc_id": "Nelson",
+      "message_id": 11095
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1608,
+          "Param2": 11101
+        }
+      ],
+      "stage_id": {
+        "id": 104,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1166,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1167,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1168,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1169,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1170,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1832,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1833,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1834,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1835,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1836,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1837,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1838,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 104,
+        "group_id": 3,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1166,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1167,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1168,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1169,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1170,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1832,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1833,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1834,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1835,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1836,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1837,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1838,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 104,
+        "group_id": 4,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1166,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1167,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1168,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1169,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1170,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1832,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1833,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1834,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1835,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1836,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1837,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1838,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 104,
+        "group_id": 13,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Nelson",
+      "message_id": 11098
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006.json
@@ -11,17 +11,17 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1180
+      "amount": 850
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 990
+      "amount": 710
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 150
+      "amount": 110
     },
     {
       "type": "select",
@@ -37,7 +37,7 @@
           "num": 3
         },
         {
-          "comment": "Demon Amulet",
+          "comment": "Demon's Amulet",
           "item_id": 9383,
           "num": 2
         }
@@ -52,37 +52,49 @@
       },
       "enemies": [
         {
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
           "is_boss": false,
           "hm_present_no": 45
         },
         {
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
           "is_boss": false,
           "hm_present_no": 45
         },
         {
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
           "is_boss": false,
           "hm_present_no": 45
         },
         {
+          "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
           "is_boss": false,
-          "hm_present_no": 46
+          "hm_present_no": 46,
+          "repop_count": 1,
+          "repop_wait_second": 5
         },
         {
+          "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
           "is_boss": false,
           "hm_present_no": 46
         }
@@ -106,11 +118,19 @@
         "layer_no": 1
       },
       "npc_id": "Soldier0",
-      "message_id": 11372
+      "message_id": 11419
     },
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 536,
+          "Param2": 12241
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -128,7 +148,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Soldier0",
-      "message_id": 11842
+      "message_id": 12238
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_1.json
@@ -1,0 +1,159 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Grim Pilgrimage (II)",
+  "quest_id": 20040006,
+  "base_level": 30,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 572,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 990
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 820
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 130
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Arisen's Mantle",
+          "item_id": 8848,
+          "num": 1
+        },
+        {
+          "comment": "Throwblast",
+          "item_id": 52,
+          "num": 2
+        },
+        {
+          "comment": "Sprite's Amulet",
+          "item_id": 9384,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 138,
+        "group_id": 1
+      },
+      "enemies": [
+        {
+          "comment": "Vigilant Rogue Defender",
+          "enemy_id": "0x011004",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 49
+        },
+        {
+          "comment": "Vigilant Rogue Defender",
+          "enemy_id": "0x011004",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 49
+        },
+        {
+          "comment": "Vigilant Rogue Defender",
+          "enemy_id": "0x011004",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 49,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 47,
+          "repop_count": 2,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 47,
+          "repop_count": 2,
+          "repop_wait_second": 5
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1049,
+          "comment": "Spawns Soldier0 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Soldier0",
+      "message_id": 11419
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 536,
+          "Param2": 12241
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Soldier0",
+      "message_id": 12238
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_2.json
@@ -1,0 +1,144 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Grim Pilgrimage (III)",
+  "quest_id": 20040006,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 572,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2630
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1560
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Magick Lion's Large Mane",
+          "item_id": 9437,
+          "num": 1
+        },
+        {
+          "comment": "Rainbow Eye Gem",
+          "item_id": 7731,
+          "num": 1
+        },
+        {
+          "comment": "Alkahest",
+          "item_id": 7833,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 138,
+        "group_id": 1
+      },
+      "enemies": [
+        {
+          "comment": "Dangerous Chimera",
+          "enemy_id": "0x015200",
+          "named_enemy_params_id": 56,
+          "level": 57,
+          "exp": 4620,
+          "is_boss": true
+        },
+        {
+          "comment": "Brutal Lapis Eye",
+          "enemy_id": "0x015412",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 388
+        },
+        {
+          "comment": "Brutal Lapis Eye",
+          "enemy_id": "0x015412",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 388
+        },
+        {
+          "comment": "Brutal Lapis Eye",
+          "enemy_id": "0x015412",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 388
+        },
+        {
+          "comment": "Brutal Lapis Eye",
+          "enemy_id": "0x015412",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 388
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1049,
+          "comment": "Spawns Soldier0 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Soldier0",
+      "message_id": 12237
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 536,
+          "Param2": 12241
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Soldier0",
+      "message_id": 12240
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007.json
@@ -27,18 +27,13 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Over Guard",
-          "item_id": 628,
+          "comment": "Crest of Torpor",
+          "item_id": 9241,
           "num": 1
         },
         {
-          "comment": "Quality Gala Extract",
-          "item_id": 9361,
-          "num": 3
-        },
-        {
-          "comment": "Demon Amulet",
-          "item_id": 9383,
+          "comment": "Enhanced Pickaxe",
+          "item_id": 9401,
           "num": 2
         }
       ]
@@ -52,9 +47,12 @@
       },
       "enemies": [
         {
+          "comment": "Vigilant Chimera",
           "enemy_id": "0x015200",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 6000,
+          "exp": 3000,
           "is_boss": true
         }
       ]
@@ -77,11 +75,19 @@
         "layer_no": 1
       },
       "npc_id": "Man511",
-      "message_id": 11372
+      "message_id": 11420
     },
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 511,
+          "Param2": 12247
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -99,7 +105,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Man511",
-      "message_id": 11842
+      "message_id": 12244
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_1.json
@@ -1,0 +1,117 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Miner’s Lifeline (II)",
+  "quest_id": 20040007,
+  "base_level": 35,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 94,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1610
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1150
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 230
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Giant Tough Pelt",
+          "item_id": 7925,
+          "num": 1
+        },
+        {
+          "comment": "Silver Ore",
+          "item_id": 7857,
+          "num": 5
+        },
+        {
+          "comment": "Superior Quality Gala Extract",
+          "item_id": 9362,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 96,
+        "group_id": 10
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Colossus",
+          "enemy_id": "0x015020",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 35,
+          "exp": 3360,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1050,
+          "comment": "Spawns Man511 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Man511",
+      "message_id": 11420
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 511,
+          "Param2": 12247
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Man511",
+      "message_id": 12244
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_2.json
@@ -1,0 +1,117 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Miner’s Lifeline (III)",
+  "quest_id": 20040007,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 94,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2610
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1560
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Flame Crystal",
+          "item_id": 7913,
+          "num": 1
+        },
+        {
+          "comment": "High Quality Magick Medal",
+          "item_id": 7870,
+          "num": 1
+        },
+        {
+          "comment": "Lava Rock",
+          "item_id": 7869,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 96,
+        "group_id": 10
+      },
+      "enemies": [
+        {
+          "comment": "Dangerous Geo Golem",
+          "enemy_id": "0x015104",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 56,
+          "level": 57,
+          "exp": 5248,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1050,
+          "comment": "Spawns Man511 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Man511",
+      "message_id": 11420
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 511,
+          "Param2": 12247
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Man511",
+      "message_id": 12244
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040008.json
@@ -45,23 +45,38 @@
         "id": 1,
         "group_id": 178
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Vigilant Sludgeman",
           "enemy_id": "0x010510",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 118,
           "is_boss": false
         },
         {
+          "comment": "Vigilant Sludgeman",
           "enemy_id": "0x010510",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 118,
           "is_boss": false
         },
         {
+          "comment": "Vigilant Sludgeman",
           "enemy_id": "0x010510",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 118,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 53,
+          "level": 22,
+          "exp": 118,
           "is_boss": false
         }
       ]
@@ -84,11 +99,19 @@
         "layer_no": 1
       },
       "npc_id": "Man510",
-      "message_id": 11372
+      "message_id": 11421
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 510,
+          "Param2": 13327
+        }
+      ],
       "stage_id": {
         "id": 1,
         "group_id": 2,
@@ -187,7 +210,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Man510",
-      "message_id": 11842
+      "message_id": 13324
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040008_1.json
@@ -1,0 +1,217 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Volden Poisonous Springs Investigation (II)",
+  "quest_id": 20040008,
+  "base_level": 25,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 84,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 820
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 680
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 110
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Black Tar",
+          "item_id": 7841,
+          "num": 2
+        },
+        {
+          "comment": "Meatloaf",
+          "item_id": 9408,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 178
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Vigilant Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 53,
+          "level": 25,
+          "exp": 130,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 53,
+          "level": 25,
+          "exp": 130,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 53,
+          "level": 25,
+          "exp": 130,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 53,
+          "level": 25,
+          "exp": 130,
+          "is_boss": false
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1051,
+          "comment": "Spawns Man510 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Man510",
+      "message_id": 11421
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 510,
+          "Param2": 13327
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1171,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1172,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1173,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 1,
+        "group_id": 3,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1171,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1172,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1173,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 1,
+        "group_id": 4,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1171,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1172,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1173,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Man510",
+      "message_id": 13324
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040008_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040008_2.json
@@ -1,0 +1,222 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Volden Poisonous Springs Investigation (Bounty)",
+  "quest_id": 20040008,
+  "base_level": 22,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 84,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1450
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1210
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 90
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Healing Elixir",
+          "item_id": 7552,
+          "num": 2
+        },
+        {
+          "comment": "Quality Gala Extract",
+          "item_id": 9361,
+          "num": 2
+        },
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 178
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Bounty Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 458,
+          "level": 22,
+          "exp": 118,
+          "is_boss": false
+        },
+        {
+          "comment": "Bounty Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 458,
+          "level": 22,
+          "exp": 118,
+          "is_boss": false
+        },
+        {
+          "comment": "Bounty Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 458,
+          "level": 22,
+          "exp": 118,
+          "is_boss": false
+        },
+        {
+          "comment": "Bounty Sludgeman",
+          "enemy_id": "0x010510",
+          "named_enemy_params_id": 458,
+          "level": 22,
+          "exp": 118,
+          "is_boss": false
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1051,
+          "comment": "Spawns Man510 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Man510",
+      "message_id": 13322
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 510,
+          "Param2": 13327
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1171,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1172,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1173,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 1,
+        "group_id": 3,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1171,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1172,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1173,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 1,
+        "group_id": 4,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1171,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1172,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1173,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Man510",
+      "message_id": 13325
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009.json
@@ -48,29 +48,69 @@
     {
       "stage_id": {
         "id": 102,
-        "group_id": 8
+        "group_id": 3
       },
+      "starting_index": 6,
       "enemies": [
         {
-          "enemy_id": "0x011000",
-          "level": 30,
-          "exp": 500,
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
           "is_boss": false,
-          "hm_present_no": 45
+          "hm_present_no": 46
         },
         {
-          "enemy_id": "0x011000",
-          "level": 30,
-          "exp": 500,
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
           "is_boss": false,
-          "hm_present_no": 45
+          "hm_present_no": 46
         },
         {
-          "enemy_id": "0x011000",
-          "level": 30,
-          "exp": 500,
+          "comment": "Vigilant Rogue Defender",
+          "enemy_id": "0x011004",
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
           "is_boss": false,
-          "hm_present_no": 45
+          "hm_present_no": 49
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
+          "is_boss": false,
+          "hm_present_no": 46
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
+          "is_boss": false,
+          "hm_present_no": 46
+        },
+        {
+          "comment": "Vigilant Rogue Defender",
+          "enemy_id": "0x011004",
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
+          "is_boss": false,
+          "hm_present_no": 49
         }
       ]
     }
@@ -92,7 +132,7 @@
         "layer_no": 1
       },
       "npc_id": "Gerd1",
-      "message_id": 11372
+      "message_id": 11422
     },
     {
       "type": "NewTalkToNpc",
@@ -110,13 +150,32 @@
         "layer_no": 1
       },
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 7,
+          "Param2": 11978
+        }
+      ],
       "npc_id": "WhiteKnight2",
-      "message_id": 11842
+      "message_id": 11973
     },
     {
       "type": "KillGroup",
       "announce_type": "Update",
       "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 102,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "WhiteKnight2",
+      "message_id": 11974
     },
     {
       "type": "NewTalkToNpc",
@@ -135,7 +194,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gerd1",
-      "message_id": 11842
+      "message_id": 11975
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009_1.json
@@ -1,0 +1,201 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Wounded Honour (II)",
+  "quest_id": 20040009,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "news_image": 511,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1230
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1030
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 130
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Blow-Resistant Cloth",
+          "item_id": 7942,
+          "num": 2
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        },
+        {
+          "comment": "Superior Gala Extract",
+          "item_id": 9398,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 102,
+        "group_id": 3
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Dangerous Rogue Healer",
+          "enemy_id": "0x011003",
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "is_boss": false,
+          "hm_present_no": 48
+        },
+        {
+          "comment": "Dangerous Rogue Warrior",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "is_boss": false,
+          "hm_present_no": 45
+        },
+        {
+          "comment": "Dangerous Rogue Warrior",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "is_boss": false,
+          "hm_present_no": 45
+        },
+        {
+          "comment": "Dangerous Rogue Healer",
+          "enemy_id": "0x011003",
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "is_boss": false,
+          "hm_present_no": 48
+        },
+        {
+          "comment": "Dangerous Rogue Warrior",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "is_boss": false,
+          "hm_present_no": 45
+        },
+        {
+          "comment": "Dangerous Rogue Warrior",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "is_boss": false,
+          "hm_present_no": 45
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1053,
+          "comment": "Spawns Gerd1 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Gerd1",
+      "message_id": 11422
+    },
+    {
+      "type": "NewTalkToNpc",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1054,
+          "comment": "Spawns WhiteKnight NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 102,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 7,
+          "Param2": 11978
+        }
+      ],
+      "npc_id": "WhiteKnight2",
+      "message_id": 11973
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 102,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "WhiteKnight2",
+      "message_id": 11974
+    },
+    {
+      "type": "NewTalkToNpc",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1053,
+          "comment": "Spawns Gerd1 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Gerd1",
+      "message_id": 11975
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Sergeant's Cloak",
           "item_id": 1017,
           "num": 1
         },
         {
+          "comment": "Enhanced Lumber Knife",
           "item_id": 9402,
           "num": 2
         },
         {
+          "comment": "Throwing Skull",
           "item_id": 9397,
           "num": 3
         }
@@ -49,9 +52,11 @@
       },
       "enemies": [
         {
+          "comment": "Brutal Colossus",
           "enemy_id": "0x015020",
+          "named_enemy_params_id": 54,
           "level": 28,
-          "exp": 4500,
+          "exp": 2968,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_1.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Bright One-Eyed (Rare Species)",
+  "quest_id": 20045000,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 95,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1840
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 240
+    },
+    {
+      "type": "exp",
+      "amount": 2150
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 2
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 2
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 72,
+        "group_id": 14
+      },
+      "enemies": [
+        {
+          "comment": "Stoneskin Cyclops (Cyclops)",
+          "enemy_id": "0x015000",
+          "named_enemy_params_id": 601,
+          "level": 56,
+          "exp": 3888,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_2.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Bright One-Eyed (Bounty)",
+  "quest_id": 20045000,
+  "base_level": 30,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 95,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1780
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 150
+    },
+    {
+      "type": "exp",
+      "amount": 2490
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Artisan's Boots",
+          "item_id": 9699,
+          "num": 1
+        },
+        {
+          "comment": "Enhanced Lockpick",
+          "item_id": 9403,
+          "num": 2
+        },
+        {
+          "comment": "Fortifier",
+          "item_id": 9377,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 72,
+        "group_id": 14
+      },
+      "enemies": [
+        {
+          "comment": "Bounty Colossus",
+          "enemy_id": "0x015020",
+          "named_enemy_params_id": 458,
+          "level": 30,
+          "exp": 3080,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Deft Gloves",
           "item_id": 920,
           "num": 1
         },
         {
+          "comment": "Three-Herb Salad",
           "item_id": 9410,
           "num": 1
         },
         {
+          "comment": "Interventive",
           "item_id": 9374,
           "num": 3
         }
@@ -47,42 +50,61 @@
         "id": 72,
         "group_id": 17
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x010309",
-          "level": 26,
-          "exp": 300,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010309",
-          "level": 26,
-          "exp": 300,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010309",
-          "level": 26,
-          "exp": 300,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
-          "level": 26,
-          "exp": 300,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 117,
+          "is_boss": false,
+          "index": 1
         },
         {
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
-          "level": 26,
-          "exp": 300,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 117,
+          "is_boss": false,
+          "index": 2
         },
         {
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
-          "level": 26,
-          "exp": 300,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 117,
+          "is_boss": false,
+          "index": 10
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 128,
+          "is_boss": false,
+          "index": 11
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 128,
+          "is_boss": false,
+          "index": 11
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 128,
+          "is_boss": false,
+          "index": 11
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_1.json
@@ -1,0 +1,129 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Messenger From the Underworld (II)",
+  "quest_id": 20045001,
+  "base_level": 34,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 96,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 930
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 170
+    },
+    {
+      "type": "exp",
+      "amount": 1340
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Cathedral Bottoms",
+          "item_id": 9719,
+          "num": 1
+        },
+        {
+          "comment": "Silver Silk Pareo",
+          "item_id": 959,
+          "num": 1
+        },
+        {
+          "comment": "Enhanced Lumber Knife",
+          "item_id": 9402,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 72,
+        "group_id": 17
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Brutal Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 54,
+          "level": 34,
+          "exp": 141,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 1
+        },
+        {
+          "comment": "Brutal Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 54,
+          "level": 34,
+          "exp": 141,
+          "is_boss": false,
+          "index": 2
+        },
+        {
+          "comment": "Brutal Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 54,
+          "level": 34,
+          "exp": 141,
+          "is_boss": false,
+          "index": 10
+        },
+        {
+          "comment": "Brutal Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 54,
+          "level": 34,
+          "exp": 154,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 11
+        },
+        {
+          "comment": "Brutal Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 54,
+          "level": 34,
+          "exp": 154,
+          "is_boss": false,
+          "index": 12
+        },
+        {
+          "comment": "Brutal Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 54,
+          "level": 34,
+          "exp": 154,
+          "is_boss": false,
+          "index": 13
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_2.json
@@ -1,0 +1,131 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Messenger From the Underworld (III)",
+  "quest_id": 20045001,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 96,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "exp",
+      "amount": 1810
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sand of Reminiscence",
+          "item_id": 9441,
+          "num": 1
+        },
+        {
+          "comment": "Demonic Gem",
+          "item_id": 7911,
+          "num": 1
+        },
+        {
+          "comment": "Cracked Black Horn",
+          "item_id": 7753,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 72,
+        "group_id": 17
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 1
+        },
+        {
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 2
+        },
+        {
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 10
+        },
+        {
+          "comment": "Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "level": 55,
+          "exp": 236,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 11
+        },
+        {
+          "comment": "Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "level": 55,
+          "exp": 236,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 12
+        },
+        {
+          "comment": "Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "level": 55,
+          "exp": 236,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 13
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002.json
@@ -10,6 +10,10 @@
   "news_image": 537,
   "rewards": [
     {
+      "type": "exp",
+      "amount": 970
+    },
+    {
       "type": "wallet",
       "wallet_type": "Gold",
       "amount": 690
@@ -20,21 +24,20 @@
       "amount": 110
     },
     {
-      "type": "exp",
-      "amount": 970
-    },
-    {
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Murg Armguards",
           "item_id": 599,
           "num": 1
         },
         {
+          "comment": "Lestania Wine",
           "item_id": 9409,
           "num": 2
         },
         {
+          "comment": "Conqueror's Amulet",
           "item_id": 9381,
           "num": 1
         }
@@ -47,13 +50,14 @@
         "id": 103,
         "group_id": 1
       },
+      "starting_index": 7,
       "enemies": [
         {
           "comment": "Vigilant Chimera",
           "enemy_id": "0x015200",
           "named_enemy_params_id": 53,
           "level": 21,
-          "exp": 3800,
+          "exp": 2460,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_1.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Shadows Within the Cave (II)",
+  "quest_id": 20045002,
+  "base_level": 24,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 537,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1100
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 790
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 120
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Griffin Beak",
+          "item_id": 7758,
+          "num": 1
+        },
+        {
+          "comment": "Mystic Bangles",
+          "item_id": 815,
+          "num": 1
+        },
+        {
+          "comment": "Angel's Amulet",
+          "item_id": 9382,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 103,
+        "group_id": 1
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Young Griffin",
+          "enemy_id": "0x015300",
+          "named_enemy_params_id": 459,
+          "level": 24,
+          "exp": 3300,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_2.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Shadows Within the Cave (III)",
+  "quest_id": 20045002,
+  "base_level": 27,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 537,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1240
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 890
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 140
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Victory Bracers",
+          "item_id": 7758,
+          "num": 1
+        },
+        {
+          "comment": "Wine-Boiled Mushroom",
+          "item_id": 815,
+          "num": 1
+        },
+        {
+          "comment": "Concoction of Light",
+          "item_id": 9382,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 103,
+        "group_id": 1
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Brutal Griffin",
+          "enemy_id": "0x015300",
+          "named_enemy_params_id": 54,
+          "level": 27,
+          "exp": 3525,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Drilled Plate Sheet",
           "item_id": 7881,
           "num": 1
         },
         {
+          "comment": "Quality Gala Extract",
           "item_id": 9361,
           "num": 2
         },
         {
+          "comment": "Demon's Amulet",
           "item_id": 9383,
           "num": 1
         }
@@ -53,7 +56,7 @@
           "enemy_id": "0x015200",
           "named_enemy_params_id": 53,
           "level": 23,
-          "exp": 4200,
+          "exp": 2580,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_1.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Tunnel Beast (II)",
+  "quest_id": 20045003,
+  "base_level": 30,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 533,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 990
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 150
+    },
+    {
+      "type": "exp",
+      "amount": 1380
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Pauldron",
+          "item_id": 1013,
+          "num": 1
+        },
+        {
+          "comment": "Battler Bracelet",
+          "item_id": 8972,
+          "num": 1
+        },
+        {
+          "comment": "Wild Steak",
+          "item_id": 9412,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 101,
+        "group_id": 5
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Ogre",
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 54,
+          "level": 30,
+          "exp": 2300,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_2.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Tunnel Beast (III)",
+  "quest_id": 20045003,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 533,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1980
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 490
+    },
+    {
+      "type": "exp",
+      "amount": 3460
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Spectral Dragon Fang",
+          "item_id": 9453,
+          "num": 1
+        },
+        {
+          "comment": "Spectral Dragonscale",
+          "item_id": 7922,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 101,
+        "group_id": 5
+      },
+      "starting_index": 9,
+      "enemies": [
+        {
+          "comment": "Brutal Mist Drake",
+          "enemy_id": "0x015710",
+          "named_enemy_params_id": 54,
+          "level": 60,
+          "exp": 9860,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_3.json
@@ -1,0 +1,98 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Tunnel Beast (Calamity)",
+  "quest_id": 20045003,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 533,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3630
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 420
+    },
+    {
+      "type": "exp",
+      "amount": 5420
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Thick Dragonscale",
+          "item_id": 7929,
+          "num": 1
+        },
+        {
+          "comment": "Behemoth Fang",
+          "item_id": 7799,
+          "num": 2
+        },
+        {
+          "comment": "Smoky Quartz",
+          "item_id": 7908,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 101,
+        "group_id": 5
+      },
+      "position_type": "manual",
+      "enemies": [
+        {
+          "comment": "Dangerous Empress Ghost",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 4095,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Dangerous Empress Ghost",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 4095,
+          "is_boss": true,
+          "index": 6
+        },
+        {
+          "comment": "Cave Raider (Behemoth)",
+          "enemy_id": "0x015709",
+          "named_enemy_params_id": 529,
+          "level": 55,
+          "exp": 8960,
+          "is_boss": true,
+          "index": 9
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_4.json
@@ -1,0 +1,98 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Tunnel Beast (Calamity II)",
+  "quest_id": 20045003,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 533,
+  "variant_index": 4,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3960
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 490
+    },
+    {
+      "type": "exp",
+      "amount": 6930
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Power+",
+          "item_id": 11719,
+          "num": 1
+        },
+        {
+          "comment": "Amber Dragonscale",
+          "item_id": 7930,
+          "num": 1
+        },
+        {
+          "comment": "Witch's Velvet",
+          "item_id": 7949,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 101,
+        "group_id": 5
+      },
+      "position_type": "manual",
+      "enemies": [
+        {
+          "comment": "Cave Raider Empress (Empress Ghost)",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 603,
+          "level": 60,
+          "exp": 4350,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Cave Raider Empress (Empress Ghost)",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 603,
+          "level": 60,
+          "exp": 4350,
+          "is_boss": true,
+          "index": 6
+        },
+        {
+          "comment": "Cave Raider Drake (Drake)",
+          "enemy_id": "0x015700",
+          "named_enemy_params_id": 602,
+          "level": 60,
+          "exp": 9860,
+          "is_boss": true,
+          "index": 9
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Torpor",
           "item_id": 9241,
           "num": 1
         },
         {
+          "comment": "Mellow Ale",
           "item_id": 9413,
           "num": 1
         },
         {
+          "comment": "Old Thief's Small Key",
           "item_id": 9429,
           "num": 3
         }
@@ -49,10 +52,11 @@
       },
       "enemies": [
         {
+          "comment": "Vigilant Chimera",
           "enemy_id": "0x015200",
           "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 4600,
+          "exp": 3000,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004_1.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Rock-Crushing Fangs (II)",
+  "quest_id": 20045004,
+  "base_level": 35,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 83,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1150
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 230
+    },
+    {
+      "type": "exp",
+      "amount": 1610
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Courtly Cloth",
+          "item_id": 7939,
+          "num": 3
+        },
+        {
+          "comment": "Enhanced Lockpick",
+          "item_id": 9403,
+          "num": 3
+        },
+        {
+          "comment": "Exquisite Fried Meat",
+          "item_id": 9416,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 192
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Colossus",
+          "enemy_id": "0x015020",
+          "named_enemy_params_id": 54,
+          "level": 35,
+          "exp": 3360,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005.json
@@ -27,10 +27,12 @@
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 7881,
+          "comment": "Saintly Hood",
+          "item_id": 734,
           "num": 1
         },
         {
+          "comment": "Old Forest Dwellers' Key",
           "item_id": 9066,
           "num": 1
         }
@@ -43,40 +45,54 @@
         "id": 96,
         "group_id": 2
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "comment": "Rock Saurian",
+          "comment": "Vigilant Rock Saurian",
           "enemy_id": "0x010450",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 112,
           "is_boss": false
         },
         {
-          "comment": "Rock Saurian",
+          "comment": "Vigilant Rock Saurian",
           "enemy_id": "0x010450",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 112,
           "is_boss": false
         },
         {
-          "comment": "Rock Saurian",
+          "comment": "Vigilant Rock Saurian",
           "enemy_id": "0x010450",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 112,
           "is_boss": false
         },
         {
-          "comment": "Rock Saurian",
+          "comment": "Vigilant Rock Saurian",
           "enemy_id": "0x010450",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 112,
           "is_boss": false
         },
         {
-          "comment": "Rock Saurian",
+          "comment": "Vigilant Rock Saurian",
           "enemy_id": "0x010450",
-          "level": 25,
-          "exp": 250,
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 112,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 53,
+          "level": 27,
+          "exp": 112,
           "is_boss": false
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005_1.json
@@ -1,0 +1,123 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Trapped in a Nightmare (II)",
+  "quest_id": 20045005,
+  "base_level": 30,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "news_image": 93,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 820
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 130
+    },
+    {
+      "type": "exp",
+      "amount": 990
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gooseneck Arm",
+          "item_id": 605,
+          "num": 1
+        },
+        {
+          "comment": "Three-Herb Salad",
+          "item_id": 9410,
+          "num": 2
+        },
+        {
+          "comment": "Blue Whiskey",
+          "item_id": 9417,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 96,
+        "group_id": 2
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Brutal Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 54,
+          "level": 31,
+          "exp": 123,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 54,
+          "level": 31,
+          "exp": 123,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Brutal Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 54,
+          "level": 31,
+          "exp": 123,
+          "is_boss": false,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Brutal Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 54,
+          "level": 31,
+          "exp": 123,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 54,
+          "level": 31,
+          "exp": 123,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Rock Saurian",
+          "enemy_id": "0x010450",
+          "named_enemy_params_id": 54,
+          "level": 31,
+          "exp": 123,
+          "is_boss": false
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045006.json
@@ -1,0 +1,191 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Seeking Riese Extract",
+  "quest_id": 20045006,
+  "base_level": 58,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5740
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2480
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1020
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Riese Extract",
+          "item_id": 9450,
+          "num": 2
+        },
+        {
+          "comment": "Dragon Fang",
+          "item_id": 7763,
+          "num": 1
+        },
+        {
+          "comment": "Witch's Velvet",
+          "item_id": 7949,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "Group 1 - Demolition Fang and Death Calling Dark Knights",
+      "stage_id": {
+        "id": 85,
+        "group_id": 10
+      },
+      "starting_index": 15,
+      "enemies": [
+        {
+          "comment": "Death Calling Dark Knight (Death Knight)",
+          "enemy_id": "0x010310",
+          "named_enemy_params_id": 639,
+          "level": 58,
+          "exp": 1660
+        },
+        {
+          "comment": "Death Calling Dark Knight (Death Knight)",
+          "enemy_id": "0x010310",
+          "named_enemy_params_id": 639,
+          "level": 58,
+          "exp": 1660
+        },
+        {
+          "comment": "Demolition Fang (Behemoth)",
+          "enemy_id": "0x015709",
+          "named_enemy_params_id": 638,
+          "level": 58,
+          "exp": 9296,
+          "is_boss": true
+        }
+      ]
+    },
+    {
+      "comment": "Group 2 - Calamity Caller and Death Courting Demon Princesses",
+      "stage_id": {
+        "id": 1,
+        "group_id": 239
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Calamity Caller (Nightmare)",
+          "enemy_id": "0x015305",
+          "named_enemy_params_id": 640,
+          "level": 58,
+          "exp": 8831,
+          "is_boss": true
+        },
+        {
+          "comment": "Death Courting Demon Princess (Empress Ghost)",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 641,
+          "level": 58,
+          "exp": 4249
+        },
+        {
+          "comment": "Death Courting Demon Princess (Empress Ghost)",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 641,
+          "level": 58,
+          "exp": 4249
+        },
+        {
+          "comment": "Death Courting Demon Princess (Empress Ghost)",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 641,
+          "level": 58,
+          "exp": 4249
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 95,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Zutan",
+      "message_id": 16426
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 2003,
+          "Param2": 16421
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 95,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Zutan",
+      "message_id": 16422
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 2003,
+          "Param2": 16423
+        }
+      ],
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 95,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Zutan",
+      "message_id": 16424
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070001.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Corpse-Eater's Horn",
           "item_id": 7751,
           "num": 1
         },
         {
+          "comment": "Drómi",
           "item_id": 7958,
           "num": 1
         },
         {
+          "comment": "Throwing Knife",
           "item_id": 9398,
           "num": 3
         }
@@ -44,6 +47,7 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Gold Ore",
           "item_id": 7859,
           "num": 2,
           "chance": 0.7
@@ -57,47 +61,47 @@
         "id": 173,
         "group_id": 1
       },
-      "placement_type": "manual",
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Vigilant Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 53,
+          "level": 44,
+          "exp": 235,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 53,
+          "level": 44,
+          "exp": 235,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 53,
+          "level": 44,
+          "exp": 235,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Ghoul",
           "enemy_id": "0x015503",
           "named_enemy_params_id": 54,
           "level": 44,
-          "exp": 6364,
-          "is_boss": true,
-          "index": 8
+          "exp": 4240,
+          "is_boss": true
         },
         {
+          "comment": "Brutal Ghoul",
           "enemy_id": "0x015503",
           "named_enemy_params_id": 54,
           "level": 44,
-          "exp": 6364,
-          "is_boss": true,
-          "index": 0
-        },
-        {
-          "enemy_id": "0x010511",
-          "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false,
-          "index": 5
-        },
-        {
-          "enemy_id": "0x010511",
-          "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false,
-          "index": 6
-        },
-        {
-          "enemy_id": "0x010511",
-          "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false,
-          "index": 4
+          "exp": 4240,
+          "is_boss": true
         }
       ]
     }
@@ -119,11 +123,19 @@
         "layer_no": 1
       },
       "npc_id": "StrangeMan",
-      "message_id": 11372
+      "message_id": 11243
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 507,
+          "Param2": 11249
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -158,7 +170,7 @@
       },
       "announce_type": "Update",
       "npc_id": "StrangeMan",
-      "message_id": 11842
+      "message_id": 11246
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Dragonleather",
           "item_id": 7941,
           "num": 2
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         },
         {
+          "comment": "Enhanced Lockpick",
           "item_id": 9403,
           "num": 3
         }
@@ -58,11 +61,19 @@
         "layer_no": 1
       },
       "npc_id": "Morten",
-      "message_id": 11372
+      "message_id": 11261
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 528,
+          "Param2": 11267
+        }
+      ],
       "stage_id": {
         "id": 68,
         "group_id": 1,
@@ -282,7 +293,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Morten",
-      "message_id": 11842
+      "message_id": 11264
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003_1.json
@@ -1,0 +1,300 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "To Steal From Orcs (II)",
+  "quest_id": 20070003,
+  "base_level": 42,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "NorthernBetlandPlains",
+  "news_image": 150,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1380
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1380
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Strong Acid Slime Piece",
+          "item_id": 7837,
+          "num": 3
+        },
+        {
+          "comment": "Throwing Knife",
+          "item_id": 9398,
+          "num": 3
+        },
+        {
+          "comment": "Three-Herb Salad",
+          "item_id": 9410,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1065,
+          "comment": "Spawns Morten NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 50,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Morten",
+      "message_id": 11261
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 528,
+          "Param2": 11267
+        }
+      ],
+      "stage_id": {
+        "id": 68,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1287,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1288,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1289,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1812,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1813,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1814,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1815,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1816,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1817,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1818,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 68,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1287,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1288,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1289,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1812,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1813,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1814,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1815,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1816,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1817,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1818,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 68,
+        "group_id": 3,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1287,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1288,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1289,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1812,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1813,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1814,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1815,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1816,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1817,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1818,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 50,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Morten",
+      "message_id": 11264
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_3.json
@@ -1,0 +1,127 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Perfect Warrior (Calamity)",
+  "quest_id": 20070004,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "NorthernBetlandPlains",
+  "news_image": 151,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6930
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3960
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 490
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Magick+",
+          "item_id": 11720,
+          "num": 1
+        },
+        {
+          "comment": "Azure Dragonscale",
+          "item_id": 7931,
+          "num": 1
+        },
+        {
+          "comment": "Dark Metal",
+          "item_id": 7887,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 68,
+        "group_id": 9
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Red-Hot Giga Machina (Gigant Machina)",
+          "enemy_id": "0x015850",
+          "named_enemy_params_id": 611,
+          "level": 60,
+          "exp": 5440,
+          "is_boss": true,
+          "index": 2
+        },
+        {
+          "comment": "Pale Ice Wyrm (Wyrm)",
+          "enemy_id": "0x015701",
+          "named_enemy_params_id": 610,
+          "level": 60,
+          "exp": 9860,
+          "is_boss": true,
+          "index": 4
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1066,
+          "comment": "Spawns Lent NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Lent",
+      "message_id": 11274
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 520,
+          "Param2": 11278
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Lent",
+      "message_id": 11277
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070005.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Red Alloy Ingot",
           "item_id": 7888,
           "num": 2
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 2
         },
         {
+          "comment": "Mellow Ale",
           "item_id": 9413,
           "num": 2
         }
@@ -44,6 +47,7 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Healing Potion",
           "item_id": 34,
           "num": 1,
           "chance": 1.0
@@ -57,49 +61,46 @@
         "id": 123,
         "group_id": 0
       },
-      "placement_type": "Manual",
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 950,
-          "is_boss": false,
-          "index": 7
+          "exp": 188
         },
         {
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 950,
-          "is_boss": false,
-          "index": 8
+          "exp": 188
         },
         {
+          "comment": "Brutal Frost Corpse Punisher",
           "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 950,
-          "is_boss": false,
-          "index": 9
+          "exp": 231,
+          "repop_count": 1,
+          "repop_wait_second": 10
         },
         {
+          "comment": "Brutal Frost Corpse Punisher",
           "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 950,
-          "is_boss": false,
-          "index": 10
+          "exp": 231,
+          "repop_count": 1,
+          "repop_wait_second": 10
         },
         {
+          "comment": "Brutal Frost Corpse Punisher",
           "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 950,
-          "is_boss": false,
-          "index": 11
-        },
-        {
-          "enemy_id": "0x010511",
-          "level": 43,
-          "exp": 950,
-          "is_boss": false,
-          "index": 12
+          "exp": 231
         }
       ]
     }
@@ -121,11 +122,19 @@
         "layer_no": 1
       },
       "npc_id": "Bandit0",
-      "message_id": 11372
+      "message_id": 11493
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 522,
+          "Param2": 13297
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -143,7 +152,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Bandit0",
-      "message_id": 11835
+      "message_id": 13294
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070005_1.json
@@ -1,0 +1,144 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Temptation of Thievery (II)",
+  "quest_id": 20070005,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "NorthernBetlandPlains",
+  "news_image": 516,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1480
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 190
+    },
+    {
+      "type": "exp",
+      "amount": 1480
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Spirit Silver Ingot",
+          "item_id": 7884,
+          "num": 2
+        },
+        {
+          "comment": "Grilled Mushroom",
+          "item_id": 9415,
+          "num": 2
+        },
+        {
+          "comment": "Wild Steak",
+          "item_id": 9412,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 123,
+        "group_id": 0
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Brutal Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 231
+        },
+        {
+          "comment": "Brutal Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 231
+        },
+        {
+          "comment": "Brutal Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 231
+        },
+        {
+          "comment": "Brutal Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 231
+        },
+        {
+          "comment": "Brutal Frost Corpse Punisher",
+          "enemy_id": "0x010511",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 231
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1067,
+          "comment": "Spawns Bandit0 NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 123,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Bandit0",
+      "message_id": 11493
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 522,
+          "Param2": 13297
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 123,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Bandit0",
+      "message_id": 13294
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075000.json
@@ -1,0 +1,77 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Roaring Lion King",
+  "quest_id": 20075000,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2070
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1480
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 230
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "White Lion Pelt",
+          "item_id": 7739,
+          "num": 1
+        },
+        {
+          "comment": "Mithril Ingot",
+          "item_id": 7880,
+          "num": 3
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 173,
+        "group_id": 0
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Brutal White Chimera",
+          "enemy_id": "0x015202",
+          "named_enemy_params_id": 54,
+          "level": 45,
+          "exp": 5037,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001.json
@@ -1,0 +1,110 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Occupied Channels",
+  "quest_id": 20075001,
+  "base_level": 49,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1610
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1340
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 210
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Diminished Fire Resist",
+          "item_id": 9268,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Diminished Ice Resist",
+          "item_id": 9270,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Diminished Lightning Resist",
+          "item_id": 9272,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 156,
+        "group_id": 4
+      },
+      "enemies": [
+        {
+          "comment": "Vigilant Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 53,
+          "level": 49,
+          "exp": 1184
+        },
+        {
+          "comment": "Vigilant Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 53,
+          "level": 49,
+          "exp": 1184
+        },
+        {
+          "comment": "Vigilant Skeleton Warrior",
+          "enemy_id": "0x010302",
+          "named_enemy_params_id": 53,
+          "level": 49,
+          "exp": 232
+        },
+        {
+          "comment": "Vigilant Skeleton Warrior",
+          "enemy_id": "0x010302",
+          "named_enemy_params_id": 53,
+          "level": 49,
+          "exp": 232
+        },
+        {
+          "comment": "Vigilant Skeleton Warrior",
+          "enemy_id": "0x010302",
+          "named_enemy_params_id": 53,
+          "level": 49,
+          "exp": 232
+        },
+        {
+          "comment": "Vigilant Skeleton Warrior",
+          "enemy_id": "0x010302",
+          "named_enemy_params_id": 53,
+          "level": 49,
+          "exp": 232
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001_1.json
@@ -1,0 +1,113 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Occupied Channels (II)",
+  "quest_id": 20075001,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1810
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1510
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Demon's Prized Liquor",
+          "item_id": 9443,
+          "num": 1
+        },
+        {
+          "comment": "Pigeon Blood",
+          "item_id": 7910,
+          "num": 1
+        },
+        {
+          "comment": "Orc Decoration",
+          "item_id": 8020,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 156,
+        "group_id": 4
+      },
+      "enemies": [
+        {
+          "comment": "Dangerous Orc General",
+          "enemy_id": "0x015830",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 1505
+        },
+        {
+          "comment": "Dangerous Orc General",
+          "enemy_id": "0x015830",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 1505
+        },
+        {
+          "comment": "Dangerous Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 352,
+          "repop_count": 1
+        },
+        {
+          "comment": "Dangerous Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 352,
+          "repop_count": 1
+        },
+        {
+          "comment": "Dangerous Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 352
+        },
+        {
+          "comment": "Dangerous Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 352
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002.json
@@ -27,32 +27,37 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Gold Ingot",
           "item_id": 7877,
           "num": 2
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         },
         {
+          "comment": "Enhanced Pickaxe",
           "item_id": 9401,
           "num": 2
         }
       ]
-  },
+    },
+    {
+      "type": "random",
+      "loot_pool": [
         {
-              "type": "random",
-              "loot_pool": [
-                {
-                  "item_id": 9303,
-                  "num": 1,
-                  "chance": 0.4
-                },
-                {
-                  "item_id": 7852,
-                  "num": 3,
-                  "chance": 0.6
-                }
+          "comment": "Crest of Ice Warding",
+          "item_id": 9303,
+          "num": 1,
+          "chance": 0.4
+        },
+        {
+          "comment": "Sandcrystal",
+          "item_id": 7852,
+          "num": 3,
+          "chance": 0.6
+        }
       ]
     }
   ],
@@ -62,16 +67,15 @@
         "id": 1,
         "group_id": 309
       },
-      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Brutal Cockatrice",
           "enemy_id": "0x015301",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 45,
-          "exp": 6476,
-          "is_boss": true,
-          "index": 0
+          "exp": 5050,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Raging Demonic Bird",
+  "comment": "The Raging Demonic Bird (II)",
   "quest_id": 20075002,
   "base_level": 57,
   "minimum_item_rank": 0,
@@ -28,16 +28,19 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Griffin Glossy Plume",
           "item_id": 9439,
           "num": 1
         },
         {
+          "comment": "Moist Black Leather",
           "item_id": 7742,
           "num": 1
         },
         {
+          "comment": "Glossy Black Feather",
           "item_id": 7818,
-          "num": 1
+          "num": 2
         }
       ]
     }
@@ -48,16 +51,15 @@
         "id": 1,
         "group_id": 309
       },
-      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015301",
+          "comment": "Dangerous Black Griffin",
+          "enemy_id": "0x015303",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
+          "named_enemy_params_id": 56,
           "level": 57,
-          "exp": 21700,
-          "is_boss": true,
-          "index": 0
+          "exp": 5187,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_2.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Raging Demonic Bird (Rare Species)",
+  "quest_id": 20075002,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "news_image": 142,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1880
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "exp",
+      "amount": 2630
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 2
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 2
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 309
+      },
+      "enemies": [
+        {
+          "comment": "Stone Shadow Cockatrice (Cockatrice)",
+          "enemy_id": "0x015301",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 612,
+          "level": 57,
+          "exp": 6058,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Marbled Beast-Steak",
           "item_id": 7726,
           "num": 3
         },
         {
+          "comment": "Enhanced Pickaxe",
           "item_id": 9401,
           "num": 3
         },
         {
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 3
         }
@@ -44,11 +47,13 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "King Bay Leaf",
           "item_id": 7983,
           "num": 3,
           "chance": 0.6
         },
         {
+          "comment": "Fireproof Earrings",
           "item_id": 9000,
           "num": 1,
           "chance": 0.4
@@ -62,54 +67,61 @@
         "id": 1,
         "group_id": 284
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015810",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 43,
-          "exp": 5264,
-          "is_boss": false
-        },
-        {
+          "comment": "Brutal Captain Orc",
           "enemy_id": "0x015820",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 5264,
-          "is_boss": false
+          "exp": 537,
+          "is_boss": false,
+          "index": 2
         },
         {
+          "comment": "Vigilant Orc Blitzer",
           "enemy_id": "0x015811",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+          "named_enemy_params_id": 53,
           "level": 43,
-          "exp": 5264,
-          "is_boss": false
+          "exp": 258,
+          "is_boss": false,
+          "index": 5
         },
         {
+          "comment": "Vigilant Orc Blitzer",
           "enemy_id": "0x015811",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+          "named_enemy_params_id": 53,
           "level": 43,
-          "exp": 5264,
-          "is_boss": false
+          "exp": 258,
+          "is_boss": false,
+          "index": 6
         },
         {
+          "comment": "Vigilant Orc Blitzer",
           "enemy_id": "0x015811",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+          "named_enemy_params_id": 53,
           "level": 43,
-          "exp": 5264,
-          "is_boss": false
+          "exp": 258,
+          "is_boss": false,
+          "index": 7
         },
         {
-          "enemy_id": "0x015811",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
+          "comment": "Vigilant Orc Battler",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 53,
           "level": 43,
-          "exp": 5264,
-          "is_boss": false
+          "exp": 299,
+          "is_boss": false,
+          "index": 11
+        },
+        {
+          "comment": "Vigilant Orc Battler",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 299,
+          "is_boss": false,
+          "index": 12
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Eliminate the Orc Platoon!",
+  "comment": "Eliminate the Orc Platoon! (II)",
   "quest_id": 20075003,
   "base_level": 44,
   "minimum_item_rank": 0,
@@ -28,14 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Pigeon Blood",
           "item_id": 7910,
           "num": 1
         },
         {
+          "comment": "Small Thief's Key",
           "item_id": 9429,
           "num": 3
         },
         {
+          "comment": "Enhanced Lumber Knife",
           "item_id": 9402,
           "num": 3
         }
@@ -48,54 +51,61 @@
         "id": 1,
         "group_id": 284
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015810",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false
-        },
-        {
+          "comment": "Brutal General Orc",
           "enemy_id": "0x015830",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 1274,
+          "is_boss": false,
+          "index": 2
         },
         {
+          "comment": "Vigilant Orc Trooper",
+          "enemy_id": "0x015812",
+          "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 258,
+          "is_boss": false,
+          "index": 5
+        },
+        {
+          "comment": "Vigilant Orc Trooper",
+          "enemy_id": "0x015812",
+          "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 258,
+          "is_boss": false,
+          "index": 6
+        },
+        {
+          "comment": "Vigilant Orc Trooper",
+          "enemy_id": "0x015812",
+          "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 258,
+          "is_boss": false,
+          "index": 7
+        },
+        {
+          "comment": "Vigilant Orc Battler",
           "enemy_id": "0x015810",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 299,
+          "is_boss": false,
+          "index": 11
         },
         {
-          "enemy_id": "0x015812",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015812",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015812",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 44,
-          "exp": 5354,
-          "is_boss": false
+          "comment": "Vigilant Orc Battler",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 299,
+          "is_boss": false,
+          "index": 12
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075005_1.json
@@ -1,0 +1,110 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Corpse-Eating White Demon (II)",
+  "quest_id": 20075005,
+  "base_level": 43,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "news_image": 146,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1410
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 220
+    },
+    {
+      "type": "exp",
+      "amount": 1980
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "White Shining Sand",
+          "item_id": 7851,
+          "num": 3
+        },
+        {
+          "comment": "Three-Herb Salad",
+          "item_id": 9410,
+          "num": 2
+        },
+        {
+          "comment": "Demon's Talisman",
+          "item_id": 9389,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 301
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Brutal Silver Roar",
+          "enemy_id": "0x015505",
+		  "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 3401,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+		  "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 188,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 14
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+		  "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 188,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 15
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+		  "named_enemy_params_id": 53,
+          "level": 43,
+          "exp": 188,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 16
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075007.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Dragonleather",
           "item_id": 7941,
           "num": 2
         },
         {
+          "comment": "Wild Steak",
           "item_id": 9412,
           "num": 2
         },
         {
+          "comment": "Harvest Salad",
           "item_id": 9418,
           "num": 1
         }
@@ -47,35 +50,54 @@
         "id": 123,
         "group_id": 1
       },
+      "position_index": 8,
       "enemies": [
         {
-          "enemy_id": "0x015800",
-          "level": 44,
-          "exp": 1100,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015800",
-          "level": 44,
-          "exp": 1100,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015800",
-          "level": 44,
-          "exp": 1100,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015800",
-          "level": 44,
-          "exp": 1100,
-          "is_boss": false
-        },
-        {
+          "comment": "Dangerous Captain Orc",
           "enemy_id": "0x015820",
+          "named_enemy_params_id": 56,
           "level": 44,
-          "exp": 1300,
+          "exp": 1274,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Orc Battler",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 299,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Orc Battler",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 299,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Orc Battler",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 299,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Orc Trooper",
+          "enemy_id": "0x015812",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 258,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Orc Trooper",
+          "enemy_id": "0x015812",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 258,
           "is_boss": false
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075008.json
@@ -1,0 +1,227 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Seeking Demon Commander's Belt",
+  "quest_id": 20075008,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "NorthernBetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5940
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2570
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1050
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Demon Commander's Belt",
+          "item_id": 9449,
+          "num": 5
+        },
+        {
+          "comment": "Diorite Steel Ingot",
+          "item_id": 9444,
+          "num": 1
+        },
+        {
+          "comment": "Wind Twine",
+          "item_id": 7930,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "Group 1 - Great Horned War Demon and Orc Elite Force",
+      "stage_id": {
+        "id": 68,
+        "group_id": 14
+      },
+      "enemies": [
+        {
+          "comment": "Great Horned War Demon (General Orc)",
+          "enemy_id": "0x015830",
+          "named_enemy_params_id": 642,
+          "level": 58,
+          "exp": 1568
+        },
+        {
+          "comment": "Great Horned War Demon (General Orc)",
+          "enemy_id": "0x015830",
+          "named_enemy_params_id": 642,
+          "level": 58,
+          "exp": 1568
+        },
+        {
+          "comment": "Orc Elite Force (Orc Battler)",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 645,
+          "level": 60,
+          "exp": 365,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Orc Elite Force (Orc Battler)",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 645,
+          "level": 60,
+          "exp": 365,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Orc Elite Force (Orc Battler)",
+          "enemy_id": "0x015810",
+          "named_enemy_params_id": 645,
+          "level": 60,
+          "exp": 365,
+          "repop_count": 1,
+          "repop_wait_second": 5
+        }
+      ]
+    },
+    {
+      "comment": "Group 2 - Mogok, War Beast Savage Chimera and Orcish Kingsguard",
+      "stage_id": {
+        "id": 1,
+        "group_id": 313
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Mogok, the Supreme Warrior",
+          "enemy_id": "0x015840",
+          "named_enemy_params_id": 646,
+          "level": 60,
+          "exp": 8500,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Orcish Kingsguard (Orc Blitzer)",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 648,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "level": 57,
+          "exp": 311,
+          "index": 2
+        },
+        {
+          "comment": "Orcish Kingsguard (Orc Blitzer)",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 648,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "level": 57,
+          "exp": 311,
+          "index": 3
+        },
+        {
+          "comment": "Orcish Kingsguard (Orc Blitzer)",
+          "enemy_id": "0x015811",
+          "named_enemy_params_id": 648,
+          "repop_count": 1,
+          "level": 57,
+          "exp": 311,
+          "index": 4
+        },
+        {
+          "comment": "War Beast Savage Chimera (Chimera)",
+          "enemy_id": "0x015200",
+          "named_enemy_params_id": 647,
+          "level": 59,
+          "exp": 4740,
+          "is_boss": true,
+          "index": 5
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 53,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Rocher",
+      "message_id": 16442
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Rocher",
+          "type": "QstTalkChg",
+          "Param1": 1706,
+          "Param2": 16443
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 53,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Rocher",
+      "message_id": 16444
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "New idle dialogue - Rocher",
+          "type": "QstTalkChg",
+          "Param1": 1706,
+          "Param2": 16445
+        }
+      ],
+      "groups": [ 1 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 1 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 53,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Rocher",
+      "message_id": 16446
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075008.json
@@ -195,7 +195,7 @@
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Accept",
+      "announce_type": "Update",
       "result_commands": [
         {
           "comment": "New idle dialogue - Rocher",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012.json
@@ -1,0 +1,106 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Monster Burning from Within",
+  "quest_id": 20095012,
+  "base_level": 48,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ZandoraWastelands",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2210
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1580
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 250
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "High Quality Magick Medal",
+          "item_id": 7870,
+          "num": 1
+        },
+        {
+          "comment": "Enhanced Pickaxe",
+          "item_id": 9401,
+          "num": 3
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 423
+      },
+      "enemies": [
+        {
+          "comment": "Brutal Geo Golem",
+          "enemy_id": "0x015104",
+          "named_enemy_params_id": 54,
+          "level": 48,
+          "exp": 4672,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 55,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Bayard",
+      "message_id": 16064
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4504,
+          "Param2": 16065
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 55,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Bayard",
+      "message_id": 16066
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_1.json
@@ -1,0 +1,107 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Monster Burning from Within (II)",
+  "quest_id": 20095012,
+  "base_level": 50,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ZandoraWastelands",
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2310
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1650
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 260
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "High Quality Magick Medal",
+          "item_id": 7870,
+          "num": 1
+        },
+        {
+          "comment": "Enhanced Lockpick",
+          "item_id": 9403,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 423
+      },
+      "enemies": [
+        {
+          "comment": "Dangerous Geo Golem",
+          "enemy_id": "0x015104",
+          "named_enemy_params_id": 56,
+          "level": 50,
+          "exp": 4800,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 55,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Bayard",
+      "message_id": 16064
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4504,
+          "Param2": 16065
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 55,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Bayard",
+      "message_id": 16066
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_2.json
@@ -1,0 +1,107 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Monster Burning from Within (Bounty)",
+  "quest_id": 20095012,
+  "base_level": 47,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ZandoraWastelands",
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5080
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3630
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Enhanced Pickaxe",
+          "item_id": 9401,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 1
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 423
+      },
+      "enemies": [
+        {
+          "comment": "Bounty Geo Golem",
+          "enemy_id": "0x015104",
+          "named_enemy_params_id": 458,
+          "level": 47,
+          "exp": 4608,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 55,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Bayard",
+      "message_id": 16064
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4504,
+          "Param2": 16065
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 55,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Bayard",
+      "message_id": 16066
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Strong Acid Slime Piece",
           "item_id": 7837,
           "num": 3
         },
         {
+          "comment": "Mellow Ale",
           "item_id": 9413,
           "num": 2
         },
         {
+          "comment": "Special Mushroom Dip",
           "item_id": 9419,
           "num": 1
         }
@@ -45,38 +48,49 @@
     {
       "stage_id": {
         "id": 113,
-        "group_id": 2
+        "group_id": 6
       },
+      "starting_index": 3,
       "enemies": [
         {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal Silver Roar",
           "enemy_id": "0x015505",
+          "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 10000,
+          "exp": 3287,
           "is_boss": true
-        },
-        {
-          "enemy_id": "0x010209",
-          "level": 40,
-          "exp": 750,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010209",
-          "level": 40,
-          "exp": 750,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010209",
-          "level": 40,
-          "exp": 750,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010209",
-          "level": 40,
-          "exp": 750,
-          "is_boss": false
         }
       ]
     }
@@ -89,7 +103,7 @@
           "type": "QstLayout",
           "action": "Set",
           "value": 1079,
-          "comment": "Spawns Lise0 NPC"
+          "comment": "Spawns Lise0 and Plum NPCs"
         }
       ],
       "stage_id": {
@@ -97,13 +111,35 @@
         "group_id": 1,
         "layer_no": 1
       },
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 500, 
+          "Param2": 11326,
+          "comment": "Plum idle dialogue 1"
+        }
+      ],
       "npc_id": "Lise0",
-      "message_id": 11372
+      "message_id": 11318
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 13, 
+          "Param2": 11324,
+          "comment": "Lise idle dialogue"
+        },
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 500, 
+          "Param2": 11328,
+          "comment": "Plum idle dialogue 2"
+        } 
+      ]
     },
     {
       "type": "KillGroup",
@@ -120,7 +156,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Lise0",
-      "message_id": 11842
+      "message_id": 11321
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000_1.json
@@ -1,0 +1,139 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Expedition Preparations (II)",
+  "quest_id": 20100000,
+  "base_level": 41,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "news_image": 564,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1890
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 210
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Lava Rock",
+          "item_id": 7869,
+          "num": 3
+        },
+        {
+          "comment": "Old Forest Dwellers' Key",
+          "item_id": 9066,
+          "num": 2
+        },
+        {
+          "comment": "Rare Meat Paté",
+          "item_id": 9420,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 113,
+        "group_id": 6
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Brutal Silver Roar",
+          "enemy_id": "0x015505",
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 3287,
+          "is_boss": true
+        },
+        {
+          "comment": "Brutal Silver Roar",
+          "enemy_id": "0x015505",
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 3287,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1079,
+          "comment": "Spawns Lise0 and Plum NPCs"
+        }
+      ],
+      "stage_id": {
+        "id": 113,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 500, 
+          "Param2": 11326,
+          "comment": "Plum idle dialogue 1"
+        }
+      ],
+      "npc_id": "Lise0",
+      "message_id": 11318
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "groups": [ 0 ],
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 13, 
+          "Param2": 11324,
+          "comment": "Lise idle dialogue"
+        },
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 500, 
+          "Param2": 11328,
+          "comment": "Plum idle dialogue 2"
+        } 
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 113,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Lise0",
+      "message_id": 11321
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "King Bay Leaf",
           "item_id": 7983,
-          "num": 1
+          "num": 2
         },
         {
+          "comment": "Superior Healing Elixir",
           "item_id": 7553,
           "num": 3
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         }
@@ -58,7 +61,7 @@
         "layer_no": 1
       },
       "npc_id": "August",
-      "message_id": 10800
+      "message_id": 11329
     },
     {
       "type": "NewDeliverItems",
@@ -69,24 +72,21 @@
       },
       "npc_id": "August",
       "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 515, 
+          "Param2": 11335,
+          "comment": "Idle dialogue"
+        }
+      ],
       "items": [
         {
           "id": 7999,
           "amount": 10
         }
       ],
-      "message_id": 10737
-    },
-    {
-      "type": "NewTalkToNpc",
-      "stage_id": {
-        "id": 97,
-        "group_id": 1,
-        "layer_no": 1
-      },
-      "announce_type": "Update",
-      "npc_id": "August",
-      "message_id": 11842
+      "message_id": 11332
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001_1.json
@@ -1,0 +1,93 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Gourmand’s Mushroom Hunt (II)",
+  "quest_id": 20100001,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "news_image": 201,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1300
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 200
+    },
+    {
+      "type": "exp",
+      "amount": 1300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gold-Striped Hardwood",
+          "item_id": 9059,
+          "num": 2
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        },
+        {
+          "comment": "Strong Gala Extract",
+          "item_id": 9363,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1080,
+          "comment": "Spawns August NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 97,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "August",
+      "message_id": 11329
+    },
+    {
+      "type": "NewDeliverItems",
+      "stage_id": {
+        "id": 97,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "August",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 515, 
+          "Param2": 11335,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "items": [
+        {
+          "id": 7999,
+          "amount": 13
+        }
+      ],
+      "message_id": 11332
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100002.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Northern Oregano",
           "item_id": 9064,
           "num": 3
         },
         {
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 3
         },
         {
+          "comment": "Throwing Knife",
           "item_id": 9398,
           "num": 3
         }
@@ -58,11 +61,19 @@
         "layer_no": 1
       },
       "npc_id": "Christoph",
-      "message_id": 11372
+      "message_id": 11337
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 513, 
+          "Param2": 11343,
+          "comment": "Idle dialogue"
+        }
+      ],
       "stage_id": {
         "id": 70,
         "group_id": 1,
@@ -544,7 +555,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Christoph",
-      "message_id": 11842
+      "message_id": 11340
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100002_1.json
@@ -1,0 +1,562 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Remains of Splendor (II)",
+  "quest_id": 20100002,
+  "base_level": 41,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "news_image": 205,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1620
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 210
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Cerussite",
+          "item_id": 9062,
+          "num": 3
+        },
+        {
+          "comment": "Conqueror's Talisman",
+          "item_id": 9387,
+          "num": 1
+        },
+        {
+          "comment": "Five-Herb Salad",
+          "item_id": 9414,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1081,
+          "comment": "Spawns Christoph NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Christoph",
+      "message_id": 11337
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 513, 
+          "Param2": 11343,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "stage_id": {
+        "id": 70,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1728,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1729,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1730,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1731,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1732,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1733,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1734,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1735,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1736,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1737,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1738,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1739,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1740,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1741,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 70,
+        "group_id": 2,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1728,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1729,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1730,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1731,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1732,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1733,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1734,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1735,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1736,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1737,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1738,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1739,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1740,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1741,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 70,
+        "group_id": 3,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1728,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1729,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1730,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1731,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1732,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1733,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1734,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1735,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1736,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1737,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1738,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1739,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1740,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1741,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 70,
+        "group_id": 4,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1728,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1729,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1730,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1731,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1732,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1733,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1734,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1735,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1736,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1737,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1738,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1739,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1740,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1741,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "CollectItem",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 70,
+        "group_id": 5,
+        "layer_no": 1
+      },
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1728,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1729,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1730,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1731,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1732,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1733,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1734,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1735,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1736,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1737,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1738,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1739,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1740,
+          "comment": "Spawns Glowing Item"
+        },
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1741,
+          "comment": "Spawns Glowing Item"
+        }
+      ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 1,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Christoph",
+      "message_id": 11340
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Cursed Cloth",
           "item_id": 7948,
           "num": 1
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 2
         },
         {
+          "comment": "Angel's Talisman",
           "item_id": 9388,
           "num": 1
         }
@@ -45,32 +48,35 @@
     {
       "stage_id": {
         "id": 114,
-        "group_id": 1
+        "group_id": 0
       },
+      "starting_index": 6,
       "enemies": [
         {
+          "comment": "Brutal Cockatrice",
           "enemy_id": "0x015301",
-          "level": 42,
-          "exp": 10500,
-          "is_boss": false
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 4882,
+          "is_boss": true
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
           "level": 41,
-          "exp": 750,
-          "is_boss": false
+          "exp": 236,
+          "repop_count": 1,
+          "repop_wait_second": 10
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
           "level": 41,
-          "exp": 750,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x015504",
-          "level": 41,
-          "exp": 750,
-          "is_boss": false
+          "exp": 236,
+          "repop_count": 1,
+          "repop_wait_second": 10
         }
       ]
     }
@@ -92,11 +98,19 @@
         "layer_no": 1
       },
       "npc_id": "StrangeMan",
-      "message_id": 11372
+      "message_id": 11345
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 507, 
+          "Param2": 11351,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -114,7 +128,7 @@
       },
       "announce_type": "Update",
       "npc_id": "StrangeMan",
-      "message_id": 11835
+      "message_id": 11348
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_1.json
@@ -1,0 +1,138 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Wicked Pursuer (II)",
+  "quest_id": 20100003,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "news_image": 562,
+  "variant_index": 1,
+  "rewards": [
+	{
+	  "type": "wallet",
+	  "wallet_type": "Gold",
+	  "amount": 1480
+	},
+	{
+	  "type": "wallet",
+	  "wallet_type": "RiftPoints",
+	  "amount": 270
+	},
+	{
+	  "type": "exp",
+	  "amount": 2420
+	},
+	{
+	  "type": "select",
+	  "loot_pool": [
+		{
+		  "comment": "Cockatrice Liquor",
+		  "item_id": 7842,
+		  "num": 1
+		},
+		{
+		  "comment": "Darkness Defense Earrings",
+		  "item_id": 9004,
+		  "num": 1
+		},
+		{
+		  "comment": "Demon's Talisman",
+		  "item_id": 9389,
+		  "num": 1
+		}
+	  ]
+	}
+  ],
+  "enemy_groups": [
+	{
+	  "stage_id": {
+		"id": 114,
+		"group_id": 0
+	  },
+	  "starting_index": 6,
+	  "enemies": [
+		{
+		  "comment": "Dangerous Cockatrice",
+		  "enemy_id": "0x015301",
+		  "named_enemy_params_id": 56,
+		  "start_think_tbl_no": 1,
+		  "level": 45,
+		  "exp": 5050,
+		  "is_boss": true
+		},
+		{
+		  "comment": "Vigilant Harpy",
+		  "enemy_id": "0x010600",
+		  "named_enemy_params_id": 53,
+		  "start_think_tbl_no": 2,
+		  "level": 45,
+		  "exp": 126,
+		  "repop_count": 1,
+		  "repop_wait_second": 10
+		},
+		{
+		  "comment": "Vigilant Harpy",
+		  "enemy_id": "0x010600",
+		  "named_enemy_params_id": 53,
+		  "start_think_tbl_no": 2,
+		  "level": 45,
+		  "exp": 126,
+		  "repop_count": 1,
+		  "repop_wait_second": 10
+		}
+	  ]
+	}
+  ],
+  "blocks": [
+	{
+	  "type": "NewNpcTalkAndOrder",
+	  "flags": [
+		{
+		  "type": "QstLayout",
+		  "action": "Set",
+		  "value": 1082,
+		  "comment": "Spawns StrangeMan NPC"
+		}
+	  ],
+	  "stage_id": {
+		"id": 114,
+		"group_id": 1,
+		"layer_no": 1
+	  },
+	  "npc_id": "StrangeMan",
+	  "message_id": 11345
+	},
+	{
+	  "type": "SeekOutEnemiesAtMarkedLocation",
+	  "announce_type": "Accept",
+	  "result_commands": [ 
+		{ 
+		  "type": "QstTalkChg", 
+		  "Param1": 507, 
+		  "Param2": 11351,
+		  "comment": "Idle dialogue"
+		}
+	  ],
+	  "groups": [ 0 ]
+	},
+	{
+	  "type": "KillGroup",
+	  "announce_type": "Update",
+	  "reset_group": false,
+	  "groups": [ 0 ]
+	},
+	{
+	  "type": "NewTalkToNpc",
+	  "stage_id": {
+		"id": 114,
+		"group_id": 1,
+		"layer_no": 1
+	  },
+	  "announce_type": "Update",
+	  "npc_id": "StrangeMan",
+	  "message_id": 11348
+	}
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_2.json
@@ -1,0 +1,125 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Wicked Pursuer (Calamity)",
+  "quest_id": 20100003,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "news_image": 562,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3630
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 360
+    },
+    {
+      "type": "exp",
+      "amount": 5440
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Magick Gold Ingot",
+          "item_id": 7886,
+          "num": 1
+        },
+        {
+          "comment": "Ambrosial Beast-Steak",
+          "item_id": 7727,
+          "num": 1
+        },
+        {
+          "comment": "White Lion Pelt",
+          "item_id": 7739,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 114,
+        "group_id": 0
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Fierce Winged Lion (Griffin)",
+          "enemy_id": "0x015300",
+          "named_enemy_params_id": 517,
+          "level": 55,
+          "exp": 5625,
+          "is_boss": true
+        },
+        {
+          "comment": "Fierce Silver Lion (White Chimera)",
+          "enemy_id": "0x015202",
+          "named_enemy_params_id": 518,
+          "level": 55,
+          "exp": 5787,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1082,
+          "comment": "Spawns StrangeMan NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 114,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "StrangeMan",
+      "message_id": 11346
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 507, 
+          "Param2": 11351,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 114,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "StrangeMan",
+      "message_id": 11349
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_3.json
@@ -1,0 +1,125 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Wicked Pursuer (Calamity II)",
+  "quest_id": 20100003,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "news_image": 562,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3960
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 490
+    },
+    {
+      "type": "exp",
+      "amount": 6930
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Protection+",
+          "item_id": 11740,
+          "num": 1
+        },
+        {
+          "comment": "Spectral Dragon Fang",
+          "item_id": 9453,
+          "num": 1
+        },
+        {
+          "comment": "Magick Lion's Large Mane",
+          "item_id": 9437,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 114,
+        "group_id": 0
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Sharp Fang Mist Dragon (Mist Drake)",
+          "enemy_id": "0x015710",
+          "named_enemy_params_id": 624,
+          "level": 60,
+          "exp": 9860,
+          "is_boss": true
+        },
+        {
+          "comment": "Wicked Clawed White Lion (White Chimera)",
+          "enemy_id": "0x015202",
+          "named_enemy_params_id": 625,
+          "level": 60,
+          "exp": 6162,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "flags": [
+        {
+          "type": "QstLayout",
+          "action": "Set",
+          "value": 1082,
+          "comment": "Spawns StrangeMan NPC"
+        }
+      ],
+      "stage_id": {
+        "id": 114,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "StrangeMan",
+      "message_id": 11347
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 507, 
+          "Param2": 11351,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 114,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "StrangeMan",
+      "message_id": 11350
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Pure White Mane",
           "item_id": 7780,
           "num": 1
         },
         {
+          "comment": "Crest of Greater Magick",
           "item_id": 9200,
           "num": 1
         },
         {
+          "comment": "Grilled Mushroom",
           "item_id": 9415,
           "num": 2
         }
@@ -47,52 +50,52 @@
         "id": 113,
         "group_id": 2
       },
-      "placement_type": "manual",
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Brutal White Chimera",
           "enemy_id": "0x015202",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
-          "level": 42,
-          "exp": 6706,
-          "is_boss": true,
-          "index": 0
-        },
-        {
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 2,
-		      "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 1
-        },
-        {
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 3
-        },
-        {
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 2,
-		      "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 7
-        },
-        {
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 8
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 4887,
+          "is_boss": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Snow-White Lion King",
+  "comment": "The Snow-White Lion King (II)",
   "quest_id": 20105000,
   "base_level": 43,
   "minimum_item_rank": 0,
@@ -13,44 +13,37 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 2970
+      "amount": 1410
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 230
+      "amount": 220
     },
     {
       "type": "exp",
-      "amount": 4150
+      "amount": 1980
     },
     {
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Pure White Mane",
           "item_id": 7780,
           "num": 1
         },
         {
-          "item_id": 9401,
-          "num": 3
+          "comment": "Holy Guard Earrings",
+          "item_id": 9003,
+          "num": 1
         },
         {
-          "item_id": 9399,
+          "comment": "Sprite's Talisman",
+          "item_id": 9390,
           "num": 1
         }
       ]
-  },
-  {
-      "type": "random",
-      "loot_pool": [
-          {
-              "item_id": 7999,
-              "num": 2,
-              "chance": 0.7
-          }
-      ]
-  }
+    }
   ],
   "enemy_groups": [
     {
@@ -58,17 +51,52 @@
         "id": 113,
         "group_id": 2
       },
-      "placement_type": "manual",
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Brutal White Chimera",
           "enemy_id": "0x015202",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 467,
-          "level": 45,
-          "exp": 7260,
-          "is_boss": true,
-          "scale": 150,
-          "index": 0
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 4887,
+          "is_boss": true
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 41,
+          "exp": 151,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 41,
+          "exp": 151,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 41,
+          "exp": 151,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 41,
+          "exp": 151,
+          "is_boss": false
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_2.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Snow-White Lion King",
+  "comment": "The Snow-White Lion King (Bounty)",
   "quest_id": 20105000,
-  "base_level": 43,
+  "base_level": 45,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DeenanWoods",
@@ -13,34 +13,48 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1410
+      "amount": 2970
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 220
+      "amount": 230
     },
     {
       "type": "exp",
-      "amount": 1980
+      "amount": 4150
     },
     {
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Pure White Mane",
           "item_id": 7780,
           "num": 1
         },
         {
-          "item_id": 9003,
-          "num": 1
+          "comment": "Enhanced Lumber Knife",
+          "item_id": 9402,
+          "num": 3
         },
         {
-          "item_id": 9390,
+          "comment": "Dragon's Spit",
+          "item_id": 9399,
           "num": 1
         }
       ]
-    }
+  },
+  {
+      "type": "random",
+      "loot_pool": [
+          {
+              "comment": "Pearl Mushroom",
+              "item_id": 7999,
+              "num": 2,
+              "chance": 0.7
+          }
+      ]
+  }
   ],
   "enemy_groups": [
     {
@@ -48,48 +62,17 @@
         "id": 113,
         "group_id": 2
       },
-      "placement_type": "manual",
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Bounty White Chimera",
           "enemy_id": "0x015202",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
-          "level": 43,
-          "exp": 6824,
+          "named_enemy_params_id": 467,
+          "level": 45,
+          "exp": 5037,
           "is_boss": true,
-          "index": 0
-        },
-        {
-          "enemy_id": "0x010201",
-          "start_think_tbl_no": 1,
-		      "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 1
-        },
-        {
-          "enemy_id": "0x010201",
-          "start_think_tbl_no": 1,
-		      "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 3
-        },
-        {
-          "enemy_id": "0x010201",
-          "start_think_tbl_no": 1,
-		      "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 7
-        },
-        {
-          "enemy_id": "0x010201",
-          "start_think_tbl_no": 1,
-		      "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 8
+          "scale": 150
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Restoration",
           "item_id": 9297,
           "num": 1
         },
         {
+          "comment": "Demon's Talisman",
           "item_id": 9389,
           "num": 1
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 2
         }
@@ -47,30 +50,61 @@
         "id": 70,
         "group_id": 7
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Brutal Ent",
           "enemy_id": "0x015031",
+          "named_enemy_params_id": 54,
           "level": 42,
-          "exp": 10500,
-          "is_boss": true
+          "exp": 3484,
+          "is_boss": true,
+          "index": 0
         },
         {
+          "comment": "Vigilant Forest Goblin",
           "enemy_id": "0x011100",
-          "level": 42,
-          "exp": 950,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 138,
+          "is_boss": false,
+          "index": 1
         },
         {
+          "comment": "Vigilant Forest Goblin",
           "enemy_id": "0x011100",
-          "level": 42,
-          "exp": 950,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 138,
+          "is_boss": false,
+          "index": 4
         },
         {
+          "comment": "Vigilant Forest Goblin",
           "enemy_id": "0x011100",
-          "level": 42,
-          "exp": 950,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 138,
+          "is_boss": false,
+          "index": 5
+        },
+        {
+          "comment": "Vigilant Forest Goblin",
+          "enemy_id": "0x011100",
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 138,
+          "is_boss": false,
+          "index": 6
+        },
+        {
+          "comment": "Vigilant Forest Goblin",
+          "enemy_id": "0x011100",
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 138,
+          "is_boss": false,
+          "index": 7
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_1.json
@@ -1,0 +1,120 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Foolish Occupiers (II)",
+  "quest_id": 20105001,
+  "base_level": 43,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 209,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1410
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "exp",
+      "amount": 1180
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Noblewoman's Corset",
+          "item_id": 986,
+          "num": 1
+        },
+        {
+          "comment": "Enhanced Lockpick",
+          "item_id": 9403,
+          "num": 3
+        },
+        {
+          "comment": "Harvest Salad",
+          "item_id": 9418,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 70,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Brutal Ent",
+          "enemy_id": "0x015031",
+          "named_enemy_params_id": 54,
+          "level": 43,
+          "exp": 3536,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Vigilant Giant Sulfur Saurian",
+          "enemy_id": "0x010411",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 229,
+          "index": 1
+        },
+        {
+          "comment": "Vigilant Giant Sulfur Saurian",
+          "enemy_id": "0x010411",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 229,
+          "index": 4
+        },
+        {
+          "comment": "Vigilant Giant Sulfur Saurian",
+          "enemy_id": "0x010411",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 229,
+          "index": 5
+        },
+        {
+          "comment": "Vigilant Giant Sulfur Saurian",
+          "enemy_id": "0x010411",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 229,
+          "index": 6
+        },
+        {
+          "comment": "Vigilant Giant Sulfur Saurian",
+          "enemy_id": "0x010411",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 229,
+          "index": 7
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_2.json
@@ -1,0 +1,120 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Foolish Occupiers (III)",
+  "quest_id": 20105001,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 209,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1840
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 1840
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Writhing Live Bark",
+          "item_id": 9442,
+          "num": 1
+        },
+        {
+          "comment": "Ent Seed",
+          "item_id": 7992,
+          "num": 2
+        },
+        {
+          "comment": "Ent Branch",
+          "item_id": 7971,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 70,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Legendary Ent",
+          "enemy_id": "0x015031",
+          "named_enemy_params_id": 57,
+          "level": 56,
+          "exp": 4212,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Brutal Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 151,
+          "index": 1
+        },
+        {
+          "comment": "Brutal Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 151,
+          "index": 4
+        },
+        {
+          "comment": "Brutal Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 151,
+          "index": 5
+        },
+        {
+          "comment": "Brutal Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 151,
+          "index": 6
+        },
+        {
+          "comment": "Brutal Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 54,
+          "level": 56,
+          "exp": 151,
+          "index": 7
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_3.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Foolish Occupiers (Bounty)",
+  "quest_id": 20105001,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 209,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2970
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 230
+    },
+    {
+      "type": "exp",
+      "amount": 3560
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Thick Bone",
+          "item_id": 7770,
+          "num": 1
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        },
+        {
+          "comment": "Special Mushroom Dip",
+          "item_id": 9419,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 70,
+        "group_id": 7
+      },
+      "enemies": [
+        {
+          "comment": "Bounty Mole Troll",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 512,
+          "level": 45,
+          "exp": 4200,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Greater Power",
           "item_id": 9196,
           "num": 1
         },
         {
+          "comment": "Sprite's Talisman",
           "item_id": 9390,
           "num": 1
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 2
         }
@@ -47,18 +50,25 @@
         "id": 70,
         "group_id": 19
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Key Bearer Mole Troll",
           "enemy_id": "0x015041",
+          "named_enemy_params_id": 391,
           "level": 42,
-          "exp": 10500,
-          "is_boss": true
+          "exp": 4020,
+          "is_boss": true,
+          "index": 5
         },
         {
+          "comment": "Brutal Mole Troll",
           "enemy_id": "0x015041",
+          "named_enemy_params_id": 54,
           "level": 42,
-          "exp": 10500,
-          "is_boss": true
+          "exp": 4020,
+          "is_boss": true,
+          "index": 9
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002_1.json
@@ -1,0 +1,121 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Surge of Hellfire (II)",
+  "quest_id": 20105002,
+  "base_level": 43,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 210,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1410
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 220
+    },
+    {
+      "type": "exp",
+      "amount": 1980
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Blow-Resistant Cloth",
+          "item_id": 7942,
+          "num": 1
+        },
+        {
+          "comment": "Strong Gala Extract",
+          "item_id": 9363,
+          "num": 3
+        },
+        {
+          "comment": "Rare Meat Paté",
+          "item_id": 9420,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 70,
+        "group_id": 19
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Key Bearer Mole Troll",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 391,
+          "level": 42,
+          "exp": 4020,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Brutal Mole Troll",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 54,
+          "level": 42,
+          "exp": 4020,
+          "is_boss": true,
+          "index": 9
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 119,
+          "index": 10
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 119,
+          "index": 11
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 119,
+          "index": 12
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 42,
+          "exp": 119,
+          "index": 14
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Cursed Cloth",
           "item_id": 7948,
           "num": 1
         },
         {
+          "comment": "Conqueror's Talisman",
           "item_id": 9387,
           "num": 1
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         }
@@ -47,11 +50,14 @@
         "id": 107,
         "group_id": 6
       },
+      "starting_index": 3,
       "enemies": [
         {
+          "comment": "Brutal Cockatrice",
           "enemy_id": "0x015301",
+          "named_enemy_params_id": 54,
           "level": 43,
-          "exp": 11000,
+          "exp": 4882,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003_1.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "When The Black Fowl Crows (Bounty)",
+  "quest_id": 20105003,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 211,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2970
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 4150
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gold Ingot",
+          "item_id": 7877,
+          "num": 1
+        },
+        {
+          "comment": "Demon's Talisman",
+          "item_id": 9389,
+          "num": 1
+        },
+        {
+          "comment": "Old Forest Dwellers' Key",
+          "item_id": 9066,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 107,
+        "group_id": 6
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Bounty Cockatrice",
+          "enemy_id": "0x015301",
+          "named_enemy_params_id": 512,
+          "level": 45,
+          "exp": 5050,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004.json
@@ -12,7 +12,7 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1410
+      "amount": 1480
     },
     {
       "type": "wallet",
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Red Alloy Ingot",
           "item_id": 7888,
           "num": 2
         },
         {
+          "comment": "Harvest Salad",
           "item_id": 9418,
           "num": 1
         },
         {
+          "comment": "Throwblast",
           "item_id": 52,
           "num": 3
         }
@@ -47,11 +50,14 @@
         "id": 109,
         "group_id": 10
       },
+      "starting_index": 3,
       "enemies": [
         {
+          "comment": "Brutal Golem",
           "enemy_id": "0x015100",
+          "named_enemy_params_id": 54,
           "level": 45,
-          "exp": 13000,
+          "exp": 3500,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_1.json
@@ -1,0 +1,78 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Keeper of the Woods (II)",
+  "quest_id": 20105004,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 206,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1980
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 490
+    },
+    {
+      "type": "exp",
+      "amount": 3460
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Spectral Dragon Claw",
+          "item_id": 7802,
+          "num": 1
+        },
+        {
+          "comment": "Spectral Dragonscale",
+          "item_id": 7922,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 109,
+        "group_id": 10
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Mist Wyrm",
+          "enemy_id": "0x015711",
+          "level": 60,
+          "exp": 9860,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_2.json
@@ -1,0 +1,106 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Keeper of the Woods (Calamity)",
+  "quest_id": 20105004,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 206,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1480
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 230
+    },
+    {
+      "type": "exp",
+      "amount": 2070
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Smooth Dragonleather",
+          "item_id": 7927,
+          "num": 1
+        },
+        {
+          "comment": "Twinkle Star",
+          "item_id": 949,
+          "num": 1
+        },
+        {
+          "comment": "Sprite's Talisman",
+          "item_id": 9390,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 109,
+        "group_id": 10
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Deenan Piercer (Angules)",
+          "enemy_id": "0x015708",
+          "named_enemy_params_id": 495,
+          "level": 45,
+          "exp": 7890,
+          "is_boss": true
+        },
+        {
+          "comment": "Dangerous Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 56,
+          "level": 45,
+          "exp": 230,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 56,
+          "level": 45,
+          "exp": 230,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 56,
+          "level": 45,
+          "exp": 230,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_3.json
@@ -1,0 +1,106 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Keeper of the Woods (Calamity II)",
+  "quest_id": 20105004,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 206,
+  "variant_index": 3,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3870
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 450
+    },
+    {
+      "type": "exp",
+      "amount": 5620
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Smooth Dragonleather",
+          "item_id": 7927,
+          "num": 1
+        },
+        {
+          "comment": "Angules Horn",
+          "item_id": 7756,
+          "num": 1
+        },
+        {
+          "comment": "Dragonleather",
+          "item_id": 7941,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 109,
+        "group_id": 10
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Deenan Piercer (Angules)",
+          "enemy_id": "0x015708",
+          "named_enemy_params_id": 532,
+          "level": 55,
+          "exp": 9120,
+          "is_boss": true
+        },
+        {
+          "comment": "Dangerous Shadow Harpy",
+          "enemy_id": "0x010607",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 240,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Shadow Harpy",
+          "enemy_id": "0x010607",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 240,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Dangerous Shadow Harpy",
+          "enemy_id": "0x010607",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 240,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
@@ -27,14 +27,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Marbled Beast-Steak",
                     "item_id": 7726,
                     "num": 3
                 },
                 {
+                    "comment": "Special Mushroom Dip",
                     "item_id": 9419,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Pickaxe",
                     "item_id": 9401,
                     "num": 3
                 }
@@ -49,9 +52,11 @@
             },
             "enemies": [
                 {
+                    "comment": "Brutal Ent",
                     "enemy_id": "0x015031",
+                    "named_enemy_params_id": 54,
                     "level": 41,
-                    "exp": 10000,
+                    "exp": 3432,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Sinister Black Cloth",
           "item_id": 7947,
           "num": 1
         },
         {
+          "comment": "Dragon's Spit",
           "item_id": 9399,
           "num": 1
         },
         {
+          "comment": "Five-Herb Salad",
           "item_id": 9414,
           "num": 2
         }
@@ -45,14 +48,63 @@
     {
       "stage_id": {
         "id": 163,
-        "group_id": 8
+        "group_id": 9
       },
+      "starting_index": 3,
       "enemies": [
         {
-          "enemy_id": "0x015600",
-          "level": 43,
-          "exp": 11000,
+          "comment": "Vigilant Witch",
+          "enemy_id": "0x015604",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 2,
+          "level": 41,
+          "exp": 2772,
           "is_boss": true
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 8,
+          "level": 43,
+          "exp": 200,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 8,
+          "level": 43,
+          "exp": 200,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 8,
+          "level": 43,
+          "exp": 200,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 8,
+          "level": 43,
+          "exp": 200,
+          "is_required": false,
+          "is_manual_set": true
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 8,
+          "level": 43,
+          "exp": 200,
+          "is_required": false,
+          "is_manual_set": true
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006_1.json
@@ -1,0 +1,108 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Old Witch of the Woods (II)",
+  "quest_id": 20105006,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 563,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1840
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 240
+    },
+    {
+      "type": "exp",
+      "amount": 1840
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Witch's Velvet",
+          "item_id": 7949,
+          "num": 1
+        },
+        {
+          "comment": "Witch's Grimoire",
+          "item_id": 7808,
+          "num": 1
+        },
+        {
+          "comment": "Smoky Quartz",
+          "item_id": 7908,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 163,
+        "group_id": 9
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Empress Ghost",
+          "enemy_id": "0x015605",
+          "level": 56,
+          "exp": 4147,
+          "is_boss": true
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 56,
+          "exp": 274
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 56,
+          "exp": 274
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 56,
+          "exp": 274
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 56,
+          "exp": 274
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 56,
+          "exp": 274
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007.json
@@ -3,7 +3,7 @@
   "type": "World",
   "comment": "A Sudden Urge to Kill",
   "quest_id": 20105007,
-  "base_level": 45,
+  "base_level": 41,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DeenanWoods",
@@ -12,31 +12,34 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1410
+      "amount": 1350
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 230
+      "amount": 210
     },
     {
       "type": "exp",
-      "amount": 2070
+      "amount": 1620
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 9260,
-          "num": 1
-        },
-        {
-          "item_id": 9418,
-          "num": 1
-        },
-        {
-          "item_id": 9415,
+          "comment": "Spirit Silver Ingot",
+          "item_id": 7884,
           "num": 2
+        },
+        {
+          "comment": "Rare Meat Paté",
+          "item_id": 9420,
+          "num": 1
+        },
+        {
+          "comment": "Enhanced Lumber Knife",
+          "item_id": 9402,
+          "num": 3
         }
       ]
     }
@@ -47,11 +50,14 @@
         "id": 97,
         "group_id": 7
       },
+      "starting_index": 5,
       "enemies": [
         {
-          "enemy_id": "0x015500",
-          "level": 45,
-          "exp": 13000,
+          "comment": "Brutal Silver Roar",
+          "enemy_id": "0x015505",
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 3287,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_1.json
@@ -1,0 +1,108 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Sudden Urge to Kill (II)",
+  "quest_id": 20105007,
+  "base_level": 56,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 204,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1540
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 180
+    },
+    {
+      "type": "exp",
+      "amount": 1540
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Sand of Reminiscence",
+          "item_id": 9441,
+          "num": 1
+        },
+        {
+          "comment": "Demonic Gem",
+          "item_id": 7911,
+          "num": 1
+        },
+        {
+          "comment": "Transumted Fur",
+          "item_id": 7781,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 97,
+        "group_id": 7
+      },
+      "enemies": [
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 56,
+          "exp": 243,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 56,
+          "exp": 279
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 56,
+          "exp": 279
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 56,
+          "exp": 279
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 56,
+          "exp": 279
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 56,
+          "exp": 279
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_2.json
@@ -1,0 +1,79 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Sudden Urge to Kill (Bounty)",
+  "quest_id": 20105007,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "news_image": 204,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2970
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 230
+    },
+    {
+      "type": "exp",
+      "amount": 3560
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Permafrost",
+          "item_id": 9260,
+          "num": 1
+        },
+        {
+          "comment": "Harvest Salad",
+          "item_id": 9418,
+          "num": 1
+        },
+        {
+          "comment": "Grilled Mushroom",
+          "item_id": 9415,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 97,
+        "group_id": 7
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Bounty Silver Roar",
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 458,
+          "level": 45,
+          "exp": 3515,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
@@ -16,7 +16,7 @@
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 180
+            "amount": 150
         },
         {
             "type": "exp",
@@ -26,16 +26,19 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 8027,
-                    "num": 1
+                    "comment": "Large Scallop Shell",
+                    "item_id": 8018,
+                    "num": 2
                 },
                 {
-                    "item_id": 7554,
-                    "num": 3
-                },
-                {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 3
+                },
+                {
+                    "comment": "Panacea",
+                    "item_id": 41,
+                    "num": 1
                 }
             ]
         }
@@ -47,7 +50,7 @@
                 "id": 63
             },
             "npc_id": "Theodor",
-            "message_id": 10800
+            "message_id": 11486
         },
         {
             "type": "DeliverItems",
@@ -57,13 +60,22 @@
             },
             "npc_id": "Theodor",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 12021,
+                "comment": "Idle dialogue"
+                }
+            ],
             "items": [
                 {
+                    "comment": "Blob Flesh",
                     "id": 7734,
                     "amount": 8
                 }
             ],
-            "message_id": 10737
+            "message_id": 12017
         },
         {
             "type": "DeliverItems",
@@ -73,13 +85,22 @@
             },
             "npc_id": "Theodor",
             "announce_type": "Update",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 12021,
+                "comment": "Idle dialogue"
+                }
+            ],
             "items": [
                 {
+                    "comment": "Mysterious Gold Lump",
                     "id": 8026,
                     "amount": 6
                 }
             ],
-            "message_id": 10737
+            "message_id": 12018
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
@@ -1,0 +1,107 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Separation and Completion (II)",
+    "quest_id": 20990001,
+    "base_level": 55,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1810
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 180
+        },
+        {
+            "type": "exp",
+            "amount": 1210
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Star Sphene",
+                    "item_id": 7914,
+                    "num": 3
+                },
+                {
+                    "comment": "Superior Healing Remedy",
+                    "item_id": 7555,
+                    "num": 5
+                },
+                {
+                    "comment": "Superior Strong Gala Extract",
+                    "item_id": 9364,
+                    "num": 5
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 63
+            },
+            "npc_id": "Theodor",
+            "message_id": 11486
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1
+            },
+            "npc_id": "Theodor",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 12021,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "items": [
+                {
+                    "comment": "Griffin Beak",
+                    "id": 7758,
+                    "amount": 3
+                }
+            ],
+            "message_id": 12017
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1
+            },
+            "npc_id": "Theodor",
+            "announce_type": "Update",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 12021,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "items": [
+                {
+                    "comment": "Dragon Hide",
+                    "id": 7928,
+                    "amount": 3
+                }
+            ],
+            "message_id": 12018
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Aliment Extractant",
                     "item_id": 8033,
                     "num": 2
                 },
                 {
+                    "comment": "Mergan Ring",
                     "item_id": 8023,
                     "num": 1
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 2
                 }
@@ -48,23 +51,65 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x011020",
-                    "level": 50,
-                    "exp": 1500,
-                    "is_boss": false,
-                    "hm_present_no": 59
-                },
-                {
-                    "enemy_id": "0x011023",
-                    "level": 50,
-                    "exp": 1500,
-                    "is_boss": false,
-                    "hm_present_no": 62
-                },
-                {
+                    "comment": "Dangerous Mergan Defender",
                     "enemy_id": "0x011024",
+                    "named_enemy_params_id": 56,
                     "level": 50,
-                    "exp": 1500,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Warrior",
+                    "enemy_id": "0x011020",
+                    "named_enemy_params_id": 59,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 65
+                },
+                {
+                    "comment": "Dangerous Mergan Warrior",
+                    "enemy_id": "0x011020",
+                    "named_enemy_params_id": 59,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 65
+                },
+                {
+                    "comment": "Dangerous Mergan Defender",
+                    "enemy_id": "0x011024",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Defender",
+                    "enemy_id": "0x011024",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Defender",
+                    "enemy_id": "0x011024",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Defender",
+                    "enemy_id": "0x011024",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 262,
                     "is_boss": false,
                     "hm_present_no": 63
                 }
@@ -80,11 +125,19 @@
                 "layer_no": 1
             },
             "npc_id": "Ariadne",
-            "message_id": 11372
+            "message_id": 11487
         },
         {
             "type": "DiscoverEnemy",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2303, 
+                "Param2": 13257,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -114,7 +167,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Ariadne",
-            "message_id": 11842
+            "message_id": 13254
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003_1.json
@@ -1,0 +1,174 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Inherited Experience (II)",
+    "quest_id": 20990003,
+    "base_level": 50,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 1370
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1100
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 220
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Aliment Extractant",
+                    "item_id": 8033,
+                    "num": 2
+                },
+                {
+                    "comment": "Mergan Ring",
+                    "item_id": 8023,
+                    "num": 1
+                },
+                {
+                    "comment": "Enhanced Lockpick",
+                    "item_id": 9403,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 58,
+                "group_id": 0
+            },
+            "enemies": [
+                {
+                    "comment": "Dangerous Mergan Seeker",
+                    "enemy_id": "0x011021",
+                    "named_enemy_params_id": 60,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Element Archer",
+                    "enemy_id": "0x011027",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 66
+                },
+                {
+                    "comment": "Dangerous Mergan Element Archer",
+                    "enemy_id": "0x011027",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 66
+                },
+                {
+                    "comment": "Dangerous Mergan Seeker",
+                    "enemy_id": "0x011021",
+                    "named_enemy_params_id": 60,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Seeker",
+                    "enemy_id": "0x011021",
+                    "named_enemy_params_id": 60,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Seeker",
+                    "enemy_id": "0x011021",
+                    "named_enemy_params_id": 60,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                },
+                {
+                    "comment": "Dangerous Mergan Seeker",
+                    "enemy_id": "0x011021",
+                    "named_enemy_params_id": 60,
+                    "level": 50,
+                    "exp": 262,
+                    "is_boss": false,
+                    "hm_present_no": 63
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 56,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Ariadne",
+            "message_id": 11487
+        },
+        {
+            "type": "DiscoverEnemy",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2303, 
+                "Param2": 13257,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "reset_group": false,
+            "announce_type": "Update",
+            "groups": [0]
+        },
+        {
+            "type": "CollectItem",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 58,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 1302, "comment": "Spawns Glowing Item"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 56,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Ariadne",
+            "message_id": 13254
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Alchemized Armor Plate",
                     "item_id": 8031,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Lumber Knife",
                     "item_id": 9402,
                     "num": 3
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 3
                 }
@@ -46,11 +49,14 @@
                 "id": 84,
                 "group_id": 10
             },
+            "starting_index": 1,
             "enemies": [
                 {
+                    "comment": "Dangerous Goliath",
                     "enemy_id": "0x015102",
-                    "level": 54,
-                    "exp": 18500,
+                    "named_enemy_params_id": 56,
+                    "level": 53,
+                    "exp": 7254,
                     "is_boss": true
                 }
             ]
@@ -65,11 +71,19 @@
                 "layer_no": 1
             },
             "npc_id": "Metrophanes",
-            "message_id": 11372
+            "message_id": 11488
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2304, 
+                "Param2": 13251,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -87,7 +101,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Metrophanes",
-            "message_id": 11842
+            "message_id": 13248
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004_1.json
@@ -1,0 +1,108 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Lost Golden Child (II)",
+    "quest_id": 20990004,
+    "base_level": 56,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 2150
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1840
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 240
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Demon Arming Points",
+                    "item_id": 8022,
+                    "num": 1
+                },
+                {
+                    "comment": "Pearl Shell",
+                    "item_id": 9796,
+                    "num": 1
+                },
+                {
+                    "comment": "Gold Thread",
+                    "item_id": 7743,
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 84,
+                "group_id": 10
+            },
+            "starting_index": 1,
+            "enemies": [
+                {
+                    "comment": "Dangerous Gigant Machina",
+                    "enemy_id": "0x015850",
+                    "named_enemy_params_id": 56,
+                    "level": 56,
+                    "exp": 5184,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 237,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Metrophanes",
+            "message_id": 11488
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2304, 
+                "Param2": 13251,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 237,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Metrophanes",
+            "message_id": 13248
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995000.json
@@ -44,14 +44,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Alchemical Extract",
                     "item_id": 9452,
                     "num": 3
                 },
                 {
+                    "comment": "Spectral Dragon Fang",
                     "item_id": 9453,
                     "num": 1
                 },
                 {
+                    "comment": "Spectral Dragon Claw",
                     "item_id": 7802,
                     "num": 1
                 }
@@ -67,38 +70,41 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Freezing Dragon Force (Mist Wyrm)",
                     "enemy_id": "0x015711",
+                    "named_enemy_params_id": 634,
                     "start_think_tbl_no": 2,
                     "level": 60,
-                    "exp": 45000,
-                    "named_enemy_params_id": 634,
+                    "exp": 9860,
                     "is_boss": true,
-                    "index": 3
+                    "index": 10
                 },
                 {
+                    "comment": "Scorching Dragon Force (Mist Drake)",
                     "enemy_id": "0x015710",
+                    "named_enemy_params_id": 633,
                     "start_think_tbl_no": 2,
                     "level": 60,
-                    "exp": 45000,
-                    "named_enemy_params_id": 633,
+                    "exp": 9860,
                     "is_boss": true,
-                    "index": 2
+                    "index": 11
                 }
             ]
         },
         {
           "stage_id": {
             "id": 84,
-            "group_id": 20
+            "group_id": 15
           },
           "placement_type": "manual",
           "enemies": [
             {
+                "comment": "Shadow of Diamantes (Diamantes)",
                 "enemy_id": "0x020500",
+                "named_enemy_params_id": 632,
                 "start_think_tbl_no": 1,
                 "level": 60,
-                "exp": 45000,
-                "named_enemy_params_id": 632,
+                "exp": 0,
                 "is_boss": true,
                 "index": 0
             }
@@ -114,11 +120,19 @@
                 "layer_no": 1
             },
             "npc_id": "Actaeon",
-            "message_id": 11372
+            "message_id": 16437
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2300, 
+                "Param2": 16438,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [ 0 ]
         },
         {
@@ -137,11 +151,19 @@
             },
             "npc_id": "Actaeon",
             "announce_type": "Update",
-            "message_id": 11842          
+            "message_id": 16439        
             },
             {
                 "type": "SeekOutEnemiesAtMarkedLocation",
                 "announce_type": "Update",
+                "result_commands": [ 
+                    { 
+                        "type": "QstTalkChg", 
+                        "Param1": 2300, 
+                        "Param2": 16440,
+                        "comment": "Idle dialogue"
+                    }
+                ],
                 "groups": [ 1 ]
             },
             {
@@ -159,7 +181,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Actaeon",
-            "message_id": 11842
+            "message_id": 16441
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Star Sphene",
                     "item_id": 7914,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Lockpick",
                     "item_id": 9403,
                     "num": 3
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 1
                 }
@@ -48,9 +51,11 @@
             },
             "enemies": [
                 {
+                    "comment": "Brutal Lindwurm",
                     "enemy_id": "0x015707",
+                    "named_enemy_params_id": 54,
                     "level": 51,
-                    "exp": 17000,
+                    "exp": 8056,
                     "is_boss": true
                 }
             ]
@@ -65,11 +70,19 @@
                 "layer_no": 1
             },
             "npc_id": "Metrophanes",
-            "message_id": 11372
+            "message_id": 16088
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2304, 
+                "Param2": 16089,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -87,7 +100,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Metrophanes",
-            "message_id": 11842
+            "message_id": 16090
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002_1.json
@@ -1,0 +1,107 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Blue Dragon's Shadow (Rare Species)",
+    "quest_id": 20995002,
+    "base_level": 60,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 3460
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1980
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 490
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Superior Healing Remedy",
+                    "item_id": 7555,
+                    "num": 2
+                },
+                {
+                    "comment": "Superior Strong Gala Extract",
+                    "item_id": 9364,
+                    "num": 2
+                },
+                {
+                    "comment": "Panacea",
+                    "item_id": 41,
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 76,
+                "group_id": 1
+            },
+            "enemies": [
+                {
+                    "comment": "Frozen Wyrm (Wyrm)",
+                    "enemy_id": "0x015701",
+                    "named_enemy_params_id": 626,
+                    "level": 60,
+                    "exp": 9860,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 237,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Metrophanes",
+            "message_id": 16088
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 2304, 
+                "Param2": 16089,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 237,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Metrophanes",
+            "message_id": 16090
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Dirty Sheet Metal",
                     "item_id": 8029,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Pickaxe",
                     "item_id": 9401,
                     "num": 3
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
                     "num": 3
                 }
@@ -47,14 +50,13 @@
                 "group_id": 5
             },
                 "placement_type": "manual",
-            "enemies": [
-                
+                "enemies": [
                 {
+                    "comment": "Dangerous Damned Golem",
                     "enemy_id": "0x015103",
-                    "start_think_tbl_no": 1,
-		            "named_enemy_params_id": 53,
+                    "named_enemy_params_id": 56,
                     "level": 53,
-                    "exp": 15632,
+                    "exp": 4867,
                     "is_boss": true,
                     "index": 4
                 }
@@ -73,11 +75,19 @@
                 "layer_no": 1
             },
             "npc_id": "4740",
-            "message_id": 11372
+            "message_id": 16070
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 4740, 
+                "Param2": 16071,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -95,7 +105,7 @@
             },
             "announce_type": "Update",
             "npc_id": "4740",
-            "message_id": 11842
+            "message_id": 16072
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004_1.json
@@ -1,13 +1,13 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Abandoned Giant Warrior",
+    "comment": "The Abandoned Giant Warrior (II)",
     "quest_id": 20995004,
     "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
-	"variant_index": 1,
+    "variant_index": 1,
     "rewards": [
         {
             "type": "exp",
@@ -27,14 +27,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Exquisite Metal Plate",
                     "item_id": 8030,
+                    "num": 1
+                },
+                {
+                    "comment": "Alchemized Armor Plate",
+                    "item_id": 8031,
                     "num": 2
                 },
                 {
-                    "item_id": 8031,
-                    "num": 3
-                },
-                {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 3
                 }
@@ -47,15 +50,14 @@
                 "id": 76,
                 "group_id": 5
             },
-                "placement_type": "manual",
+            "placement_type": "manual",
             "enemies": [
-             
                 {
+                    "comment": "Dangerous Goliath",
                     "enemy_id": "0x015102",
-                    "start_think_tbl_no": 1,
-		            "named_enemy_params_id": 56,
+                    "named_enemy_params_id": 56,
                     "level": 56,
-                    "exp": 21700,
+                    "exp": 7553,
                     "is_boss": true,
                     "index": 4
                 }
@@ -74,11 +76,19 @@
                 "layer_no": 1
             },
             "npc_id": "4740",
-            "message_id": 11372
+            "message_id": 16070
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 4740, 
+                "Param2": 16071,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -96,7 +106,7 @@
             },
             "announce_type": "Update",
             "npc_id": "4740",
-            "message_id": 11842
+            "message_id": 16072
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
@@ -10,7 +10,7 @@
     "rewards": [
         {
             "type": "exp",
-            "amount": 3630
+            "amount": 2960
         },
         {
             "type": "wallet",
@@ -20,21 +20,24 @@
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 360
+            "amount": 330
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7823,
-                    "num": 1
+                    "comment": "Alkahest",
+                    "item_id": 7833,
+                    "num": 2
                 },
                 {
+                    "comment": "Alchemized Armor Plate",
                     "item_id": 8031,
                     "num": 2
                 },
                 {
-                    "item_id": 9378,
+                    "comment": "Superior Healing Remedy",
+                    "item_id": 7555,
                     "num": 2
                 }
             ]
@@ -49,25 +52,17 @@
                 "layer_no": 0
                 
             },
-                "placement_type": "manual",
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Dangerous Alchemized Griffin",
                     "enemy_id": "0x015304",
                     "level": 55,
                     "start_think_tbl_no": 1,
-		            "named_enemy_params_id": 54,
-                    "exp": 19700,
+                    "named_enemy_params_id": 56,
+                    "exp": 5700,
                     "is_boss": true,
-                    "index": 15,
-                    "drop_items": [
-                        {
-                        "item_id": 7823,
-                        "item_min": 1,
-                        "item_max": 3,
-                        "quality": 1,
-                        "drop_chance": 0.9
-                      }
-                    ]
+                    "index": 11
                 }
             ]
         }
@@ -84,11 +79,19 @@
                 "layer_no": 1
             },
             "npc_id": "Eunike",
-            "message_id": 11372
+            "message_id": 16073
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 4742, 
+                "Param2": 16074,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -106,7 +109,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Eunike",
-            "message_id": 11842
+            "message_id": 16075
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
@@ -1,0 +1,161 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "An Altered Beast Attacks! (Calamity)",
+    "quest_id": 20995005,
+    "base_level": 55,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 5420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 3630
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 330
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Bright Gold Feather",
+                    "item_id": 7823,
+                    "num": 1
+                },
+                {
+                    "comment": "Alchemized Armor Plate",
+                    "item_id": 8031,
+                    "num": 3
+                },
+                {
+                    "comment": "Bone Meal",
+                    "item_id": 9378,
+                    "num": 5
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 76,
+                "group_id": 4,
+                "sub_group_id": 0,
+                "layer_no": 0
+                
+            },
+            "starting_index": 10,
+            "enemies": [
+                {
+                    "comment": "Alchemized Griffin No. 04 (Alchemized Griffin)",
+                    "enemy_id": "0x015304",
+                    "named_enemy_params_id": 510,
+                    "level": 55,
+                    "exp": 5700,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Dangerous Mergan Element Archer",
+                    "enemy_id": "0x011027",
+                    "named_enemy_params_id": 56,
+                    "hm_present_no": 66,
+                    "level": 55,
+                    "exp": 281
+                },
+                {
+                    "comment": "Dangerous Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 512
+                },
+                {
+                    "comment": "Dangerous Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 512,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Dangerous Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 512
+                },
+                {
+                    "comment": "Dangerous Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 512
+                },
+                {
+                    "comment": "Dangerous Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 512,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NewNpcTalkAndOrder",
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 1620, "comment": "Spawns Eunike NPC"}
+            ],
+            "stage_id": {
+                "id": 76,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Eunike",
+            "message_id": 16073
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 4742, 
+                "Param2": 16074,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 76,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Eunike",
+            "message_id": 16075
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995006.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Alkahest",
                     "item_id": 7833,
                     "num": 2
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
                     "num": 3
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 1
                 }
@@ -52,7 +55,7 @@
                 "layer_no": 1
             },
             "npc_id": "4743",
-            "message_id": 11372
+            "message_id": 16079
         },
         {
             "type": "NewDeliverItems",
@@ -63,13 +66,22 @@
             },
             "npc_id": "4743",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 4743, 
+                "Param2": 16077,
+                "comment": "Idle dialogue"
+                }
+            ],
             "items": [
                 {
+                    "comment": "Bonemeal",
                     "id": 7850,
                     "amount": 9
                 }
             ],
-            "message_id": 10737
+            "message_id": 16078
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995006_1.json
@@ -1,0 +1,88 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Training Requirement (II)",
+    "quest_id": 20995006,
+    "base_level": 55,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1810
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 180
+        },
+        {
+            "type": "exp",
+            "amount": 1210
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Alkahest",
+                    "item_id": 7833,
+                    "num": 3
+                },
+                {
+                    "comment": "Superior Healing Remedy",
+                    "item_id": 7555,
+                    "num": 5
+                },
+                {
+                    "comment": "Superior Strong Gala Extract",
+                    "item_id": 9364,
+                    "num": 5
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NewNpcTalkAndOrder",
+            "flags": [
+                {"type": "QstLayout", "action": "Set", "value": 1627, "comment": "Spawns 禁域守の神官 NPC"}
+            ],
+            "stage_id": {
+                "id": 76,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "4743",
+            "message_id": 16079
+        },
+        {
+            "type": "NewDeliverItems",
+            "stage_id": {
+                "id": 76,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "4743",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 4743, 
+                "Param2": 16077,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "items": [
+                {
+                    "comment": "Dirty Sheet Metal",
+                    "id": 8029,
+                    "amount": 12
+                }
+            ],
+            "message_id": 16078
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995007.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Training Stakes",
                     "item_id": 8027,
                     "num": 1
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
                     "num": 3
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 3
                 }
@@ -49,7 +52,7 @@
                 "layer_no": 1
             },
             "npc_id": "Iosef",
-            "message_id": 11372
+            "message_id": 16080
         },
         {
             "type": "DeliverItems",
@@ -59,13 +62,22 @@
             },
             "npc_id": "Iosef",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "comment": "Idle dialogue",
+                "type": "QstTalkChg", 
+                "Param1": 2302, 
+                "Param2": 16081
+                }
+            ],
             "items": [
                 {
+                    "comment": "Chipped Gold Lump",
                     "id": 8025,
                     "amount": 9
                 }
             ],
-            "message_id": 10737
+            "message_id": 16082
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995007_1.json
@@ -1,0 +1,84 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Mergoda's Resource Issue (II)",
+    "quest_id": 20995007,
+    "base_level": 55,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1810
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 180
+        },
+        {
+            "type": "exp",
+            "amount": 1210
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Alchemic Wood",
+                    "item_id": 9159,
+                    "num": 3
+                },
+                {
+                    "comment": "Superior Healing Remedy",
+                    "item_id": 7555,
+                    "num": 5
+                },
+                {
+                    "comment": "Superior Strong Gala Extract",
+                    "item_id": 9364,
+                    "num": 5
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 237,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Iosef",
+            "message_id": 16080
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 237,
+                "group_id": 1
+            },
+            "npc_id": "Iosef",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "comment": "Idle dialogue",
+                "type": "QstTalkChg", 
+                "Param1": 2302, 
+                "Param2": 16081
+                }
+            ],
+            "items": [
+                {
+                    "comment": "Chipped Gold Lump",
+                    "id": 8025,
+                    "amount": 9
+                }
+            ],
+            "message_id": 16082
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Alchemic Wood",
                     "item_id": 9159,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Lumber Knife",
                     "item_id": 9402,
                     "num": 3
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 1
                 }
@@ -49,40 +52,44 @@
             "starting_index": 6,
             "enemies": [
                 {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Brutal Silver Roar",
                     "enemy_id": "0x015505",
+                    "named_enemy_params_id": 54,
                     "level": 52,
-                    "exp": 14000,
+                    "exp": 3914,
                     "is_boss": true
-                },
-                {
-                    "enemy_id": "0x010103",
-                    "level": 52,
-                    "exp": 1500,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010103",
-                    "level": 52,
-                    "exp": 1500,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010103",
-                    "level": 52,
-                    "exp": 1500,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010103",
-                    "level": 52,
-                    "exp": 1500,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010103",
-                    "level": 52,
-                    "exp": 1500,
-                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009_1.json
@@ -1,0 +1,110 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Experiments Strike Back (II)",
+    "quest_id": 20995009,
+    "base_level": 52,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1570
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 250
+        },
+        {
+            "type": "exp",
+            "amount": 1880
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Gold Thread",
+                    "item_id": 7743,
+                    "num": 1
+                },
+                {
+                    "comment": "Transmuted Gold Feather",
+                    "item_id": 7822,
+                    "num": 1
+                },
+                {
+                    "comment": "Enhanced Lockpick",
+                    "item_id": 9403,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 84,
+                "group_id": 5
+            },
+            "starting_index": 6,
+            "enemies": [
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Brutal Silver Roar",
+                    "enemy_id": "0x015505",
+                    "named_enemy_params_id": 54,
+                    "level": 52,
+                    "exp": 3914,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [0]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995010.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Aliment Extractant",
                     "item_id": 8033,
                     "num": 1
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 2
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 2
                 }
@@ -46,48 +49,65 @@
                 "id": 84,
                 "group_id": 11
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Dangerous Skull Lord",
                     "enemy_id": "0x010313",
+                    "named_enemy_params_id": 56,
                     "level": 52,
-		    "named_enemy_params_id": 556,
-                    "exp": 6146,
-                    "is_boss": false
+                    "exp": 1232,
+                    "is_boss": false,
+                    "index": 0
                 },
                 {
-                    "enemy_id": "0x010311",
-		    "named_enemy_params_id": 650,
-                    "level": 52,
-                    "exp": 5936,
-                    "is_boss": false
-                },
-                {
+                    "comment": "Dangerous Skull Lord",
                     "enemy_id": "0x010313",
+                    "named_enemy_params_id": 56,
                     "level": 52,
-		    "named_enemy_params_id": 556,
-                    "exp": 6146,
-                    "is_boss": false
+                    "exp": 1232,
+                    "is_boss": false,
+                    "index": 1
                 },
                 {
+                    "comment": "Brutal Ghost Mail",
                     "enemy_id": "0x010311",
-		    "named_enemy_params_id": 650,
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 1,
                     "level": 52,
-                    "exp": 5936,
-                    "is_boss": false
+                    "exp": 616,
+                    "is_boss": false,
+                    "index": 9
                 },
                 {
+                    "comment": "Brutal Ghost Mail",
                     "enemy_id": "0x010311",
-		    "named_enemy_params_id": 650,
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 1,
                     "level": 52,
-                    "exp": 5936,
-                    "is_boss": false
+                    "exp": 616,
+                    "is_boss": false,
+                    "index": 10
                 },
                 {
+                    "comment": "Brutal Ghost Mail",
                     "enemy_id": "0x010311",
-		    "named_enemy_params_id": 650,
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 1,
                     "level": 52,
-                    "exp": 5936,
-                    "is_boss": false
+                    "exp": 616,
+                    "is_boss": false,
+                    "index": 11
+                },
+                {
+                    "comment": "Brutal Ghost Mail",
+                    "enemy_id": "0x010311",
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 1,
+                    "level": 52,
+                    "exp": 616,
+                    "is_boss": false,
+                    "index": 12
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
@@ -3,7 +3,7 @@
     "type": "World",
     "comment": "The Shadow That Roams the Dead City",
     "quest_id": 20995011,
-    "base_level": 55,
+    "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Magick Gold Ingot",
                     "item_id": 7886,
                     "num": 1
                 },
                 {
+                    "comment": "Transmuted Gold Feather",
                     "item_id": 7822,
                     "num": 2
                 },
                 {
+                    "comment": "Superior Healing Remedy",
                     "item_id": 7555,
                     "num": 3
                 }
@@ -48,34 +51,32 @@
             },
             "enemies": [
                 {
+                    "comment": "Legendary Goliath",
                     "enemy_id": "0x015102",
-                    "level": 55,
-                    "exp": 21000,
+                    "named_enemy_params_id": 57,
+                    "level": 56,
+                    "exp": 7533,
                     "is_boss": true
                 },
                 {
+                    "comment": "Critical Alchemized Harpy",
                     "enemy_id": "0x010606",
-                    "level": 55,
-                    "exp": 2100,
-                    "is_boss": false
+                    "named_enemy_params_id": 56,
+                    "level": 56,
+                    "exp": 265,
+                    "is_boss": false,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
                 },
                 {
+                    "comment": "Critical Alchemized Harpy",
                     "enemy_id": "0x010606",
-                    "level": 55,
-                    "exp": 2100,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010606",
-                    "level": 55,
-                    "exp": 2100,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010606",
-                    "level": 55,
-                    "exp": 2100,
-                    "is_boss": false
+                    "named_enemy_params_id": 56,
+                    "level": 56,
+                    "exp": 265,
+                    "is_boss": false,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
                 }
             ]
         }
@@ -89,11 +90,19 @@
                 "layer_no": 1
             },
             "npc_id": "Theodor",
-            "message_id": 11372
+            "message_id": 16083
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 16084,
+                "comment": "Idle dialogue"
+                }
+            ],
             "groups": [0]
         },
         {
@@ -111,7 +120,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Theodor",
-            "message_id": 11842
+            "message_id": 16085
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_1.json
@@ -1,0 +1,123 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Shadow That Roams the Dead City (Calamity)",
+    "quest_id": 20995011,
+    "base_level": 55,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 5080
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 3850
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 610
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Exquisite Metal Plate",
+                    "item_id": 8030,
+                    "num": 1
+                },
+                {
+                    "comment": "Dirty Sheet Metal",
+                    "item_id": 8029,
+                    "num": 2
+                },
+                {
+                    "comment": "Alchemized Armor Plate",
+                    "item_id": 8031,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 84,
+                "group_id": 9
+            },
+            "enemies": [
+                {
+                    "comment": "Titan Soldier - Prototype (Damned Golem)",
+                    "enemy_id": "0x015103",
+                    "named_enemy_params_id": 526,
+                    "level": 55,
+                    "exp": 4992,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Titan Soldier - Type II (Goliath)",
+                    "enemy_id": "0x015102",
+                    "named_enemy_params_id": 525,
+                    "level": 55,
+                    "exp": 7440,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Titan Soldier - Type II (Goliath)",
+                    "enemy_id": "0x015102",
+                    "named_enemy_params_id": 525,
+                    "level": 55,
+                    "exp": 7440,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Theodor",
+            "message_id": 16083
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 16084,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Theodor",
+            "message_id": 16085
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_2.json
@@ -1,0 +1,124 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Shadow That Roams the Dead City (Calamity II)",
+    "quest_id": 20995011,
+    "base_level": 60,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "variant_ìndex": 2,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 5040
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4320
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 570
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Crest of Restoration+",
+                    "item_id": 11743,
+                    "num": 1
+                },
+                {
+                    "comment": "Alchemite",
+                    "item_id": 7871,
+                    "num": 1
+                },
+                {
+                    "comment": "Flame Crystal",
+                    "item_id": 7913,
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 84,
+                "group_id": 9
+            },
+            "enemies": [
+                {
+                    "comment": "Fire Armed Magickal Construct - Combat Type (Geo Golem)",
+                    "enemy_id": "0x015104",
+                    "named_enemy_params_id": 629,
+                    "level": 60,
+                    "exp": 5440,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Titan Soldier - Type III (Goliath)",
+                    "enemy_id": "0x015102",
+                    "named_enemy_params_id": 628,
+                    "level": 60,
+                    "exp": 7905,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Brutal Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "named_enemy_params_id": 54,
+                    "level": 60,
+                    "exp": 550,
+                    "repop_count": 3,
+                    "repop_wait_second": 10
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Theodor",
+            "message_id": 16083
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 16084,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Theodor",
+            "message_id": 16085
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000001.json
@@ -1,0 +1,165 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Dancing Phantoms Down Below",
+  "quest_id": 21000001,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2965
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1880
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 235
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Unappraised Moon Trinket (Soldier)",
+          "item_id": 11759,
+          "num": 1
+        },
+        {
+          "comment": "Iron Ore Fragment",
+          "item_id": 7853,
+          "num": 5
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 406,
+        "group_id": 1
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Wight",
+          "enemy_id": "0x015600",
+          "level": 55,
+          "exp": 2836,
+          "is_boss": true
+        },
+        {
+          "comment": "Wight",
+          "enemy_id": "0x015600",
+          "level": 55,
+          "exp": 2836,
+          "is_boss": true
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "level": 55,
+          "exp": 318
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "level": 55,
+          "exp": 318
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 57,
+          "exp": 329,
+          "repop_count": 1
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 57,
+          "exp": 329,
+          "repop_count": 1
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 57,
+          "exp": 329
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 25
+      },
+      "npc_id": "Alfred",
+      "message_id": 17035
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 25
+      },
+      "npc_id": "Alfred",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1313,
+          "Param2": 17036
+        }
+      ],
+      "items": [
+        {
+          "comment": "Drómi",
+          "id": 7958,
+          "amount": 2
+        }
+      ],
+      "message_id": 17037
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1313,
+          "Param2": 17038
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 25
+      },
+      "announce_type": "Update",
+      "npc_id": "Alfred",
+      "message_id": 17039
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000002.json
@@ -1,0 +1,168 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Hometown Concerns",
+  "quest_id": 21000002,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2965
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1880
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 235
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mithril Ingot",
+          "item_id": 7880,
+          "num": 2
+        },
+        {
+          "comment": "Moonglow",
+          "item_id": 7981,
+          "num": 5
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 133,
+        "group_id": 2
+      },
+      "placement_type": "manual",
+      "comment": "Using regular rogues as placeholders",
+      "enemies": [
+        {
+          "comment": "Scarlet Defender",
+          "enemy_id": "0x011004",
+          "hm_preset_no": 91,
+          "level": 57,
+          "exp": 329,
+          "index": 0
+        },
+        {
+          "comment": "Scarlet Hunter",
+          "enemy_id": "0x011002",
+          "hm_preset_no": 89,
+          "level": 57,
+          "exp": 329,
+          "index": 1
+        },
+        {
+          "comment": "Scarlet Hunter",
+          "enemy_id": "0x011002",
+          "hm_preset_no": 89,
+          "level": 57,
+          "exp": 329,
+          "index": 2
+        },
+        {
+          "comment": "Scarlet Hunter",
+          "enemy_id": "0x011002",
+          "hm_preset_no": 89,
+          "level": 57,
+          "exp": 329,
+          "index": 5
+        },
+        {
+          "comment": "Scarlet Warrior",
+          "enemy_id": "0x011006",
+          "hm_preset_no": 93,
+          "level": 57,
+          "exp": 329,
+          "index": 7
+        },
+        {
+          "comment": "Scarlet Warrior",
+          "enemy_id": "0x011006",
+          "hm_preset_no": 93,
+          "level": 57,
+          "exp": 329,
+          "index": 9
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 17
+      },
+      "npc_id": "Gloria",
+      "message_id": 17040
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 17
+      },
+      "npc_id": "Gloria",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1208,
+          "Param2": 17041
+        }
+      ],
+      "items": [
+        {
+          "comment": "Drómi",
+          "id": 7958,
+          "amount": 2
+        }
+      ],
+      "message_id": 17042
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1208,
+          "Param2": 17043
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 17
+      },
+      "announce_type": "Update",
+      "npc_id": "Gloria",
+      "message_id": 17044
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
@@ -1,0 +1,151 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Monstrous Rampage",
+  "quest_id": 21000003,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6976
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 265
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Corroded Giant Eyeball",
+          "item_id": 11774,
+          "num": 1
+        },
+        {
+          "comment": "Quality Gala Mushroom",
+          "item_id": 7994,
+          "num": 7
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 333,
+        "group_id": 4
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops (Slight)",
+          "enemy_id": "0x015012",
+          "level": 60,
+          "exp": 3783,
+          "is_boss": true,
+          "infection_type": 1,
+          "index": 5
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 60,
+          "exp": 756,
+          "index": 7
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 60,
+          "exp": 756,
+          "index": 8
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 60,
+          "exp": 756,
+          "index": 9
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 333,
+        "group_id": 9
+      },
+      "enemies": [
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "start_think_tbl_no": 2,
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "start_think_tbl_no": 2,
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "start_think_tbl_no": 2,
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "start_think_tbl_no": 2,
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "start_think_tbl_no": 2,
+          "level": 60,
+          "exp": 756
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [0]
+    },
+    {
+      "type": "Raw",
+      "announce_type": "Accept",
+      "check_commands": [ { "type": "EmHpLess", "Param1": 824, "Param2": 4, "Param3": 5, "Param4": 35 } ] 
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "reset_group": false,
+      "groups": [0]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000004.json
@@ -1,0 +1,86 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Witch's Rumor",
+  "quest_id": 21000004,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeForest",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3940
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5360
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 687
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gleipnir",
+          "item_id": 7959,
+          "num": 2
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Sanya",
+      "message_id": 17054
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Emerada0",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Sanya",
+          "type": "QstTalkChg",
+          "Param1": 1409,
+          "Param2": 17055
+        },
+        {
+          "comment": "Idle dialogue - Emerada",
+          "type": "QstTalkChg",
+          "Param1": 4501,
+          "Param2": 17056
+        }
+      ],
+      "items": [
+        {
+          "comment": "Unappraised Star Trinket (General)",
+          "id": 13480,
+          "amount": 6
+        }
+      ],
+      "message_id": 17057
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000012.json
@@ -1,0 +1,150 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Light in the Village",
+  "quest_id": 21000012,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2965
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1880
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 235
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gleipnir",
+          "item_id": 7959,
+          "num": 1
+        },
+        {
+          "comment": "Crystal",
+          "item_id": 7901,
+          "num": 5
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 87,
+        "group_id": 4
+      },
+      "starting_index": 10,
+      "enemies": [
+        {
+          "comment": "Shadow Chimera",
+          "enemy_id": "0x015203",
+          "level": 57,
+          "exp": 5572,
+          "is_boss": true
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 57,
+          "exp": 277
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 57,
+          "exp": 277
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 57,
+          "exp": 246
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 57,
+          "exp": 246
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 57,
+          "exp": 246
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 57,
+          "exp": 246
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 57,
+          "exp": 246
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 57,
+          "exp": 246
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Myra",
+      "message_id": 17030
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1306,
+          "Param2": 17031
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Myra",
+      "message_id": 17032
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
@@ -1,0 +1,127 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Forgotten Evil Image",
+  "quest_id": 21000013,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "HidellPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 2965
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1880
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 235
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+		  "comment": "Sacred Blessed Cloth",
+          "item_id": 7943,
+          "num": 1
+        },
+        {
+		  "comment": "Cedar Wood",
+          "item_id": 7967,
+          "num": 2
+        },
+        {
+		  "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups" : [
+    {
+      "stage_id": {
+        "id": 87,
+        "group_id": 1
+      },
+	  "starting_index": 9,
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops (Severe)",
+          "enemy_id": "0x015012",
+          "level": 57,
+          "exp": 3292,
+          "is_boss": true,
+          "infection_type": 2
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 87,
+        "group_id": 7
+      },
+      "enemies": [
+	    {
+		  "comment": "Goblin Bomber",
+		  "enemy_id": "0x011150",
+		  "level": 57,
+		  "exp": 656
+		},
+		{
+		  "comment": "Goblin Bomber",
+		  "enemy_id": "0x011150",
+		  "level": 57,
+		  "exp": 656
+	    },
+		{
+		  "comment": "Goblin Bomber",
+		  "enemy_id": "0x011150",
+		  "level": 57,
+		  "exp": 656
+		},
+		{
+		  "comment": "Goblin Bomber",
+		  "enemy_id": "0x011150",
+		  "level": 57,
+		  "exp": 656
+		},
+		{
+		  "comment": "Goblin Bomber",
+		  "enemy_id": "0x011150",
+		  "level": 57,
+		  "exp": 656
+		}
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [0]
+    },
+    {
+      "type": "WeakenGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [0],
+	  "percent": 35
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000014.json
@@ -1,0 +1,86 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Lighthouse Keeper's Favor",
+  "quest_id": 21000014,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BreyaCoast",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3783
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4950
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 625
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Cursed Cloth",
+          "item_id": 7948,
+          "num": 2
+        },
+        {
+          "comment": "Large Scallop Shell",
+          "item_id": 8018,
+          "num": 5
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 47
+      },
+      "npc_id": "Rudolfo",
+      "message_id": 17045
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Rosa",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Rudolfo",
+          "type": "QstTalkChg",
+          "Param1": 4500,
+          "Param2": 17046
+        },
+        {
+          "comment": "Idle dialogue - Rosa",
+          "type": "QstTalkChg",
+          "Param1": 1201,
+          "Param2": 17047
+        }
+      ],
+      "items": [
+        {
+          "comment": "Rock Finger",
+          "id": 11506,
+          "amount": 6
+        }
+      ],
+      "message_id": 17048
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000016.json
@@ -1,0 +1,151 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Longing to Be an Adult",
+  "quest_id": 21000016,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeForest",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 7092
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Phantom Metal",
+          "item_id": 7890,
+          "num": 1
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 67,
+        "group_id": 3
+      },
+      "starting_index": 10,
+      "enemies": [
+        {
+          "comment": "Ent",
+          "enemy_id": "0x015031",
+          "level": 65,
+          "exp": 3940,
+          "is_boss": true
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Ent",
+          "enemy_id": "0x015031",
+          "level": 65,
+          "exp": 3940,
+          "is_boss": true
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 65,
+          "exp": 788
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Cain",
+      "message_id": 17066
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Cain",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1410,
+          "Param2": 17067
+        }
+      ],
+      "items": [
+        {
+          "comment": "Gold Thread",
+          "id": 7743,
+          "amount": 2
+        }
+      ],
+      "message_id": 17068
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1410,
+          "Param2": 17069
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Cain",
+      "message_id": 17070
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000018.json
@@ -1,0 +1,162 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Heavily Occupied",
+  "quest_id": 21000018,
+  "base_level": 58,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3017
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1913
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 240
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gleipnir",
+          "item_id": 7959,
+          "num": 1
+        },
+        {
+          "comment": "Iron Ore Fragment",
+          "item_id": 7853,
+          "num": 5
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 120,
+        "group_id": 0
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Colossus",
+          "enemy_id": "0x015020",
+          "level": 58,
+          "exp": 1676,
+          "is_boss": true
+        },
+        {
+          "comment": "Redcap Fighter",
+          "enemy_id": "0x011111",
+          "level": 58,
+          "exp": 335
+        },
+        {
+          "comment": "Redcap Fighter",
+          "enemy_id": "0x011111",
+          "level": 58,
+          "exp": 335
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "level": 58,
+          "exp": 335
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "level": 58,
+          "exp": 335
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "level": 58,
+          "exp": 335
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "level": 58,
+          "exp": 335
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 66
+      },
+      "npc_id": "Cyrus",
+      "message_id": 17073
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 66
+      },
+      "npc_id": "Cyrus",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1900,
+          "Param2": 17074
+        }
+      ],
+      "items": [
+        {
+          "comment": "Blow-Resistant Cloth",
+          "id": 7942,
+          "amount": 2
+        }
+      ],
+      "message_id": 17075
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1900,
+          "Param2": 17076
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 66
+      },
+      "announce_type": "Update",
+      "npc_id": "Cyrus",
+      "message_id": 17077
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000020.json
@@ -1,0 +1,124 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Lakeside Danger",
+  "quest_id": 21000020,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeGrove",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6976
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 265
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Ash Quartz",
+          "item_id": 11768,
+          "num": 3
+        },
+        {
+          "comment": "Crystal",
+          "item_id": 7901,
+          "num": 5
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 1
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Troll",
+          "enemy_id": "0x015040",
+          "level": 62,
+          "exp": 3844,
+          "is_boss": true,
+          "index": 10
+        },
+        {
+          "comment": "Ghost Mail",
+          "enemy_id": "0x010311",
+          "level": 60,
+          "exp": 756,
+          "index": 11
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 60,
+          "exp": 756,
+          "index": 14
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 60,
+          "exp": 756,
+          "index": 15
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 22
+      },
+      "npc_id": "Ivan",
+      "message_id": 17091
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4503,
+          "Param2": 17092
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 22
+      },
+      "announce_type": "Update",
+      "npc_id": "Ivan",
+      "message_id": 17093
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000021.json
@@ -1,0 +1,86 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Lonesome Hunter",
+  "quest_id": 21000021,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeGrove",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3876
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5195
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 662
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Black Iron Ingot",
+          "item_id": 7878,
+          "num": 2
+        },
+        {
+          "comment": "Cedar Wood",
+          "item_id": 7967,
+          "num": 2
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 137
+      },
+      "npc_id": "Christine",
+      "message_id": 17095
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 22
+      },
+      "npc_id": "Ivan",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Christine",
+          "type": "QstTalkChg",
+          "Param1": 4506,
+          "Param2": 17096
+        },
+        {
+          "comment": "Idle dialogue - Ivan",
+          "type": "QstTalkChg",
+          "Param1": 4503,
+          "Param2": 17097
+        }
+      ],
+      "items": [
+        {
+          "comment": "Tomb Gravel",
+          "id": 11772,
+          "amount": 6
+        }
+      ],
+      "message_id": 17098
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000025.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000025.json
@@ -6,7 +6,7 @@
     "base_level": 63,
     "minimum_item_rank": 0,
     "discoverable": false,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle", 
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Ice Cube Fragment",
                     "item_id": 11504,
                     "num": 3
                 },
                 {
+                    "comment": "Aliment Extractant",
                     "item_id": 8033,
                     "num": 1
                 },
                 {
+                    "comment": "Superior Healing Remedy",
                     "item_id": 7555,
                     "num": 3
                 }
@@ -45,43 +48,125 @@
             "stage_id": {
                 "id": 330,
                 "group_id": 6
-            },			
+            },          
             "enemies": [
                 {
+                    "comment": "Treasure-Bearing Silver Roar",
                     "enemy_id": "0x015505",
+                    "named_enemy_params_id": 1119,
                     "level": 60,
-                    "exp": 40000,
+                    "exp": 4370,
+                    "drop_items": [
+                        {
+                            "item_id": 7782,
+                            "item_min": 1,
+                            "item_max": 2,
+                            "quality": 0,
+                            "drop_chance": 0.6
+                        },
+                        {
+                            "item_id": 7759,
+                            "item_min": 1,
+                            "item_max": 3,
+                            "quality": 0,
+                            "drop_chance": 0.9
+                        },
+                        {
+                            "item_id": 7744,
+                            "item_min": 1,
+                            "item_max": 1,
+                            "quality": 0,
+                            "drop_chance": 0.4
+                        },
+                        {
+                            "item_id": 18828,
+                            "item_min": 1,
+                            "item_max": 1,
+                            "quality": 0,
+                            "drop_chance": 1.0
+                        }
+                    ],
                     "is_boss": true
-        },
-        {
+                },
+                {
+                    "comment": "Treasure-Bearing Silver Roar",
                     "enemy_id": "0x015505",
+                    "named_enemy_params_id": 1119,
                     "level": 60,
-                    "exp": 40000,
+                    "exp": 4370,
+                    "drop_items": [
+                        {
+                            "item_id": 7782,
+                            "item_min": 1,
+                            "item_max": 2,
+                            "quality": 0,
+                            "drop_chance": 0.6
+                        },
+                        {
+                            "item_id": 7759,
+                            "item_min": 1,
+                            "item_max": 3,
+                            "quality": 0,
+                            "drop_chance": 0.9
+                        },
+                        {
+                            "item_id": 7744,
+                            "item_min": 1,
+                            "item_max": 1,
+                            "quality": 0,
+                            "drop_chance": 0.4
+                        },
+                        {
+                            "item_id": 18828,
+                            "item_min": 1,
+                            "item_max": 1,
+                            "quality": 0,
+                            "drop_chance": 1.0
+                        }
+                    ],
                     "is_boss": true
-        },
-        {
+                },
+                {
+                    "comment": "Frost Skeleton",
                     "enemy_id": "0x010315",
                     "level": 60,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 756
+                },
+                {
+                    "comment": "Frost Skeleton",
                     "enemy_id": "0x010315",
                     "level": 60,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 756
+                },
+                {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Aqua Jelly",
                     "enemy_id": "0x010904",
                     "level": 60,
-                    "exp": 1000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 756              
+                },
+                {
+                    "comment": "Aqua Jelly",
                     "enemy_id": "0x010904",
                     "level": 60,
-                    "exp": 1000,
-                    "is_boss": false					
+                    "exp": 756              
+                },
+                {
+                    "comment": "Aqua Jelly",
+                    "enemy_id": "0x010904",
+                    "level": 60,
+                    "exp": 756              
+                },
+                {
+                    "comment": "Aqua Jelly",
+                    "enemy_id": "0x010904",
+                    "level": 60,
+                    "exp": 756              
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000026.json
@@ -1,0 +1,280 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Jewels: Emerged Colossus",
+  "quest_id": 21000026,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "HidellPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 9079
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1980
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 250
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Hidell Medal",
+          "item_id": 10999,
+          "num": 1
+        },
+        {
+          "comment": "Aliment Extractant",
+          "item_id": 8033,
+          "num": 1
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 406,
+        "group_id": 11
+      },
+      "comments": "Named enemies drop Unappraised Moon Trinket (Soldier)",
+      "enemies": [
+        {
+          "comment": "Jewel-Bearing Goliath",
+          "enemy_id": "0x015102",
+          "named_enemy_params_id": 1121,
+          "level": 57,
+          "exp": 7626,
+          "drop_items": [
+            {
+              "item_id": 8031,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            },
+            {
+              "item_id": 8031,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8030,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 11759,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 1,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Jewel-Bearing Goliath",
+          "enemy_id": "0x015102",
+          "named_enemy_params_id": 1121,
+          "level": 60,
+          "exp": 7905,
+          "drop_items": [
+            {
+              "item_id": 8031,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            },
+            {
+              "item_id": 8031,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8030,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 11759,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Jewel-Bearing Alchemy Eye",
+          "enemy_id": "0x015420",
+          "named_enemy_params_id": 1121,
+          "level": 60,
+          "exp": 421,
+          "drop_items": [
+            {
+              "item_id": 7871,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7863,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7731,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 11759,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewel-Bearing Alchemy Eye",
+          "enemy_id": "0x015420",
+          "named_enemy_params_id": 1121,
+          "level": 60,
+          "exp": 421,
+          "drop_items": [
+            {
+              "item_id": 7871,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7863,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7731,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 11759,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewel-Bearing Alchemy Eye",
+          "enemy_id": "0x015420",
+          "named_enemy_params_id": 1121,
+          "level": 60,
+          "exp": 421,
+          "drop_items": [
+            {
+              "item_id": 7871,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7863,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7731,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 11759,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 60,
+          "exp": 756
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "[Door of Dragonforce] Call of Vengeful Spirits",
+  "comment": "Door of Dragonforce: Call of Vengeful Spirits",
   "quest_id": 21000027,
   "base_level": 60,
   "minimum_item_rank": 0,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
@@ -1,0 +1,135 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Door of Dragonforce] Call of Vengeful Spirits",
+  "quest_id": 21000027,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BreyaCoast",
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1980
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 250
+    },
+    {
+      "type": "exp",
+      "amount": 9079
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Breya Medal",
+          "item_id": 11000,
+          "num": 1
+        },
+        {
+          "comment": "Aliment Extractant",
+          "item_id": 8033,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 333,
+        "group_id": 8
+      },
+      "comment": "Needs correct XP values",
+      "enemies": [
+        {
+          "comment": "Dragonforce-Bearing Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "named_enemy_params_id": 1120,
+          "level": 60,
+          "exp": 756,
+          "blood_orbs": 149
+        },
+        {
+          "comment": "Dragonforce-Bearing Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "named_enemy_params_id": 1120,
+          "level": 60,
+          "exp": 756,
+          "blood_orbs": 149
+        },
+        {
+          "comment": "Dragonforce-Bearing Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "named_enemy_params_id": 1120,
+          "level": 60,
+          "exp": 756,
+          "blood_orbs": 149
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Dragonforce-Bearing Ghost Mail",
+          "enemy_id": "0x010311",
+          "named_enemy_params_id": 1120,
+          "level": 60,
+          "exp": 1125,
+          "blood_orbs": 149,
+          "is_boss": true
+        },
+        {
+          "comment": "Dragonforce-Bearing Ghost Mail",
+          "enemy_id": "0x010311",
+          "named_enemy_params_id": 1120,
+          "level": 60,
+          "exp": 1125,
+          "blood_orbs": 149,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000028.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000028.json
@@ -1,0 +1,280 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Jewelry: The Source of the Nightmare",
+  "quest_id": 21000028,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MysreeForest",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 18420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mysree Medal",
+          "item_id": 11001,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 430,
+        "group_id": 17
+      },
+      "comment": "Up to nine Unappraised Star Trinket (Soldier) drops",
+      "enemies": [
+        {
+          "comment": "Jewelry-Bearing Nightmare",
+          "enemy_id": "0x015305",
+          "named_enemy_params_id": 1121,
+          "level": 70,
+          "exp": 10108,
+          "drop_items": [
+            {
+              "item_id": 7819,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7746,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 1,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Jewelry-Bearing Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 1121,
+          "level": 70,
+          "exp": 1535,
+          "drop_items": [
+            {
+              "item_id": 7911,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7753,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 9441,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Jewelry-Bearing Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 1121,
+          "level": 70,
+          "exp": 1535,
+          "drop_items": [
+            {
+              "item_id": 7911,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7753,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 9441,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Jewelry-Bearing Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 1121,
+          "level": 70,
+          "exp": 1535,
+          "drop_items": [
+            {
+              "item_id": 7911,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7753,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 9441,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Jewelry-Bearing Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 1121,
+          "level": 70,
+          "exp": 1535,
+          "drop_items": [
+            {
+              "item_id": 7911,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7753,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 9441,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "repop_count": 1,
+          "repop_wait_second": 10
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000030.json
@@ -1,0 +1,151 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Prized Knowledge",
+  "quest_id": 21000030,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6976
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 265
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Tomb Gravel",
+          "item_id": 11772,
+          "num": 3
+        },
+        {
+          "comment": "Cedar Wood",
+          "item_id": 7967,
+          "num": 2
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 431,
+        "group_id": 4
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Ghoul",
+          "enemy_id": "0x015503",
+          "level": 60,
+          "exp": 3783,
+          "is_boss": true
+        },
+        {
+          "comment": "Ghoul",
+          "enemy_id": "0x015503",
+          "level": 60,
+          "exp": 3783,
+          "is_boss": true
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 60,
+          "exp": 756
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 66
+      },
+      "npc_id": "Cyrus",
+      "message_id": 17081
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 66
+      },
+      "npc_id": "Cyrus",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1900,
+          "Param2": 17082
+        }
+      ],
+      "items": [
+        {
+          "comment": "Blessed Drop",
+          "id": 7831,
+          "amount": 2
+        }
+      ],
+      "message_id": 17083
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1900,
+          "Param2": 17084
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 66
+      },
+      "announce_type": "Update",
+      "npc_id": "Cyrus",
+      "message_id": 17085
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000034.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000034.json
@@ -1,0 +1,86 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Deal with the Goblins",
+  "quest_id": 21000034,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3786
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5195
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 662
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Cursed Cloth",
+          "item_id": 7948,
+          "num": 2
+        },
+        {
+          "comment": "Large Scallop Shell",
+          "item_id": 8018,
+          "num": 5
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Chunk",
+      "message_id": 17108
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 95
+      },
+      "npc_id": "Ugau",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Chunk",
+          "type": "QstTalkChg",
+          "Param1": 1602,
+          "Param2": 17109
+        },
+        {
+          "comment": "Idle dialogue - Ugau",
+          "type": "QstTalkChg",
+          "Param1": 2001,
+          "Param2": 17110
+        }
+      ],
+      "items": [
+        {
+          "comment": "Ash Quartz",
+          "id": 11768,
+          "amount": 6
+        }
+      ],
+      "message_id": 17111
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000039.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000039.json
@@ -1,33 +1,33 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Door of Jewelry: Emerged Colossus",
-  "quest_id": 21000026,
-  "base_level": 60,
+  "comment": "Door of Jewelry: Truth Behind The Legend",
+  "quest_id": 21000039,
+  "base_level": 63,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "area_id": "HidellPlains",
+  "area_id": "BetlandPlains",
   "rewards": [
     {
       "type": "exp",
-      "amount": 9079
+      "amount": 9302
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1980
+      "amount": 2078
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 250
+      "amount": 265
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Hidell Medal",
-          "item_id": 10999,
+          "comment": "Betland Medal",
+          "item_id": 11005,
           "num": 1
         },
         {
@@ -46,38 +46,24 @@
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 406,
-        "group_id": 11
+        "id": 431,
+        "group_id": 8
       },
-      "comments": "Up to five Unappraised Moon Trinket (Soldier) drops",
+      "comment": "Up to five Unappraised Moon Trinket (Soldier) drops",
       "enemies": [
         {
-          "comment": "Jewelry-Bearing Goliath",
-          "enemy_id": "0x015102",
+          "comment": "Jewelry-Bearing Frost Machina",
+          "enemy_id": "0x015851",
           "named_enemy_params_id": 1121,
-          "level": 60,
-          "exp": 7905,
+          "level": 63,
+          "exp": 8800,
           "drop_items": [
             {
-              "item_id": 8031,
-              "item_min": 1,
-              "item_max": 1,
-              "quality": 0,
-              "drop_chance": 0.1
-            },
-            {
-              "item_id": 8031,
+              "item_id": 11778,
               "item_min": 1,
               "item_max": 2,
               "quality": 0,
               "drop_chance": 0.9
-            },
-            {
-              "item_id": 8030,
-              "item_min": 1,
-              "item_max": 1,
-              "quality": 0,
-              "drop_chance": 0.8
             },
             {
               "item_id": 11759,
@@ -90,70 +76,80 @@
           "is_boss": true
         },
         {
-          "comment": "Jewelry-Bearing Goliath",
-          "enemy_id": "0x015102",
+          "comment": "Jewelry-Bearing Frost Machina",
+          "enemy_id": "0x015851",
           "named_enemy_params_id": 1121,
-          "level": 57,
-          "exp": 7626,
+          "level": 60,
+          "exp": 8500,
           "drop_items": [
             {
-              "item_id": 8031,
-              "item_min": 1,
-              "item_max": 1,
-              "quality": 0,
-              "drop_chance": 0.1
-            },
-            {
-              "item_id": 8031,
+              "item_id": 11778,
               "item_min": 1,
               "item_max": 2,
               "quality": 0,
               "drop_chance": 0.9
             },
             {
-              "item_id": 8030,
-              "item_min": 1,
-              "item_max": 1,
-              "quality": 0,
-              "drop_chance": 0.8
-            },
-            {
               "item_id": 11759,
               "item_min": 1,
               "item_max": 1,
-              "quality": 1,
+              "quality": 0,
               "drop_chance": 1.0
             }
           ],
           "is_boss": true
         },
         {
-          "comment": "Jewelry-Bearing Alchemy Eye",
-          "enemy_id": "0x015420",
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Jewelry-Bearing Shadow Harpy",
+          "enemy_id": "0x010607",
           "named_enemy_params_id": 1121,
-          "level": 60,
-          "exp": 421,
+          "level": 63,
+          "exp": 264,
           "drop_items": [
             {
-              "item_id": 7871,
+              "item_id": 7911,
               "item_min": 1,
               "item_max": 2,
               "quality": 0,
               "drop_chance": 0.8
             },
             {
-              "item_id": 7863,
+              "item_id": 7783,
               "item_min": 1,
-              "item_max": 1,
+              "item_max": 4,
               "quality": 0,
-              "drop_chance": 0.7
+              "drop_chance": 0.9
             },
             {
-              "item_id": 7731,
+              "item_id": 9441,
               "item_min": 1,
-              "item_max": 1,
+              "item_max": 2,
               "quality": 0,
-              "drop_chance": 0.3
+              "drop_chance": 0.4
             },
             {
               "item_id": 11759,
@@ -165,32 +161,32 @@
           ]
         },
         {
-          "comment": "Jewelry-Bearing Alchemy Eye",
-          "enemy_id": "0x015420",
+          "comment": "Jewelry-Bearing Shadow Harpy",
+          "enemy_id": "0x010607",
           "named_enemy_params_id": 1121,
-          "level": 60,
-          "exp": 421,
+          "level": 63,
+          "exp": 264,
           "drop_items": [
             {
-              "item_id": 7871,
+              "item_id": 7911,
               "item_min": 1,
               "item_max": 2,
               "quality": 0,
               "drop_chance": 0.8
             },
             {
-              "item_id": 7863,
+              "item_id": 7783,
               "item_min": 1,
-              "item_max": 1,
+              "item_max": 4,
               "quality": 0,
-              "drop_chance": 0.7
+              "drop_chance": 0.9
             },
             {
-              "item_id": 7731,
+              "item_id": 9441,
               "item_min": 1,
-              "item_max": 1,
+              "item_max": 2,
               "quality": 0,
-              "drop_chance": 0.3
+              "drop_chance": 0.4
             },
             {
               "item_id": 11759,
@@ -202,32 +198,32 @@
           ]
         },
         {
-          "comment": "Jewelry-Bearing Alchemy Eye",
-          "enemy_id": "0x015420",
+          "comment": "Jewelry-Bearing Shadow Harpy",
+          "enemy_id": "0x010607",
           "named_enemy_params_id": 1121,
-          "level": 60,
-          "exp": 421,
+          "level": 63,
+          "exp": 264,
           "drop_items": [
             {
-              "item_id": 7871,
+              "item_id": 7911,
               "item_min": 1,
               "item_max": 2,
               "quality": 0,
               "drop_chance": 0.8
             },
             {
-              "item_id": 7863,
+              "item_id": 7783,
               "item_min": 1,
-              "item_max": 1,
+              "item_max": 4,
               "quality": 0,
-              "drop_chance": 0.7
+              "drop_chance": 0.9
             },
             {
-              "item_id": 7731,
+              "item_id": 9441,
               "item_min": 1,
-              "item_max": 1,
+              "item_max": 2,
               "quality": 0,
-              "drop_chance": 0.3
+              "drop_chance": 0.4
             },
             {
               "item_id": 11759,
@@ -237,30 +233,6 @@
               "drop_chance": 0.1
             }
           ]
-        },
-        {
-          "comment": "Alchemized Harpy",
-          "enemy_id": "0x010606",
-          "level": 60,
-          "exp": 756
-        },
-        {
-          "comment": "Alchemized Harpy",
-          "enemy_id": "0x010606",
-          "level": 60,
-          "exp": 756
-        },
-        {
-          "comment": "Alchemized Harpy",
-          "enemy_id": "0x010606",
-          "level": 60,
-          "exp": 756
-        },
-        {
-          "comment": "Alchemized Harpy",
-          "enemy_id": "0x010606",
-          "level": 60,
-          "exp": 756
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "[Door of Gemstones] Away, Foul Things!",
+  "comment": "Door of Gemstones: Away, Foul Things!",
   "quest_id": 21000041,
   "base_level": 63,
   "minimum_item_rank": 0,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
@@ -1,0 +1,226 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Door of Gemstones] Away, Foul Things!",
+  "quest_id": 21000041,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MysreeGrove",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3876
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1590
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mysree Grove Medal",
+          "item_id": 11004,
+          "num": 1
+        },
+        {
+          "comment": "Aliment Extractant",
+          "item_id": 8033,
+          "num": 1
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 16
+      },
+      "comment": "Enemies drop up to 6500 RC",
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Gemstone-Bearing Mist Drake",
+          "enemy_id": "0x015710",
+          "named_enemy_params_id": 1118,
+          "level": 63,
+          "exp": 10208,
+          "drop_items": [
+            {
+              "item_id": 7802,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7922,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Gemstone-Bearing Ghost Mail",
+          "enemy_id": "0x010311",
+          "named_enemy_params_id": 1118,
+          "level": 63,
+          "exp": 704,
+          "drop_items": [
+            {
+              "item_id": 7868,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7889,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "index": 1
+        },
+        {
+          "comment": "Gemstone-Bearing Ghost Mail",
+          "enemy_id": "0x010311",
+          "named_enemy_params_id": 1118,
+          "level": 63,
+          "exp": 704,
+          "drop_items": [
+            {
+              "item_id": 7868,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7889,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "index": 2
+        },
+        {
+          "comment": "Gemstone-Bearing Ghost Mail",
+          "enemy_id": "0x010311",
+          "named_enemy_params_id": 1118,
+          "level": 63,
+          "exp": 704,
+          "drop_items": [
+            {
+              "item_id": 7868,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7889,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 7794,
+              "item_min": 10,
+              "item_max": 10,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "index": 5
+        },
+        {
+          "comment": "Gemstone-Bearing Ghost Mail",
+          "enemy_id": "0x010311",
+          "named_enemy_params_id": 1118,
+          "level": 63,
+          "exp": 704,
+          "drop_items": [
+            {
+              "item_id": 7868,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7889,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 7794,
+              "item_min": 10,
+              "item_max": 10,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "index": 6
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000044.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000044.json
@@ -1,0 +1,184 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Merchant's Pride",
+  "quest_id": 21000044,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6976
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 265
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Volden Quality Coal",
+          "item_id": 11770,
+          "num": 1
+        },
+        {
+          "comment": "Iron Ore Fragment",
+          "item_id": 7853,
+          "num": 5
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 410,
+        "group_id": 4
+      },
+      "placement_type": "manual",
+      "comment": "Likely needs correct XP values",
+      "enemies": [
+        {
+          "comment": "Ogre",
+          "enemy_id": "0x015500",
+          "level": 63,
+          "exp": 3844,
+          "is_boss": true,
+          "index": 3
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 63,
+          "exp": 756,
+          "index": 6
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 63,
+          "exp": 756,
+          "index": 7
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 8
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 9
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 10
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 11
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 12
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 13
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Dorothea",
+      "message_id": 17119
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Dorothea",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1600,
+          "Param2": 17120
+        }
+      ],
+      "items": [
+        {
+          "comment": "Scroll of Magickal Defense",
+          "id": 8010,
+          "amount": 2
+        }
+      ],
+      "message_id": 17121
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1600,
+          "Param2": 17122
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Dorothea",
+      "message_id": 17123
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000045.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000045.json
@@ -1,0 +1,303 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Treasures: Dark and Depressing Thoughts",
+  "quest_id": 21000045,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "VoldenMines",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3876
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 12468
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 265
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Volden Medal",
+          "item_id": 11002,
+          "num": 1
+        },
+        {
+          "comment": "Aliment Extractant",
+          "item_id": 8033,
+          "num": 1
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 410,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "comment": "Up to 50000G",
+      "enemies": [
+        {
+          "comment": "Treasure-Bearing Geo Golem",
+          "enemy_id": "0x015203",
+          "named_enemy_params_id": 1119,
+          "level": 63,
+          "exp": 5632,
+          "scale": 150,
+          "drop_items": [
+            {
+              "item_id": 7867,
+              "item_min": 1,
+              "item_max": 8,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7870,
+              "item_min": 1,
+              "item_max": 8,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7869,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 7913,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Treasure-Bearing Geo Golem",
+          "enemy_id": "0x015203",
+          "named_enemy_params_id": 1119,
+          "level": 60,
+          "exp": 3783,
+          "drop_items": [
+            {
+              "item_id": 7867,
+              "item_min": 1,
+              "item_max": 8,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7870,
+              "item_min": 1,
+              "item_max": 8,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7869,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 7913,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Witch",
+          "enemy_id": "0x015604",
+          "start_think_tbl_no": 2,
+          "level": 63,
+          "exp": 775,
+          "index": 2
+        },
+        {
+          "comment": "Treasure-Bearing Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 1119,
+          "start_think_tbl_no": 8,
+          "level": 63,
+          "exp": 1408,
+          "drop_items": [
+            {
+              "item_id": 7850,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7772,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_manual_set": true,
+          "index": 3
+        },
+        {
+          "comment": "Treasure-Bearing Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 1119,
+          "start_think_tbl_no": 8,
+          "level": 63,
+          "exp": 1408,
+          "drop_items": [
+            {
+              "item_id": 7850,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7772,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_manual_set": true,
+          "index": 5
+        },
+        {
+          "comment": "Treasure-Bearing Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 1119,
+          "start_think_tbl_no": 8,
+          "level": 63,
+          "exp": 1408,
+          "drop_items": [
+            {
+              "item_id": 7850,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7772,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_manual_set": true,
+          "index": 6
+        },
+        {
+          "comment": "Treasure-Bearing Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 1119,
+          "start_think_tbl_no": 8,
+          "level": 63,
+          "exp": 1408,
+          "drop_items": [
+            {
+              "item_id": 7850,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7772,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_manual_set": true,
+          "index": 7
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000049.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000049.json
@@ -6,7 +6,7 @@
     "base_level": 63,
     "minimum_item_rank": 0,
     "discoverable": false,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle", 
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 8033,
-                    "num": 1
-                },
-                {
+                    "comment": "Stalactite Tip",
                     "item_id": 11775,
                     "num": 3
                 },
                 {
+                    "comment": "Aliment Extractant",
+                    "item_id": 8033,
+                    "num": 1
+                },
+                {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 3
                 }
@@ -45,38 +48,92 @@
             "stage_id": {
                 "id": 321,
                 "group_id": 12
-            },			
+            },
+            "comment": "Named enemies drop a total of 1540 BO",     
             "enemies": [
                 {
+                    "comment": "Dragonforce-Bearing Infected Behemoth (Severe)",
                     "enemy_id": "0x015712",
+                    "named_enemy_params_id": 1128,
+                    "infection_type": 2,
                     "level": 63,
-                    "exp": 45000,
-                    "is_boss": true,
-                    "infection_type": 2	
-        },
-        {
+                    "exp": 10560,
+                    "blood_orbs": 154,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Dragonforce-Bearing Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
+                    "named_enemy_params_id": 1128,
+                    "infection_type": 2,
+                    "repop_count": 1,
+                    "repop_wait_second": 30,
                     "level": 63,
-                    "exp": 4000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 422,
+                    "blood_orbs": 154
+                },
+                {
+                    "comment": "Dragonforce-Bearing Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
+                    "named_enemy_params_id": 1128,
+                    "infection_type": 2,
+                    "repop_count": 1,
+                    "repop_wait_second": 30,
                     "level": 63,
-                    "exp": 4000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 422,
+                    "blood_orbs": 154
+                },
+                {
+                    "comment": "Dragonforce-Bearing Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
+                    "named_enemy_params_id": 1128,
+                    "infection_type": 2,
+                    "repop_count": 1,
+                    "repop_wait_second": 30,
                     "level": 63,
-                    "exp": 4000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 422,
+                    "blood_orbs": 154
+                },
+                {
+                    "comment": "Dragonforce-Bearing Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
+                    "named_enemy_params_id": 1128,
+                    "infection_type": 2,
+                    "repop_count": 1,
+                    "repop_wait_second": 30,
                     "level": 63,
-                    "exp": 4000,
-                    "is_boss": false					
+                    "exp": 422,
+                    "blood_orbs": 154               
+                },
+                {
+                    "comment": "Dragonforce-Bearing Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "named_enemy_params_id": 1128,
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 422,
+                    "blood_orbs": 154               
+                },
+                {
+                    "comment": "Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 422          
+                },
+                {
+                    "comment": "Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 422          
+                },
+                {
+                    "comment": "Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 422          
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
@@ -1,0 +1,132 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Menace of the Ruins",
+  "quest_id": 21000053,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 10665
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Prism Crystal",
+          "item_id": 11808,
+          "num": 3
+        },
+        {
+          "comment": "Soft Tectrix",
+          "item_id": 11799,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 5
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops - Severe",
+          "enemy_id": "0x015012",
+          "infection_type": 2,
+          "level": 68,
+          "exp": 5925,
+          "is_boss": true
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 14
+      },
+      "enemies": [
+        {
+          "comment": "Infected Snow Harpy",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 3,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Infected Snow Harpy",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 3,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Infected Snow Harpy",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 3,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Infected Snow Harpy",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 3,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Infected Snow Harpy",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 3,
+          "level": 68,
+          "exp": 1185
+        }
+      ]
+    }
+  ], 
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [0]
+    },
+    {
+      "type": "WeakenGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [0],
+      "percent": 35
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000055.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000055.json
@@ -1,0 +1,171 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Lure of the Shadow",
+  "quest_id": 21000055,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "EasternZandora",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 7092
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Ancient Beast Pelt",
+          "item_id": 11793,
+          "num": 3
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 432,
+        "group_id": 8
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Living Armor",
+          "enemy_id": "0x010306",
+          "level": 65,
+          "exp": 3940
+        },
+        {
+          "comment": "Living Armor",
+          "enemy_id": "0x010306",
+          "level": 65,
+          "exp": 3940
+        },
+        {
+          "comment": "Skeleton Brute",
+          "enemy_id": "0x010307",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Skeleton Brute",
+          "enemy_id": "0x010307",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Frost Skeleton",
+          "enemy_id": "0x010315",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Frost Skeleton",
+          "enemy_id": "0x010315",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Frost Skeleton",
+          "enemy_id": "0x010315",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Frost Skeleton",
+          "enemy_id": "0x010315",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Lyonnet",
+      "message_id": 17328
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Lyonnet",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1804,
+          "Param2": 17329
+        }
+      ],
+      "items": [
+        {
+          "comment": "Magick Gold Ingot",
+          "id": 7886,
+          "amount": 2
+        }
+      ],
+      "message_id": 17330
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1804,
+          "Param2": 17331
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Lyonnet",
+      "message_id": 17332
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000065.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000065.json
@@ -1,0 +1,220 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Jewelry: Recklessness",
+  "quest_id": 21000065,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 14220
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Dowe Medal",
+          "item_id": 11003,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 364,
+        "group_id": 6
+      },
+      "comment": "Up to five Unappraised Star Trinket (General) drops",
+      "enemies": [
+        {
+          "comment": "Jewelry-Bearing Armored Cyclops",
+          "enemy_id": "0x015003",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 5925,
+          "drop_items": [
+            {
+              "item_id": 9438,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.1
+            },
+            {
+              "item_id": 7924,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7740,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 7771,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 8028,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 7762,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Jewelry-Bearing Eliminator",
+          "enemy_id": "0x010508",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7726,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewelry-Bearing Eliminator",
+          "enemy_id": "0x010508",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7726,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewelry-Bearing Eliminator",
+          "enemy_id": "0x010508",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7726,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewelry-Bearing Eliminator",
+          "enemy_id": "0x010508",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7726,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000066.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000066.json
@@ -1,0 +1,142 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Deathly Black Shadow",
+  "quest_id": 21000066,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 10665
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mirage Crystal",
+          "item_id": 11809,
+          "num": 3
+        },
+        {
+          "comment": "Soft Tectrix",
+          "item_id": 11799,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 3
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Cockatrice",
+          "enemy_id": "0x015301",
+          "level": 68,
+          "exp": 5925,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 68,
+          "exp": 1185,
+          "index": 6
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 68,
+          "exp": 1185,
+          "index": 7
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 68,
+          "exp": 1185,
+          "index": 8
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 68,
+          "exp": 1185,
+          "index": 9
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 68,
+          "exp": 1185,
+          "index": 10
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 105,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "4502",
+      "message_id": 17315
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 4502, 
+          "Param2": 17316,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 105,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "4502",
+      "message_id": 17317
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000067.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000067.json
@@ -1,0 +1,168 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Guardian of Ancient Remains",
+  "quest_id": 21000067,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 10665
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Prism Crystal",
+          "item_id": 11808,
+          "num": 4
+        },
+        {
+          "comment": "Soft Tectrix",
+          "item_id": 11799,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 426,
+        "group_id": 1
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Silver Roar",
+          "enemy_id": "0x015505",
+          "level": 68,
+          "exp": 3940,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 68,
+          "exp": 1185,
+          "index": 1
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 68,
+          "exp": 1185,
+          "index": 2
+        },
+        {
+          "comment": "Direwolf",
+          "enemy_id": "0x010201",
+          "level": 68,
+          "exp": 1185,
+          "index": 6
+        },
+        {
+          "comment": "Direwolf",
+          "enemy_id": "0x010201",
+          "level": 68,
+          "exp": 1185,
+          "index": 7
+        },
+        {
+          "comment": "Direwolf",
+          "enemy_id": "0x010201",
+          "level": 68,
+          "exp": 1185,
+          "index": 8
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 105,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "4502",
+      "message_id": 17323
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 105,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "4502",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 4502, 
+          "Param2": 17324,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "items": [
+        {
+          "comment": "Spirit Silver Ingot",
+          "id": 7884,
+          "amount": 2
+        }
+      ],
+      "message_id": 17325
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 4502, 
+          "Param2": 17326,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 105,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "4502",
+      "message_id": 17327
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000068.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000068.json
@@ -1,0 +1,86 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "An Embellished Rumor",
+  "quest_id": 21000068,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "EasternZandora",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3940
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5360
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 687
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Ancient Beast Pelt",
+          "item_id": 11793,
+          "num": 3
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Isabel",
+      "message_id": 17336
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 139
+      },
+      "npc_id": "Dian",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Isabel",
+          "type": "QstTalkChg",
+          "Param1": 1802,
+          "Param2": 17337
+        },
+        {
+          "comment": "Idle dialogue - Dian",
+          "type": "QstTalkChg",
+          "Param1": 4507,
+          "Param2": 17338
+        }
+      ],
+      "items": [
+        {
+          "comment": "Cave Silkworm",
+          "id": 11791,
+          "amount": 6
+        }
+      ],
+      "message_id": 17339
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000069.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000069.json
@@ -1,0 +1,138 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Headlong into Danger",
+  "quest_id": 21000069,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "EasternZandora",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 7092
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Ancient Beast Pelt",
+          "item_id": 11793,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 432,
+        "group_id": 5
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Geo Golem",
+          "enemy_id": "0x015104",
+          "level": 63,
+          "exp": 3876,
+          "is_boss": true,
+          "index": 2
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 65,
+          "exp": 788,
+          "index": 8
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 65,
+          "exp": 788,
+          "index": 9
+        },
+        {
+          "comment": "Flame Skeleton",
+          "enemy_id": "0x010314",
+          "level": 65,
+          "exp": 788,
+          "index": 11
+        },
+        {
+          "comment": "Flame Skeleton",
+          "enemy_id": "0x010314",
+          "level": 65,
+          "exp": 788,
+          "index": 13
+        },
+        {
+          "comment": "Flame Skeleton",
+          "enemy_id": "0x010314",
+          "level": 65,
+          "exp": 788,
+          "index": 14
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 57
+      },
+      "npc_id": "Oliver",
+      "message_id": 17340
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1809,
+          "Param2": 17341
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 57
+      },
+      "announce_type": "Update",
+      "npc_id": "Oliver",
+      "message_id": 17342
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000076.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000076.json
@@ -1,0 +1,301 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Jewelry: Newcomer's Highlight",
+  "quest_id": 21000076,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DeenanWoods",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 14220
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Deenan Medal",
+          "item_id": 11006,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 12
+      },
+      "comment": "Up to five Unappraised Star Trinket (General) drops",
+      "enemies": [
+        {
+          "comment": "Jewelry-Bearing White Chimera",
+          "enemy_id": "0x015202",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 5925,
+          "drop_items": [
+            {
+              "item_id": 7739,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7780,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7807,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7771,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 9437,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 7921,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Jewelry-Bearing White Chimera",
+          "enemy_id": "0x015202",
+          "named_enemy_params_id": 1121,
+          "level": 67,
+          "exp": 5925,
+          "drop_items": [
+            {
+              "item_id": 7739,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7780,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7807,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7771,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 1
+            },
+            {
+              "item_id": 9437,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 7921,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.5
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Jewelry-Bearing Lux Corpse Punisher",
+          "enemy_id": "0x010515",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewelry-Bearing Lux Corpse Punisher",
+          "enemy_id": "0x010515",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewelry-Bearing Lux Corpse Punisher",
+          "enemy_id": "0x010515",
+          "named_enemy_params_id": 1121,
+          "level": 68,
+          "exp": 1185,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 13480,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000077.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000077.json
@@ -1,0 +1,320 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Treasures: Where Fools Lie Buried",
+  "quest_id": 21000077,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "EasternZandora",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3940
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 12864
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Eastern Zandora Medal",
+          "item_id": 11008,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 432,
+        "group_id": 10
+      },
+      "starting_index": 1,
+      "comment": "Up to 66000G",
+      "enemies": [
+        {
+          "comment": "Treasure-Bearing Shadow Chimera",
+          "enemy_id": "0x015203",
+          "named_enemy_params_id": 1119,
+          "level": 65,
+          "exp": 6120,
+          "drop_items": [
+            {
+              "item_id": 7911,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 7800,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7748,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Treasure-Bearing Shadow Chimera",
+          "enemy_id": "0x015203",
+          "named_enemy_params_id": 1119,
+          "level": 65,
+          "exp": 6120,
+          "drop_items": [
+            {
+              "item_id": 7911,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 7800,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7748,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Treasure-Bearing Dark Corpse Torturer",
+          "enemy_id": "0x010520",
+          "named_enemy_params_id": 1119,
+          "level": 65,
+          "exp": 468,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Dark Corpse Torturer",
+          "enemy_id": "0x010520",
+          "named_enemy_params_id": 1119,
+          "level": 65,
+          "exp": 468,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Dark Corpse Torturer",
+          "enemy_id": "0x010520",
+          "named_enemy_params_id": 1119,
+          "level": 65,
+          "exp": 468,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Dark Corpse Torturer",
+          "enemy_id": "0x010520",
+          "named_enemy_params_id": 1119,
+          "level": 65,
+          "exp": 468,
+          "drop_items": [
+            {
+              "item_id": 7741,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8024,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000078.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000078.json
@@ -1,0 +1,211 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Door of Jewelry] Invasive Agent Elimination",
+  "quest_id": 21000078,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 9457
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+		  "comment": "Northern Betland Medal",
+          "item_id": 11007,
+          "num": 1
+        },
+        {
+		  "comment": "Superior Quality Gala Extract",
+          "item_id": 9362,
+          "num": 3
+        },
+        {
+		  "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 334,
+        "group_id": 8
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Jewelry-Bearing Manticore",
+          "enemy_id": "0x015210",
+		  "named_enemy_params_id": 1121,
+          "level": 65,
+          "exp": 9000,
+          "drop_items": [
+            {
+              "item_id": 7774,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7925,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 11805,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Jewelry-Bearing Manticore",
+          "enemy_id": "0x015210",
+		  "named_enemy_params_id": 1121,
+          "level": 63,
+          "exp": 8800,
+          "drop_items": [
+            {
+              "item_id": 7774,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7925,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 11805,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Jewelry-Bearing Infected Orc Soldier (Severe)",
+          "enemy_id": "0x015813",
+		  "named_enemy_params_id": 1121,
+          "infection_type": 2,
+          "level": 65,
+          "exp": 540,
+          "drop_items": [
+            {
+              "item_id": 11408,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Jewelry-Bearing Infected Orc Soldier (Severe)",
+          "enemy_id": "0x015813",
+		  "named_enemy_params_id": 1121,
+          "infection_type": 2,
+          "level": 65,
+          "exp": 540,
+          "drop_items": [
+            {
+              "item_id": 11408,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 13479,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000078.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000078.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "[Door of Jewelry] Invasive Agent Elimination",
+  "comment": "Door of Jewelry: Invasive Agent Elimination",
   "quest_id": 21000078,
   "base_level": 65,
   "minimum_item_rank": 0,
@@ -50,6 +50,7 @@
         "group_id": 8
       },
       "starting_index": 1,
+      "comment": "Up to two Unappraised Star Trinket (General) and two (Soldier)",
       "enemies": [
         {
           "comment": "Jewelry-Bearing Manticore",
@@ -80,7 +81,7 @@
               "drop_chance": 0.6
             },
             {
-              "item_id": 13479,
+              "item_id": 13480,
               "item_min": 1,
               "item_max": 1,
               "quality": 0,
@@ -118,11 +119,11 @@
               "drop_chance": 0.6
             },
             {
-              "item_id": 13479,
+              "item_id": 13480,
               "item_min": 1,
               "item_max": 1,
               "quality": 0,
-              "drop_chance": 1.0
+              "drop_chance": 0.1
             }
           ],
           "is_boss": true

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000079.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000079.json
@@ -1,0 +1,168 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "In Search of Gems",
+  "quest_id": 21000079,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MergodaRuins",
+  "news_image": 562,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 10665
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Gold-Stained Animal Fur",
+          "item_id": 11803,
+          "num": 3
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 424,
+        "group_id": 4
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Lux Skeleton",
+          "enemy_id": "0x010317",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Lux Skeleton Brute",
+          "enemy_id": "0x010323",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Lux Skeleton Brute",
+          "enemy_id": "0x010323",
+          "level": 68,
+          "exp": 1185
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 56,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Ariadne",
+      "message_id": 17397
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 56,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Ariadne",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg", 
+          "Param1": 2303, 
+          "Param2": 17402
+        }
+      ],
+      "items": [
+        {
+          "comment": "Sacred Blessed Cloth",
+          "id": 7943,
+          "amount": 2
+        }
+      ],
+      "message_id": 17403
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [ 
+        { 
+          "type": "QstTalkChg", 
+          "Param1": 2303, 
+          "Param2": 17404,
+          "comment": "Idle dialogue"
+        }
+      ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 56,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Ariadne",
+      "message_id": 17405
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000087.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000087.json
@@ -6,7 +6,7 @@
     "base_level": 68,
     "minimum_item_rank": 0,
     "discoverable": false,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle", 
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Mirage Crystal",
                     "item_id": 11809,
                     "num": 2
                 },
                 {
+                    "comment": "Stone Bouquet",
                     "item_id": 11790,
                     "num": 1
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 3
                 }
@@ -44,44 +47,77 @@
         {
             "stage_id": {
                 "id": 408,
-                "group_id": 7
-            },			
+                "group_id": 15
+            },
+            "comment": "Enemies drop a total of 1722 BO",
             "enemies": [
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Dragonforce-Bearing Infected Gorecyclops (Severe)",
+                    "enemy_id": "0x015012",
+                    "named_enemy_params_id": 1198,
+                    "infection_type": 2,
                     "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010430",
+                    "exp": 7440,
+                    "blood_orbs": 907,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Dragonforce-Bearing Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1198,
                     "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010430",
+                    "exp": 502,
+                    "blood_orbs": 163
+                },
+                {
+                    "comment": "Dragonforce-Bearing Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1198,
                     "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010430",
+                    "exp": 502,
+                    "blood_orbs": 163
+                },
+                {
+                    "comment": "Dragonforce-Bearing Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1198,
                     "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010430",
+                    "exp": 502,
+                    "blood_orbs": 163
+                },
+                {
+                    "comment": "Dragonforce-Bearing Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1198,
                     "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010430",
+                    "exp": 502,
+                    "blood_orbs": 163
+                },
+                {
+                    "comment": "Dragonforce-Bearing Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1198,
                     "level": 68,
-                    "exp": 3000,
-                    "is_boss": false					
+                    "exp": 502,
+                    "blood_orbs": 163               
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185             
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185             
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185             
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000088.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000088.json
@@ -1,0 +1,152 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Good Old Days",
+    "quest_id": 21000088,
+    "base_level": 68,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MergodaRuins",
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 10665
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 2243
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 290
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Electrum Plate",
+                    "item_id": 7891,
+                    "num": 1
+                },
+                {
+                    "comment": "Superior Strong Gala Extract",
+                    "item_id": 9364,
+                    "num": 3
+                },
+                {
+                    "comment": "Panacea",
+                    "item_id": 41,
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 84,
+                "group_id": 5
+            },
+            "comment": "Needs correct EXP values",
+            "placement_type": "manual",
+            "enemies": [
+                {
+                    "comment": "Drake",
+                    "enemy_id": "0x015700",
+                    "level": 68,
+                    "exp": 10788,
+                    "is_boss": true,
+                    "index": 12
+                },
+                {
+                    "comment": "Lux Corpse Torturer",
+                    "enemy_id": "0x010519",
+                    "level": 68,
+                    "exp": 788,
+                    "index": 13
+                },
+                {
+                    "comment": "Lux Corpse Torturer",
+                    "enemy_id": "0x010519",
+                    "level": 68,
+                    "exp": 788,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 14
+                },
+                {
+                    "comment": "Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "level": 68,
+                    "exp": 788,
+                    "index": 15
+                },
+                {
+                    "comment": "Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "level": 68,
+                    "exp": 788,
+                    "index": 16
+                },
+                {
+                    "comment": "Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "level": 68,
+                    "exp": 788,
+                    "index": 18
+                },
+                {
+                    "comment": "Alchemized Skeleton",
+                    "enemy_id": "0x010312",
+                    "level": 68,
+                    "exp": 788,
+                    "index": 19
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "npc_id": "Theodor",
+            "message_id": 17417
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [ 
+                { 
+                "type": "QstTalkChg", 
+                "Param1": 10, 
+                "Param2": 17418,
+                "comment": "Idle dialogue"
+                }
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 63,
+                "group_id": 1,
+                "layer_no": 1
+            },
+            "announce_type": "Update",
+            "npc_id": "Theodor",
+            "message_id": 17419
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000089.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000089.json
@@ -1,0 +1,168 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Call from the Undead",
+  "quest_id": 21000089,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MergodaRuins",
+  "news_image": 562,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "exp",
+      "amount": 10665
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+		  "comment": "Gold-Stained Animal Fur",
+          "item_id": 11803,
+          "num": 3
+        },
+        {
+		  "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+		  "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 424,
+        "group_id": 4
+      },
+	  "starting_index": 1,
+      "enemies": [
+        {
+		  "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+		  "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+		  "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+		  "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+		  "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+		  "comment": "Lux Skeleton Brute",
+          "enemy_id": "0x010323",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+		  "comment": "Lux Skeleton Brute",
+          "enemy_id": "0x010323",
+          "level": 68,
+          "exp": 1185
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 56,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Ariadne",
+      "message_id": 17421
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 56,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "npc_id": "Ariadne",
+      "announce_type": "Accept",
+	  "result_commands": [ 
+	    { 
+		  "comment": "Idle dialogue",
+		  "type": "QstTalkChg", 
+		  "Param1": 2303, 
+		  "Param2": 17422
+		}
+	  ],
+      "items": [
+        {
+		  "comment": "Sacred Blessed Cloth",
+          "id": 7943,
+          "amount": 2
+        }
+      ],
+      "message_id": 17423
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+	  "result_commands": [ 
+	    { 
+		  "type": "QstTalkChg", 
+		  "Param1": 2303, 
+		  "Param2": 17424,
+		  "comment": "Idle dialogue"
+		}
+	  ],
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 56,
+        "group_id": 1,
+        "layer_no": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Ariadne",
+      "message_id": 17425
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000090.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000090.json
@@ -6,7 +6,7 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": false,
-	"area_id": "MergodaRuins",
+    "area_id": "MergodaRuins",
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Gold-Stained Animal Fur",
                     "item_id": 11803,
                     "num": 3
                 },
                 {
+                    "comment": "Superior Healing Remedy",
                     "item_id": 7555,
                     "num": 3
                 },
                 {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
                     "num": 3
                 }
@@ -46,14 +49,58 @@
                 "id": 424,
                 "group_id": 2
             },
+            "starting_index": 9,
             "enemies": [
                 {
-                    "comment": "Infected Gorecyclops",
+                    "comment": "Infected Gorecyclops (Severe)",
                     "enemy_id": "0x015012",
                     "level": 65,
-                    "exp": 45000,
+                    "exp": 3743,
                     "is_boss": true,
                     "infection_type": 2
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 424,
+                "group_id": 6
+            },
+            "enemies": [
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "start_think_tbl_no": 2,
+                    "level": 65,
+                    "exp": 788
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "start_think_tbl_no": 2,
+                    "level": 65,
+                    "exp": 788
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "start_think_tbl_no": 1,
+                    "level": 65,
+                    "exp": 788
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "start_think_tbl_no": 2,
+                    "level": 65,
+                    "exp": 788
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "start_think_tbl_no": 2,
+                    "level": 65,
+                    "exp": 788
                 }
             ]
         }
@@ -64,8 +111,20 @@
             "groups": [0]
         },
         {
-            "type": "KillGroup",
+            "type": "WeakenGroup",
             "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [0],
+            "percent": 35
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
             "reset_group": false,
             "groups": [0]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
@@ -1,0 +1,371 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Gemstones: Absolutely No Entry!",
+  "quest_id": 21000091,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MergodaRuins",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 5925
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 1740
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Prism Crystal",
+          "item_id": 11808,
+          "num": 3
+        },
+        {
+          "comment": "Mergoda Medal",
+          "item_id": 11010,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 424,
+        "group_id": 7
+      },
+      "comment": "Enemies drop up to 13500 RC",
+      "enemies": [
+        {
+          "comment": "Gemstone-Bearing Damned Golem",
+          "enemy_id": "0x015103",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 5804,
+          "drop_items": [
+            {
+              "item_id": 8029,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8025,
+              "item_min": 1,
+              "item_max": 7,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7871,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Gemstone-Bearing Wight",
+          "enemy_id": "0x015600",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 3442,
+          "drop_items": [
+            {
+              "item_id": 7729,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.5
+            },
+            {
+              "item_id": 7804,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7769,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Gemstone-Bearing Wight",
+          "enemy_id": "0x015600",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 3442,
+          "drop_items": [
+            {
+              "item_id": 7729,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.5
+            },
+            {
+              "item_id": 7804,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7769,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Gemstone-Bearing Wight",
+          "enemy_id": "0x015600",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 3442,
+          "drop_items": [
+            {
+              "item_id": 7729,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.5
+            },
+            {
+              "item_id": 7804,
+              "item_min": 1,
+              "item_max": 3,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7769,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Gemstone-Bearing Damned Wolf",
+          "enemy_id": "0x010208",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 304,
+          "drop_items": [
+            {
+              "item_id": 7781,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8025,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Gemstone-Bearing Damned Wolf",
+          "enemy_id": "0x010208",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 304,
+          "drop_items": [
+            {
+              "item_id": 7781,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8025,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Gemstone-Bearing Damned Wolf",
+          "enemy_id": "0x010208",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 304,
+          "drop_items": [
+            {
+              "item_id": 7781,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8025,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Gemstone-Bearing Damned Wolf",
+          "enemy_id": "0x010208",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 304,
+          "drop_items": [
+            {
+              "item_id": 7781,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8025,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Gemstone-Bearing Damned Wolf",
+          "enemy_id": "0x010208",
+          "named_enemy_params_id": 1118,
+          "level": 68,
+          "exp": 304,
+          "drop_items": [
+            {
+              "item_id": 7781,
+              "item_min": 1,
+              "item_max": 5,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 8025,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.7
+            },
+            {
+              "item_id": 7794,
+              "item_min": 15,
+              "item_max": 15,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000095.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000095.json
@@ -1,0 +1,376 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Door of Treasures: Thunderous Roar",
+  "quest_id": 21000095,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "ZandoraWastelands",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6675
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 13854
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Zandora Medal",
+          "item_id": 11009,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 363,
+        "group_id": 5
+      },
+      "comment": "Up to 99000G",
+      "enemies": [
+        {
+          "comment": "Treasure-Bearing Drake",
+          "enemy_id": "0x015700",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 11020,
+          "drop_items": [
+            {
+              "item_id": 7928,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7806,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7930,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Treasure-Bearing Witch",
+          "enemy_id": "0x015604",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 6675,
+          "drop_items": [
+            {
+              "item_id": 7832,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.2
+            },
+            {
+              "item_id": 7894,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.6
+            },
+            {
+              "item_id": 7900,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 7947,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.4
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ],
+          "is_boss": true
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        },
+        {
+          "comment": "Treasure-Bearing Strix",
+          "enemy_id": "0x010610",
+          "named_enemy_params_id": 1119,
+          "level": 70,
+          "exp": 456,
+          "drop_items": [
+            {
+              "item_id": 7778,
+              "item_min": 1,
+              "item_max": 4,
+              "quality": 0,
+              "drop_chance": 0.9
+            },
+            {
+              "item_id": 19508,
+              "item_min": 9,
+              "item_max": 9,
+              "quality": 0,
+              "drop_chance": 1.0
+            },
+            {
+              "item_id": 19508,
+              "item_min": 2,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000099.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000099.json
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Reconnaissance Medal",
                     "item_id": 11779,
                     "num": 1
                 },
                 {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
                     "num": 3
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 3
                 }
@@ -46,32 +49,106 @@
                 "id": 443,
                 "group_id": 2
             },
+            "comment": "Group 0 - Frost Machina and Gigant Machina (1675 BO)",
             "enemies": [
                 {
-                    "enemy_id": "0x015850",
+                    "comment": "Dragonforce-Bearing Frost Machina",
+                    "enemy_id": "0x015851",
+                    "named_enemy_params_id": 1198,
                     "level": 70,
-                    "exp": 85000,
+                    "exp": 9500,
+                    "blood_orbs": 927,
                     "is_boss": true
                 },
                 {
-                    "enemy_id": "0x015851",
+                    "comment": "Dragonforce-Bearing Gigant Machina",
+                    "enemy_id": "0x015850",
+                    "named_enemy_params_id": 1198,
                     "level": 70,
-                    "exp": 85000,
+                    "exp": 6080,
+                    "blood_orbs": 748,
                     "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 443,
+                "group_id": 1
+            },
+            "comment": "Group 1 - Saurian Sages (334 BO)",
+            "enemies": [
+                {
+                    "comment": "Dragonforce-Bearing Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "named_enemy_params_id": 1198,
+                    "level": 70,
+                    "exp": 456,
+                    "blood_orbs": 167
+                },
+                {
+                    "comment": "Dragonforce-Bearing Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "named_enemy_params_id": 1198,
+                    "level": 70,
+                    "exp": 456,
+                    "blood_orbs": 167
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 456
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 456
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 456
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 456
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 456
                 }
             ]
         }
     ],
-    "blocks": [
-        {
-            "type": "DiscoverEnemy",
-            "groups": [0]
+    "processes": [
+        { 
+            "blocks": [
+                {
+                    "type": "DiscoverEnemy",
+                    "groups": [0]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Accept",
+                    "reset_group": false,
+                    "groups": [0,1]
+                }
+            ]
         },
-        {
-            "type": "KillGroup",
-            "announce_type": "Accept",
-            "reset_group": false,
-            "groups": [0]
+        { 
+            "blocks": [
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Dialogue, monster information, position and rewards update across several Season 1 and early Season 2 world quests, with Hidell Plains, Breya Coast, Volden Mines, Deenan Woods and Mergoda Ruins taking the lion's share of the update.

All Lestania [Door of X] quests should be in place and should reward their expected loot (actual drop rate is very likely off).

Several missing variants were also added, and special variants (Twelve Calamities, Rare Species) are partially added (roughly half of them are in place).