### PR TITLE
Dowe Valley/Infected World Quests Review

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_1.json
@@ -3,7 +3,7 @@
   "type": "World",
   "comment": "A Heart Throbs Once More (II)",
   "quest_id": 20000014,
-  "base_level": 8,
+  "base_level": 28,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_2.json
@@ -3,7 +3,7 @@
   "type": "World",
   "comment": "A Heart Throbs Once More (III)",
   "quest_id": 20000014,
-  "base_level": 8,
+  "base_level": 30,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020000_1.json
@@ -1,45 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Fort’s Supply Problems",
+  "comment": "The Fort’s Supply Problems (II)",
   "quest_id": 20020000,
-  "base_level": 15,
+  "base_level": 17,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 49,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 750
+      "amount": 1200
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 60
+      "amount": 70
     },
     {
       "type": "exp",
-      "amount": 240
+      "amount": 280
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Palm Flower",
-          "item_id": 83,
+          "comment": "Sorcerer's Hat",
+          "item_id": 8153,
           "num": 1
         },
         {
-          "comment": "Lockpick",
-          "item_id": 59,
-          "num": 3
+          "comment": "Interventive",
+          "item_id": 9374,
+          "num": 2
         },
         {
-          "comment": "Pickaxe",
-          "item_id": 57,
-          "num": 3
+          "comment": "Concoction of Light",
+          "item_id": 9376,
+          "num": 2
         }
       ]
     }
@@ -73,7 +74,7 @@
         {
           "comment": "Healing Elixir",
           "id": 7552,
-          "amount": 3
+          "amount": 5
         }
       ],
       "message_id": 12000
@@ -98,7 +99,7 @@
         {
           "comment": "Hematite",
           "id": 7861,
-          "amount": 3
+          "amount": 5
         }
       ],
       "message_id": 11111

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000.json
@@ -32,7 +32,7 @@
           "num": 1
         },
         {
-          "comment": "Refreshing Remedys ",
+          "comment": "Refreshing Remedy",
           "item_id": 9375,
           "num": 3
         },
@@ -50,14 +50,15 @@
         "id": 1,
         "group_id": 196
       },
-        "placement_type": "manual",
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Brutal Colossus",
           "enemy_id": "0x015020",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 53,
           "level": 30,
-          "exp": 5446,
+          "exp": 3080,
           "is_boss": true,
           "index": 5
         }
@@ -81,7 +82,7 @@
         "layer_no": 1
       },
       "npc_id": "WearyHarpy",
-      "message_id": 10800
+      "message_id": 11156
     },
     {
         "type": "NewDeliverItems",
@@ -92,13 +93,22 @@
         },
         "npc_id": "WearyHarpy",
         "announce_type": "Accept",
+        "result_commands": [
+          {
+            "type": "QstTalkChg",
+            "Param1": 526,
+            "Param2": 11162,
+            "comment": "Idle dialogue"
+          }
+        ],
         "items": [
             {
+                "comment": "Pine Lumber",
                 "id": 7968,
                 "amount": 1
             }
         ],
-        "message_id": 10737
+        "message_id": 11165
     },
     {
       "type": "NewDeliverItems",
@@ -109,13 +119,22 @@
       },
       "npc_id": "WearyHarpy",
       "announce_type": "Update",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 526,
+          "Param2": 11162,
+          "comment": "Idle dialogue"
+        }
+      ],
       "items": [
         {
+          "comment": "Clear Spring Water",
           "id": 7825,
           "amount": 5
         }
       ],
-      "message_id": 10737
+      "message_id": 11166
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
@@ -137,7 +156,7 @@
       },
       "announce_type": "Update",
       "npc_id": "WearyHarpy",
-      "message_id": 11842
+      "message_id": 11161
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Nest of Labor and Love",
+  "comment": "A Nest of Labor and Love (II)",
   "quest_id": 20030000,
   "base_level": 32,
   "minimum_item_rank": 0,
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Deft Gloves",
+          "comment": "Soldier Arms",
           "item_id": 711,
           "num": 1
         },
         {
-          "comment": "Refreshing Remedys ",
+          "comment": "Wild Steak",
           "item_id": 9412,
           "num": 1
         },
         {
-          "comment": "Throwblast",
+          "comment": "Enhanced Pickaxe",
           "item_id": 9401,
           "num": 3
         }
@@ -54,11 +54,12 @@
         "placement_type": "manual",
         "enemies": [
         {
+          "comment": "Brutal Chimera",
           "enemy_id": "0x015200",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-		  "named_enemy_params_id": 53,
           "level": 32,
-          "exp": 5636,
+          "exp": 3120,
           "is_boss": true,
           "index": 5
         }
@@ -82,9 +83,8 @@
         "layer_no": 1
       },
       "npc_id": "WearyHarpy",
-      "message_id": 10800
+      "message_id": 11156
     },
-    
     {
       "type": "DeliverItems",
       "stage_id": {
@@ -94,15 +94,23 @@
       },
       "npc_id": "WearyHarpy",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 526,
+          "Param2": 11162,
+          "comment": "Idle dialogue"
+        }
+      ],
       "items": [
         {
+          "comment": "Pine Lumber",
           "id": 7968,
           "amount": 5
         }
       ],
-      "message_id": 10737
+      "message_id": 11165
     },
-
     {
       "type": "NewDeliverItems",
       "stage_id": {
@@ -112,16 +120,23 @@
       },
       "npc_id": "WearyHarpy",
       "announce_type": "Update",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 526,
+          "Param2": 11162,
+          "comment": "Idle dialogue"
+        }
+      ],
       "items": [
         {
+          "comment": "Healing Drop",
           "id": 7829,
           "amount": 3
         }
       ],
-      "message_id": 10737
+      "message_id": 11166
     },
-
-    
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Update",
@@ -142,7 +157,7 @@
       },
       "announce_type": "Update",
       "npc_id": "WearyHarpy",
-      "message_id": 11842
+      "message_id": 11161
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Nest of Labor and Love",
+  "comment": "A Nest of Labor and Love (III)",
   "quest_id": 20030000,
   "base_level": 36,
   "minimum_item_rank": 0,
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Deft Gloves",
+          "comment": "Crest of Blind Warding",
           "item_id": 9326,
           "num": 1
         },
         {
-          "comment": "Refreshing Remedys ",
+          "comment": "Mellow Ale",
           "item_id": 9413,
           "num": 2
         },
         {
-          "comment": "Throwblast",
+          "comment": "Enhanced Lumber Knife",
           "item_id": 9402,
           "num": 3
         }
@@ -54,11 +54,12 @@
         "placement_type": "manual",
         "enemies": [
         {
+          "comment": "Brutal Armored Cyclops",
           "enemy_id": "0x015002",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-		  "named_enemy_params_id": 54,
           "level": 36,
-          "exp": 6040,
+          "exp": 3416,
           "is_boss": true,
           "index": 5
         }
@@ -82,9 +83,8 @@
         "layer_no": 1
       },
       "npc_id": "WearyHarpy",
-      "message_id": 10800
+      "message_id": 11156
     },
-    
     {
       "type": "DeliverItems",
       "stage_id": {
@@ -94,15 +94,23 @@
       },
       "npc_id": "WearyHarpy",
       "announce_type": "Accept",
-      "items": [
+      "result_commands": [
         {
-          "id": 7968,
-          "amount": 5
+          "type": "QstTalkChg",
+          "Param1": 526,
+          "Param2": 11162,
+          "comment": "Idle dialogue"
         }
       ],
-      "message_id": 10737
+      "items": [
+        {
+          "comment": "White Wood",
+          "id": 7964,
+          "amount": 2
+        }
+      ],
+      "message_id": 11165
     },
-
     {
       "type": "NewDeliverItems",
       "stage_id": {
@@ -112,16 +120,23 @@
       },
       "npc_id": "WearyHarpy",
       "announce_type": "Update",
-      "items": [
+      "result_commands": [
         {
-          "id": 7829,
-          "amount": 3
+          "type": "QstTalkChg",
+          "Param1": 526,
+          "Param2": 11162,
+          "comment": "Idle dialogue"
         }
       ],
-      "message_id": 10737
+      "items": [
+        {
+          "comment": "Healing Drop",
+          "id": 7829,
+          "amount": 5
+        }
+      ],
+      "message_id": 11166
     },
-
-    
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Update",
@@ -142,7 +157,7 @@
       },
       "announce_type": "Update",
       "npc_id": "WearyHarpy",
-      "message_id": 11842
+      "message_id": 11161
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001.json
@@ -45,7 +45,7 @@
   ],
   "blocks": [
     {
-      "type": "NpcTalkAndOrder",
+      "type": "NewNpcTalkAndOrder",
       "flags": [
         {
           "type": "QstLayout",
@@ -55,7 +55,7 @@
         }
       ],
       "stage_id": {
-        "id": 306,
+        "id": 14,
         "group_id": 1,
         "layer_no": 1
       },
@@ -63,10 +63,11 @@
       "message_id": 11167
     },
     {
-      "type": "DeliverItems",
+      "type": "NewDeliverItems",
       "stage_id": {
-        "id": 306,
-        "group_id": 1
+        "id": 14,
+        "group_id": 1,
+        "layer_no": 1	
       },
       "npc_id": "August",
       "announce_type": "Accept",
@@ -81,7 +82,7 @@
       "items": [
         {
           "comment": "Coconut-Scented Milkcap",
-          "id": 8036,
+          "id": 9063,
           "amount": 8
         }
       ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001_1.json
@@ -61,7 +61,7 @@
         "layer_no": 1
       },
       "npc_id": "August",
-      "message_id": 11168
+      "message_id": 11167
     },
     {
       "type": "DeliverItems",
@@ -86,7 +86,7 @@
           "amount": 10
         }
       ],
-      "message_id": 11171
+      "message_id": 11170
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030001_1.json
@@ -46,7 +46,7 @@
   ],
   "blocks": [
     {
-      "type": "NpcTalkAndOrder",
+      "type": "NewNpcTalkAndOrder",
       "flags": [
         {
           "type": "QstLayout",
@@ -56,7 +56,7 @@
         }
       ],
       "stage_id": {
-        "id": 306,
+        "id": 14,
         "group_id": 1,
         "layer_no": 1
       },
@@ -64,10 +64,11 @@
       "message_id": 11167
     },
     {
-      "type": "DeliverItems",
+      "type": "NewDeliverItems",
       "stage_id": {
-        "id": 306,
-        "group_id": 1
+        "id": 14,
+        "group_id": 1,
+        "layer_no": 1
       },
       "npc_id": "August",
       "announce_type": "Accept",
@@ -82,7 +83,7 @@
       "items": [
         {
           "comment": "Coconut-Scented Milkcap",
-          "id": 8036,
+          "id": 9063,
           "amount": 10
         }
       ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030002_1.json
@@ -1,39 +1,40 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Historical Mementos",
+  "comment": "Historical Mementos (II)",
   "quest_id": 20030002,
-  "base_level": 35,
+  "base_level": 40,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 70,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "exp",
-      "amount": 960
+      "amount": 1100
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1150
+      "amount": 1320
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 120
+      "amount": 170
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Crest of Freeze Warding",
-          "item_id": 9317,
-          "num": 1
+          "comment": "Strong Thread",
+          "item_id": 7956,
+          "num": 3
         },
         {
-          "comment": "Forest Dwellers Old Key",
-          "item_id": 9066,
+          "comment": "Grilled Mushroom",
+          "item_id": 9415,
           "num": 2
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003.json
@@ -72,12 +72,12 @@
         {
           "comment": "Brutal Behemoth",
           "enemy_id": "0x015709",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
+          "start_think_tbl_no": 1,
           "level": 40,
           "exp": 7280,
           "is_boss": true,
-          "index": 2
+          "index": 4
         }
       ]
     }
@@ -91,7 +91,7 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11196
+      "message_id": 11197
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
@@ -121,7 +121,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11199
+      "message_id": 11200
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_1.json
@@ -67,12 +67,12 @@
         {
           "comment": "Dangerous Angules",
           "enemy_id": "0x015708",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
+          "start_think_tbl_no": 1,
           "level": 51,
           "exp": 8664,
           "is_boss": true,
-          "index": 2
+          "index": 4
         }
       ]
     }
@@ -86,7 +86,7 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11196
+      "message_id": 11197
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
@@ -116,7 +116,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11199
+      "message_id": 11200
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_2.json
@@ -57,12 +57,12 @@
         {
           "comment": "Dangerous Angules",
           "enemy_id": "0x015708",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 56,
+          "start_think_tbl_no": 1,
           "level": 58,
           "exp": 9462,
           "is_boss": true,
-          "index": 2
+          "index": 4
         }
       ]
     }
@@ -76,7 +76,7 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11198
+      "message_id": 11197
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
@@ -106,7 +106,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11201
+      "message_id": 11200
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_4.json
@@ -56,12 +56,12 @@
         {
           "comment": "Big Fang Behemoth (Behemoth)",
           "enemy_id": "0x015709",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 595,
+          "start_think_tbl_no": 1,
           "level": 58,
           "exp": 9296,
           "is_boss": true,
-          "index": 2
+          "index": 4
         }
       ]
     }
@@ -75,7 +75,7 @@
         "layer_no": 1
       },
       "npc_id": "Urda",
-      "message_id": 11198
+      "message_id": 11197
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
@@ -105,7 +105,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Urda",
-      "message_id": 11201
+      "message_id": 11200
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030004.json
@@ -34,7 +34,7 @@
         {
           "comment": "Demon Amulet",
           "item_id": 923,
-          "num": 1
+          "num": 2
         },
         {
           "comment": "Enhanced Lockpick",
@@ -42,32 +42,33 @@
           "num": 2
         }
       ]
-  },
-  {
+    },
+    {
       "type": "random",
       "loot_pool": [
-          {
-              "item_id": 8844,
-              "num": 1,
-              "chance": 0.5
-          }
+        {
+          "comment": "Guardian's Cape",
+          "item_id": 8843,
+          "num": 1,
+          "chance": 0.5
+        }
       ]
-  }
-],
+    }
+  ],
   "enemy_groups": [
     {
       "stage_id": {
         "id": 154,
         "group_id": 2
       },
-        "placement_type": "manual",
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Brutal Wight",
           "enemy_id": "0x015600",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 30,
-          "exp": 5446,
+          "exp": 1664,
           "is_boss": true,
           "index": 7
         }
@@ -91,11 +92,19 @@
         "layer_no": 1
       },
       "npc_id": "Gerd1",
-      "message_id": 11372
+      "message_id": 11403
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 7,
+          "Param2": 11969,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -130,7 +139,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gerd1",
-      "message_id": 11842
+      "message_id": 11967
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030004_1.json
@@ -28,57 +28,60 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Victory Bracers",
+          "comment": "Resolver Arms",
           "item_id": 924,
           "num": 1
         },
         {
-          "comment": "Demon Amulet",
-          "item_id": 2324,
+          "comment": "Iron Bracers",
+          "item_id": 712,
           "num": 1
         },
         {
-          "comment": "Enhanced Lockpick",
+          "comment": "Three-Herb Salad",
           "item_id": 9410,
           "num": 2
         }
       ]
-  },
-  {
+    },
+    {
       "type": "random",
       "loot_pool": [
-          {
-              "item_id": 1015,
-              "num": 1,
-              "chance": 0.3
-          },
-          {
-            "item_id": 7875,
-            "num": 2,
-            "chance": 0.3
+        {
+          "comment": "Survivor's Cape",
+          "item_id": 1015,
+          "num": 1,
+          "chance": 0.3
         },
         {
+          "comment": "Silver Ingot",
+          "item_id": 7875,
+          "num": 2,
+          "chance": 0.3
+        },
+        {
+          "comment": "Ancient Grimoire",
           "item_id": 7764,
           "num": 1,
           "chance": 0.3
-      }
+        }
       ]
-  }
-],
+    }
+  ],
   "enemy_groups": [
     {
       "stage_id": {
         "id": 154,
         "group_id": 2
       },
-        "placement_type": "manual",
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Brutal Wight",
           "enemy_id": "0x015600",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 32,
-          "exp": 5636,
+          "exp": 1757,
           "is_boss": true,
           "index": 7
         }
@@ -102,11 +105,19 @@
         "layer_no": 1
       },
       "npc_id": "Gerd1",
-      "message_id": 11372
+      "message_id": 11403
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 7,
+          "Param2": 11969,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -141,7 +152,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Gerd1",
-      "message_id": 11842
+      "message_id": 11967
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005.json
@@ -32,7 +32,7 @@
           "num": 3
         },
         {
-          "comment": "Blue wiskey",
+          "comment": "Blue Whiskey",
           "item_id": 9417,
           "num": 2
         },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005.json
@@ -50,56 +50,70 @@
         "id": 90,
         "group_id": 6
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Vigilant Undead Swordsman",
+          "enemy_id": "0x010503",
+          "named_enemy_params_id": 53,
+          "level": 37,
+          "exp": 141,
+          "index": 0
+        },
+        {
+          "comment": "Vigilant Undead Swordsman",
+          "enemy_id": "0x010503",
+          "named_enemy_params_id": 53,
+          "level": 37,
+          "exp": 141,
+          "index": 3
+        },
+        {
+          "comment": "Vigilant Undead Swordsman",
+          "enemy_id": "0x010503",
+          "named_enemy_params_id": 53,
+          "level": 37,
+          "exp": 141,
+          "index": 4
+        },
+        {
+          "comment": "Vigilant Stout Undead",
+          "enemy_id": "0x010502",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 152,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 6
+        },
+        {
+          "comment": "Vigilant Stout Undead",
+          "enemy_id": "0x010502",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 152,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 7
+        },
+        {
+          "comment": "Vigilant Stout Undead",
+          "enemy_id": "0x010502",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 152,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 8
+        },
+        {
+          "comment": "Brutal Armored Cyclops",
           "enemy_id": "0x015002",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 38,
-          "exp": 6254,
-          "is_boss": true
-        },
-        {
-          "enemy_id": "0x010301",
-          "start_think_tbl_no": 1,
-          "level": 38,
-          "exp": 1564,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010301",
-          "start_think_tbl_no": 1,
-          "level": 38,
-          "exp": 1564,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010301",
-          "start_think_tbl_no": 1,
-          "level": 38,
-          "exp": 1564,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010502",
-          "start_think_tbl_no": 1,
-             "level": 38,
-          "exp": 1564,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010502",
-          "start_think_tbl_no": 2,
-               "level": 38,
-          "exp": 1564,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010502",
-          "start_think_tbl_no": 2,
-           "level": 38,
-          "exp": 1564,
-          "is_boss": false
+          "exp": 3339,
+          "is_boss": true,
+          "index": 14
         }
       ]
     }
@@ -121,11 +135,19 @@
         "layer_no": 1
       },
       "npc_id": "Bandit0",
-      "message_id": 11372
+      "message_id": 11989
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 522,
+          "Param2": 11988,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -143,7 +165,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Bandit0",
-      "message_id": 11842
+      "message_id": 11986
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Petty Thief’s Woes",
+  "comment": "A Petty Thief’s Woes (II)",
   "quest_id": 20030005,
   "base_level": 56,
   "minimum_item_rank": 0,
@@ -17,7 +17,7 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1540
+      "amount": 1350
     },
     {
       "type": "wallet",
@@ -28,17 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "witch velv",
+          "comment": "Witch's Velvet",
           "item_id": 7949,
           "num": 1
         },
         {
-          "comment": "witch grim",
+          "comment": "Witch's Grimoire",
           "item_id": 7808,
           "num": 1
         },
         {
-          "comment": "black cryst",
+          "comment": "Smoky Quartz",
           "item_id": 7908,
           "num": 1
         }
@@ -51,68 +51,75 @@
         "id": 90,
         "group_id": 6
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Vigilant Skeleton",
+          "enemy_id": "0x010300",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 166,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 0
+        },
+        {
+          "comment": "Vigilant Skeleton",
+          "enemy_id": "0x010300",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 166,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 3
+        },
+        {
+          "comment": "Vigilant Skeleton",
+          "enemy_id": "0x010300",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 166,
+          "index": 4
+        },
+        {
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "start_think_tbl_no": 8,
+          "level": 55,
+          "exp": 245,
+          "is_required": false,
+          "is_manual_set": true,
+          "index": 6
+        },
+        {
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "start_think_tbl_no": 8,
+          "level": 55,
+          "exp": 245,
+          "is_required": false,
+          "is_manual_set": true,
+          "index": 7
+        },
+        {
+          "comment": "Mudman",
+          "enemy_id": "0x010509",
+          "start_think_tbl_no": 8,
+          "level": 55,
+          "exp": 245,
+          "is_required": false,
+          "is_manual_set": true,
+          "index": 8
+        },
+        {
+          "comment": "Brutal Empress Ghost",
           "enemy_id": "0x015605",
-          "start_think_tbl_no": 2,
           "named_enemy_params_id": 56,
+          "start_think_tbl_no": 2,
           "level": 56,
-          "exp": 21700,
-          "is_boss": true
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 55,
-          "exp": 6476,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 55,
-          "exp": 6476,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 55,
-          "exp": 6476,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 55,
-          "exp": 6476,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010300",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 55,
-          "exp": 6476,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010509",
-          "start_think_tbl_no": 1,
-             "level": 55,
-          "exp": 6476,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010509",
-          "start_think_tbl_no": 1,
-               "level": 55,
-          "exp": 6476,
-          "is_boss": false
+          "exp": 4147,
+          "is_boss": true,
+          "index": 14
         }
       ]
     }
@@ -134,11 +141,19 @@
         "layer_no": 1
       },
       "npc_id": "Bandit0",
-      "message_id": 11372
+      "message_id": 11989
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 522,
+          "Param2": 11988,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -156,7 +171,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Bandit0",
-      "message_id": 11842
+      "message_id": 11986
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030007_1.json
@@ -1,46 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Timeless Castle (IV)",
-  "quest_id": 20030003,
-  "base_level": 58,
+  "comment": "The Spectator (II)",
+  "quest_id": 20030007,
+  "base_level": 36,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DoweValley",
-  "news_image": 71,
-  "variant_index": 3,
+  "news_image": 505,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "exp",
-      "amount": 3340
+      "amount": 1660
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1910
+      "amount": 1180
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 380
+      "amount": 190
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Dragon Fang",
-          "item_id": 7763,
+          "comment": "Silver Chainmail",
+          "item_id": 985,
           "num": 1
         },
         {
-          "comment": "Thick Dragonscale",
-          "item_id": 7929,
+          "comment": "Goat Horn",
+          "item_id": 7785,
           "num": 1
         },
         {
-          "comment": "Behemoth Fang",
-          "item_id": 7799,
-          "num": 1
+          "comment": "Wine-Boiled Mushroom",
+          "item_id": 9412,
+          "num": 2
         }
       ]
     }
@@ -48,20 +48,18 @@
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 69,
-        "group_id": 19
+        "id": 166,
+        "group_id": 4
       },
-      "placement_type": "manual",
+      "starting_index": 7,
       "enemies": [
         {
-          "comment": "Legendary Behemoth",
-          "enemy_id": "0x015709",
-          "named_enemy_params_id": 57,
-          "start_think_tbl_no": 1,
-          "level": 58,
-          "exp": 9296,
-          "is_boss": true,
-          "index": 4
+          "comment": "Brutal Chimera",
+          "enemy_id": "0x015200",
+          "named_enemy_params_id": 54,
+          "level": 36,
+          "exp": 3360,
+          "is_boss": true
         }
       ]
     }
@@ -70,12 +68,12 @@
     {
       "type": "NpcTalkAndOrder",
       "stage_id": {
-        "id": 42,
+        "id": 51,
         "group_id": 1,
         "layer_no": 1
       },
-      "npc_id": "Urda",
-      "message_id": 11197
+      "npc_id": "Chester0",
+      "message_id": 12213
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
@@ -84,8 +82,8 @@
         {
           "comment": "Idle dialogue",
           "type": "QstTalkChg",
-          "Param1": 1502,
-          "Param2": 11202
+          "Param1": 539,
+          "Param2": 12212
         }
       ],
       "groups": [ 0 ]
@@ -99,13 +97,13 @@
     {
       "type": "TalkToNpc",
       "stage_id": {
-        "id": 42,
+        "id": 51,
         "group_id": 1,
         "layer_no": 1
       },
       "announce_type": "Update",
-      "npc_id": "Urda",
-      "message_id": 11200
+      "npc_id": "Chester0",
+      "message_id": 12210
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030007_2.json
@@ -1,45 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Spectator",
+  "comment": "The Spectator (Twelve Calamities)",
   "quest_id": 20030007,
-  "base_level": 31,
+  "base_level": 55,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 505,
+  "variant_index": 2,
   "rewards": [
     {
       "type": "exp",
-      "amount": 1430
+      "amount": 5080
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1020
+      "amount": 3900
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 160
+      "amount": 360
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Faerie Band",
-          "item_id": 9564,
-          "num": 1
+          "comment": "Troll's Poisonous Moss",
+          "item_id": 8000,
+          "num": 3
         },
         {
-          "comment": "Conqueror Amulet",
-          "item_id": 9381,
-          "num": 2
+          "comment": "Thick Bone",
+          "item_id": 7770,
+          "num": 3
         },
         {
-          "comment": "Wine-Boiled Mushroom",
-          "item_id": 9411,
-          "num": 2
+          "comment": "Gold Thread",
+          "item_id": 7743,
+          "num": 3
         }
       ]
     }
@@ -53,11 +54,27 @@
       "starting_index": 7,
       "enemies": [
         {
-          "comment": "Vigilant Chimera",
-          "enemy_id": "0x015200",
-          "named_enemy_params_id": 53,
-          "level": 31,
-          "exp": 3060,
+          "comment": "Lord of Rock (Mole Troll)",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 528,
+          "level": 55,
+          "exp": 4800,
+          "is_boss": true
+        },
+        {
+          "comment": "Lord of Rock (Mole Troll)",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 528,
+          "level": 55,
+          "exp": 4800,
+          "is_boss": true
+        },
+        {
+          "comment": "Lord of Rock (Mole Troll)",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 528,
+          "level": 55,
+          "exp": 4800,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008.json
@@ -27,17 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Healing Elixir",
-          "item_id": 2594,
+          "comment": "Pourpoint",
+          "item_id": 982,
           "num": 1
         },
         {
-          "comment": "Quality Gala Extract",
-          "item_id": 3635,
+          "comment": "Belligerent Tied",
+          "item_id": 1000,
           "num": 1
         },
         {
-          "comment": "Small Thief Key",
+          "comment": "Wild Steak",
           "item_id": 9412,
           "num": 2
         }
@@ -47,6 +47,7 @@
       "type": "random",
       "loot_pool": [
           {
+              "comment": "Scholar's Ring",
               "item_id": 8992,
               "num": 1,
               "chance": 0.6
@@ -60,13 +61,15 @@
         "id": 136,
         "group_id": 2
       },
+      "starting_index": 1,
       "enemies": [
         {
+          "comment": "Vigilant Ogre",
           "enemy_id": "0x015500",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 32,
-          "exp": 5636,
+          "exp": 2420,
           "is_boss": true
         }
       ]
@@ -89,11 +92,19 @@
         "layer_no": 1
       },
       "npc_id": "Man510",
-      "message_id": 11372
+      "message_id": 11407
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 510,
+          "Param2": 12227,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -111,7 +122,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Man510",
-      "message_id": 11842
+      "message_id": 12224
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_1.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "No Unexpected Guests",
+  "comment": "No Unexpected Guests (II)",
   "quest_id": 20030008,
-  "base_level": 30,
+  "base_level": 34,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DoweValley",
@@ -12,35 +12,35 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1980
+      "amount": 1520
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1650
+      "amount": 1120
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 130
+      "amount": 170
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Healing Elixir",
-          "item_id": 7552,
+          "comment": "Crest of Blind Warding",
+          "item_id": 9326,
+          "num": 1
+        },
+        {
+          "comment": "Demon's Amulet",
+          "item_id": 9383,
           "num": 2
         },
         {
-          "comment": "Quality Gala Extract",
-          "item_id": 9361,
+          "comment": "Mellow Ale",
+          "item_id": 9413,
           "num": 2
-        },
-        {
-          "comment": "Small Thief Key",
-          "item_id": 9429,
-          "num": 3
         }
       ]
   },
@@ -48,6 +48,7 @@
       "type": "random",
       "loot_pool": [
           {
+              "comment": "Scholar's Ring",
               "item_id": 8992,
               "num": 1,
               "chance": 0.6
@@ -63,11 +64,12 @@
       },
       "enemies": [
         {
-          "enemy_id": "0x015040",
+          "comment": "Brutal Ogre",
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 54,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 467,
-          "level": 30,
-          "exp": 5446,
+          "level": 34,
+          "exp": 2540,
           "is_boss": true
         }
       ]
@@ -90,11 +92,19 @@
         "layer_no": 1
       },
       "npc_id": "Man510",
-      "message_id": 11372
+      "message_id": 11407
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 510,
+          "Param2": 12227,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -112,7 +122,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Man510",
-      "message_id": 11842
+      "message_id": 12224
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_1.json
@@ -62,6 +62,7 @@
         "id": 136,
         "group_id": 2
       },
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Brutal Ogre",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_2.json
@@ -62,6 +62,7 @@
         "id": 136,
         "group_id": 2
       },
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Bounty Troll",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030008_2.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "No Unexpected Guests",
+  "comment": "No Unexpected Guests (Bounty)",
   "quest_id": 20030008,
-  "base_level": 34,
+  "base_level": 30,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DoweValley",
@@ -12,35 +12,35 @@
   "rewards": [
     {
       "type": "exp",
-      "amount": 1520
+      "amount": 1980
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1120
+      "amount": 1650
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 170
+      "amount": 130
     },
     {
       "type": "select",
       "loot_pool": [
         {
           "comment": "Healing Elixir",
-          "item_id": 9626,
-          "num": 1
+          "item_id": 7552,
+          "num": 2
         },
         {
           "comment": "Quality Gala Extract",
-          "item_id": 9383,
+          "item_id": 9361,
           "num": 2
         },
         {
           "comment": "Small Thief Key",
-          "item_id": 9413,
-          "num": 2
+          "item_id": 9429,
+          "num": 3
         }
       ]
   },
@@ -48,6 +48,7 @@
       "type": "random",
       "loot_pool": [
           {
+              "comment": "Scholar's Ring",
               "item_id": 8992,
               "num": 1,
               "chance": 0.6
@@ -63,11 +64,12 @@
       },
       "enemies": [
         {
-          "enemy_id": "0x015500",
+          "comment": "Bounty Troll",
+          "enemy_id": "0x015040",
+          "named_enemy_params_id": 467,
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 34,
-          "exp": 5834,
+          "level": 30,
+          "exp": 2520,
           "is_boss": true
         }
       ]
@@ -90,11 +92,19 @@
         "layer_no": 1
       },
       "npc_id": "Man510",
-      "message_id": 11372
+      "message_id": 11407
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "type": "QstTalkChg",
+          "Param1": 510,
+          "Param2": 12227,
+          "comment": "Idle dialogue"
+        }
+      ],
       "groups": [ 0 ]
     },
     {
@@ -112,7 +122,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Man510",
-      "message_id": 11842
+      "message_id": 12224
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001.json
@@ -12,29 +12,32 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1320
+      "amount": 1150
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 260
+      "amount": 230
     },
     {
       "type": "exp",
-      "amount": 1080
+      "amount": 1610
     },
     {
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Golem Magickal Rock",
+          "item_id": 7866,
+          "num": 1
+        },
+        {
+          "comment": "Lapis Lazuli",
           "item_id": 7902,
           "num": 3
         },
         {
-          "item_id": 9384,
-          "num": 2
-        },
-        {
+          "comment": "Old Forest Dwellers' Key",
           "item_id": 9066,
           "num": 2
         }
@@ -47,11 +50,14 @@
         "id": 69,
         "group_id": 6
       },
+      "starting_index": 1,
       "enemies": [
         {
+          "comment": "Keywarden Golem",
           "enemy_id": "0x015100",
+          "named_enemy_params_id": 387,
           "level": 35,
-          "exp": 6000,
+          "exp": 3000,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001_1.json
@@ -1,63 +1,64 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "After That Dragon! (II)",
-  "quest_id": 20035009,
-  "base_level": 40,
+  "comment": "The Sleeping Giant (II)",
+  "quest_id": 20035001,
+  "base_level": 56,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DoweValley",
-  "news_image": 64,
+  "news_image": 72,
   "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1320
+      "amount": 1840
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 260
+      "amount": 290
     },
     {
       "type": "exp",
-      "amount": 1840
+      "amount": 2430
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Water Dragon Fang",
-          "item_id": 7765,
+          "comment": "Giant Single Pelt",
+          "item_id": 9438,
           "num": 1
         },
         {
-          "comment": "Dragonleather",
-          "item_id": 7941,
+          "comment": "Giant Eyeball",
+          "item_id": 7740,
           "num": 1
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
-          "num": 1
+          "comment": "Rugged Leather",
+          "item_id": 7924,
+          "num": 3
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 1,
-        "group_id": 228
+        "id": 69,
+        "group_id": 6
       },
+      "starting_index": 1,
       "enemies": [
         {
-          "comment": "Dangerous Lindwurm",
-          "enemy_id": "0x015707",
-          "named_enemy_params_id": 56,
-          "level": 40,
-          "exp": 6890,
+          "comment": "Keywarden Cyclops (Club)",
+          "enemy_id": "0x015001",
+          "named_enemy_params_id": 387,
+          "level": 56,
+          "exp": 3888,
           "is_boss": true
         }
       ]
@@ -66,7 +67,6 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
-      "show_marker": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_1.json
@@ -1,45 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Footsteps in the Halls",
+  "comment": "The Footsteps in the Halls (II)",
   "quest_id": 20035002,
-  "base_level": 33,
+  "base_level": 36,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DoweValley",
   "news_image": 75,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1080
+      "amount": 1180
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 140
+      "amount": 170
     },
     {
       "type": "exp",
-      "amount": 1080
+      "amount": 1300
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Loneliness Gloves",
-          "item_id": 9659,
+          "comment": "Braided Hose",
+          "item_id": 1002,
           "num": 1
         },
         {
-          "comment": "Throwing Skull",
-          "item_id": 9397,
+          "comment": "Enhanced Pickaxe",
+          "item_id": 9401,
           "num": 3
         },
         {
-          "comment": "Refreshing Remedy",
-          "item_id": 9375,
-          "num": 3
+          "comment": "Mellow Ale",
+          "item_id": 9413,
+          "num": 2
         }
       ]
     }
@@ -53,36 +54,36 @@
       "starting_index": 9,
       "enemies": [
         {
-          "comment": "Vigilant Undead Swordsman",
-          "enemy_id": "0x010503",
+          "comment": "Vigilant Skeleton Mage",
+          "enemy_id": "0x010308",
           "named_enemy_params_id": 53,
-          "level": 33,
-          "exp": 129,
+          "level": 34,
+          "exp": 134,
           "repop_count": 1,
           "repop_wait_second": 10
         },
         {
-          "comment": "Vigilant Undead Swordsman",
-          "enemy_id": "0x010503",
+          "comment": "Vigilant Skeleton Mage",
+          "enemy_id": "0x010308",
           "named_enemy_params_id": 53,
-          "level": 33,
-          "exp": 129,
+          "level": 34,
+          "exp": 134,
           "repop_count": 1,
           "repop_wait_second": 10
         },
         {
-          "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "named_enemy_params_id": 53,
-          "level": 33,
-          "exp": 151
+          "named_enemy_params_id": 54,
+          "level": 36,
+          "exp": 161
         },
         {
-          "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "named_enemy_params_id": 53,
-          "level": 33,
-          "exp": 151
+          "named_enemy_params_id": 54,
+          "level": 36,
+          "exp": 161
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_2.json
@@ -1,0 +1,112 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Footsteps in the Halls (III)",
+  "quest_id": 20035002,
+  "base_level": 57,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DoweValley",
+  "news_image": 75,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1880
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 250
+    },
+    {
+      "type": "exp",
+      "amount": 1880
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Dark Metal",
+          "item_id": 7887,
+          "num": 1
+        },
+        {
+          "comment": "Demon Arming Points",
+          "item_id": 8022,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 69,
+        "group_id": 18
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Brutal Gigant Machina",
+          "enemy_id": "0x015850",
+          "named_enemy_params_id": 54,
+          "level": 57,
+          "exp": 5248,
+          "is_boss": true,
+          "index": 7
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "level": 56,
+          "exp": 258,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 9
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "level": 56,
+          "exp": 258,
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 10
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "level": 56,
+          "exp": 258,
+          "index": 11
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "level": 56,
+          "exp": 258,
+          "index": 12
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035003.json
@@ -1,63 +1,62 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "After That Dragon! (II)",
-  "quest_id": 20035009,
-  "base_level": 40,
+  "comment": "The Glittering Horn",
+  "quest_id": 20035003,
+  "base_level": 35,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DoweValley",
-  "news_image": 64,
-  "variant_index": 1,
   "rewards": [
+    {
+      "type": "exp",
+      "amount": 3230
+    },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1320
+      "amount": 2310
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 260
-    },
-    {
-      "type": "exp",
-      "amount": 1840
+      "amount": 180
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Water Dragon Fang",
-          "item_id": 7765,
-          "num": 1
+		  "comment": "Superior Quality Gala Extract",
+          "item_id": 9362,
+          "num": 3
         },
         {
-          "comment": "Dragonleather",
-          "item_id": 7941,
-          "num": 1
+		  "comment": "Superior Healing Elixir",
+          "item_id": 7553,
+          "num": 2
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
-          "num": 1
+		  "comment": "Conqueror's Amulet",
+          "item_id": 9381,
+          "num": 2
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
       "stage_id": {
         "id": 1,
-        "group_id": 228
+        "group_id": 487
       },
+      "starting_index": 2,
       "enemies": [
         {
-          "comment": "Dangerous Lindwurm",
-          "enemy_id": "0x015707",
-          "named_enemy_params_id": 56,
-          "level": 40,
-          "exp": 6890,
+		  "comment": "Bounty Chimera",
+          "enemy_id": "0x015200",
+          "named_enemy_params_id": 458,
+          "level": 35,
+          "exp": 3300,
           "is_boss": true
         }
       ]
@@ -66,7 +65,6 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
-      "show_marker": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004.json
@@ -26,17 +26,17 @@
       "type": "select",
       "loot_pool": [
         {
-		  "comment": "Sentry Tights",
+          "comment": "Sentry Tights",
           "item_id": 8733,
           "num": 1
         },
         {
-		  "comment": "Special Bracers",
+          "comment": "Special Bracers",
           "item_id": 983,
           "num": 1
         },
         {
-		  "comment": "Old Forest Dwellers' Key",
+          "comment": "Old Forest Dwellers' Key",
           "item_id": 9066,
           "num": 2
         }
@@ -53,21 +53,21 @@
       "starting_index": 4,
       "enemies": [
         {
-		  "comment": "Vigilant Skeleton Knight",
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
           "named_enemy_params_id": 53,
           "level": 38,
           "exp": 155
         },
         {
-		  "comment": "Vigilant Skeleton Knight",
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
           "named_enemy_params_id": 53,
           "level": 38,
           "exp": 155
         },
         {
-		  "comment": "Vigilant Skeleton Knight",
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
           "named_enemy_params_id": 53,
           "level": 38,
@@ -80,25 +80,25 @@
         "id": 90,
         "group_id": 3
       },
-      "starting_index": 3,
       "comment": "Group 2 - Skeleton Sorcerers",
+      "starting_index": 3,
       "enemies": [
         {
-		  "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Vigilant Skeleton Sorcerer",
           "enemy_id": "0x010309",
           "named_enemy_params_id": 53,
           "level": 38,
           "exp": 169
         },
         {
-		  "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Vigilant Skeleton Sorcerer",
           "enemy_id": "0x010309",
           "named_enemy_params_id": 53,
           "level": 38,
           "exp": 169
         },
         {
-		  "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Vigilant Skeleton Sorcerer",
           "enemy_id": "0x010309",
           "named_enemy_params_id": 53,
           "level": 38,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004.json
@@ -1,0 +1,139 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Wandering Knights",
+  "quest_id": 20035004,
+  "base_level": 38,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1250
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1250
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 160
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+		  "comment": "Sentry Tights",
+          "item_id": 8733,
+          "num": 1
+        },
+        {
+		  "comment": "Special Bracers",
+          "item_id": 983,
+          "num": 1
+        },
+        {
+		  "comment": "Old Forest Dwellers' Key",
+          "item_id": 9066,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 90,
+        "group_id": 4
+      },
+      "comment": "Group 1 - Skeleton Knights",
+      "starting_index": 4,
+      "enemies": [
+        {
+		  "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 155
+        },
+        {
+		  "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 155
+        },
+        {
+		  "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 155
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 90,
+        "group_id": 3
+      },
+      "starting_index": 3,
+      "comment": "Group 2 - Skeleton Sorcerers",
+      "enemies": [
+        {
+		  "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 169
+        },
+        {
+		  "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 169
+        },
+        {
+		  "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 169
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [ 0 ]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Accept",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [ 1 ]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "SpawnGroup",
+          "groups": [ 1 ]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004_1.json
@@ -2,7 +2,7 @@
   "state_machine": "GenericStateMachine",
   "type": "World",
   "comment": "The Wandering Knights (II)",
-  "quest_id": 20035002,
+  "quest_id": 20035004,
   "base_level": 45,
   "minimum_item_rank": 0,
   "discoverable": false,
@@ -27,17 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
-		  "comment": "Mystery Organs",
+          "comment": "Mystery Organs",
           "item_id": 7744,
           "num": 1
         },
         {
-		  "comment": "Enhanced Pickaxe",
+          "comment": "Enhanced Pickaxe",
           "item_id": 9401,
           "num": 3
         },
         {
-		  "comment": "Strong Gala Extract",
+          "comment": "Strong Gala Extract",
           "item_id": 9363,
           "num": 3
         }
@@ -54,28 +54,28 @@
       "starting_index": 4,
       "enemies": [
         {
-		  "comment": "Vigilant Undead Warrior",
+          "comment": "Vigilant Undead Warrior",
           "enemy_id": "0x010504",
           "named_enemy_params_id": 53,
           "level": 45,
           "exp": 203
         },
         {
-		  "comment": "Vigilant Undead Warrior",
+          "comment": "Vigilant Undead Warrior",
           "enemy_id": "0x010504",
           "named_enemy_params_id": 53,
           "level": 45,
           "exp": 203
         },
         {
-		  "comment": "Vigilant Undead Warrior",
+          "comment": "Vigilant Undead Warrior",
           "enemy_id": "0x010504",
           "named_enemy_params_id": 53,
           "level": 45,
           "exp": 203
         },
         {
-		  "comment": "Vigilant Undead Warrior",
+          "comment": "Vigilant Undead Warrior",
           "enemy_id": "0x010504",
           "named_enemy_params_id": 53,
           "level": 45,
@@ -88,11 +88,11 @@
         "id": 90,
         "group_id": 3
       },
-      "starting_index": 4,
       "comment": "Group 2 - Ghouls",
+      "starting_index": 4,
       "enemies": [
         {
-		  "comment": "Brutal Ghoul",
+          "comment": "Brutal Ghoul",
           "enemy_id": "0x015503",
           "named_enemy_params_id": 54,
           "level": 45,
@@ -100,7 +100,7 @@
           "is_boss": true
         },
         {
-		  "comment": "Brutal Ghoul",
+          "comment": "Brutal Ghoul",
           "enemy_id": "0x015503",
           "named_enemy_params_id": 54,
           "level": 45,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004_1.json
@@ -1,0 +1,142 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Wandering Knights (II)",
+  "quest_id": 20035002,
+  "base_level": 45,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DoweValley",
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1620
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1480
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 210
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+		  "comment": "Mystery Organs",
+          "item_id": 7744,
+          "num": 1
+        },
+        {
+		  "comment": "Enhanced Pickaxe",
+          "item_id": 9401,
+          "num": 3
+        },
+        {
+		  "comment": "Strong Gala Extract",
+          "item_id": 9363,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 90,
+        "group_id": 4
+      },
+      "comment": "Group 1 - Undead Warriors",
+      "starting_index": 4,
+      "enemies": [
+        {
+		  "comment": "Vigilant Undead Warrior",
+          "enemy_id": "0x010504",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 203
+        },
+        {
+		  "comment": "Vigilant Undead Warrior",
+          "enemy_id": "0x010504",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 203
+        },
+        {
+		  "comment": "Vigilant Undead Warrior",
+          "enemy_id": "0x010504",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 203
+        },
+        {
+		  "comment": "Vigilant Undead Warrior",
+          "enemy_id": "0x010504",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 203
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 90,
+        "group_id": 3
+      },
+      "starting_index": 4,
+      "comment": "Group 2 - Ghouls",
+      "enemies": [
+        {
+		  "comment": "Brutal Ghoul",
+          "enemy_id": "0x015503",
+          "named_enemy_params_id": 54,
+          "level": 45,
+          "exp": 3700,
+          "is_boss": true
+        },
+        {
+		  "comment": "Brutal Ghoul",
+          "enemy_id": "0x015503",
+          "named_enemy_params_id": 54,
+          "level": 45,
+          "exp": 3700,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [ 0 ]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Accept",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [ 1 ]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "SpawnGroup",
+          "groups": [ 1 ]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Hard Leather Cloth",
           "item_id": 7937,
           "num": 3
         },
         {
+          "comment": "Fortifier",
           "item_id": 9377,
           "num": 3
         },
         {
+          "comment": "Wild Steak",
           "item_id": 9412,
           "num": 1
         }
@@ -47,30 +50,40 @@
         "id": 1,
         "group_id": 214
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Brutal Dread Ape",
           "enemy_id": "0x015502",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
+          "start_think_tbl_no": 1,
           "level": 30,
-          "exp": 5446,
+          "exp": 2048,
           "is_boss": true
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 28,
-          "exp": 300,
-          "is_boss": false
+          "exp": 182
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
           "level": 28,
-          "exp": 300,
-          "is_boss": false
+          "exp": 182
+        },
+        {
+          "comment": "Vigilant Brute Ape",
+          "enemy_id": "0x015504",
+          "named_enemy_params_id": 53,
+          "start_think_tbl_no": 1,
+          "level": 28,
+          "exp": 182
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Apes of Mayhem",
+  "comment": "The Apes of Mayhem (II)",
   "quest_id": 20035005,
   "base_level": 34,
   "minimum_item_rank": 0,
@@ -28,39 +28,45 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Shock Warding",
           "item_id": 9320,
           "num": 1
         },
         {
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 2
         },
         {
+          "comment": "Angel's Amulet",
           "item_id": 9382,
           "num": 2
         }
       ]
-  },
-  {
+    },
+    {
       "type": "random",
       "loot_pool": [
-          {
-              "item_id":8969,
-              "num": 1,
-              "chance": 0.4
-          },
-          {
-            "item_id":9429,
-            "num": 1,
-            "chance": 0.4
+        {
+          "comment": "Knight's Ring",
+          "item_id": 8969,
+          "num": 1,
+          "chance": 0.4
         },
-          {
-            "item_id":9013,
-            "num": 1,
-            "chance": 0.4
+        {
+          "comment": "Small Thief's Key",
+          "item_id": 9429,
+          "num": 1,
+          "chance": 0.4
+        },
+        {
+          "comment": "Misty Feather Earrings",
+          "item_id": 9013,
+          "num": 1,
+          "chance": 0.4
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
@@ -68,29 +74,42 @@
         "id": 1,
         "group_id": 214
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Brutal Dread Ape",
           "enemy_id": "0x015502",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 34,
-          "exp": 5834,
+          "exp": 2278,
           "is_boss": true
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 32,
-          "exp": 1126,
+          "exp": 198,
           "is_boss": false
         },
         {
+          "comment": "Vigilant Brute Ape",
           "enemy_id": "0x015504",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 32,
-          "exp": 1126,
+          "exp": 198,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Brute Ape",
+          "enemy_id": "0x015504",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 32,
+          "exp": 198,
           "is_boss": false
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Apes of Mayhem",
+  "comment": "The Apes of Mayhem (III)",
   "quest_id": 20035005,
   "base_level": 39,
   "minimum_item_rank": 0,
@@ -28,20 +28,22 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Wanderer's Wrist Ring",
           "item_id": 9007,
           "num": 1
         },
         {
+          "comment": "Enhanced Lockpick",
           "item_id": 9403,
           "num": 3
         },
         {
+          "comment": "Superior Healing Elixir",
           "item_id": 7553,
           "num": 3
-       
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
@@ -49,24 +51,24 @@
         "id": 1,
         "group_id": 214
       },
+      "starting_index": 5,
       "enemies": [
         {
+          "comment": "Brutal Dread Ape",
           "enemy_id": "0x015502",
-          "start_think_tbl_no": 0,
           "named_enemy_params_id": 54,
           "level": 39,
-          "exp": 6364,
+          "exp": 2566,
           "is_boss": true
         },
         {
+          "comment": "Brutal Dread Ape",
           "enemy_id": "0x015502",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 39,
-          "exp": 6364,
+          "exp": 2566,
           "is_boss": true
         }
-        
       ]
     }
   ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035006.json
@@ -12,29 +12,32 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1050
+      "amount": 1040
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 140
+      "amount": 160
     },
     {
       "type": "exp",
-      "amount": 1230
+      "amount": 1250
     },
     {
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Innocence Cape",
           "item_id": 9759,
           "num": 1
         },
         {
+          "comment": "Three-Herb Salad",
           "item_id": 9410,
           "num": 2
         },
         {
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 2
         }
@@ -47,34 +50,43 @@
         "id": 99,
         "group_id": 2
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Brutal Mist Hunter",
           "enemy_id": "0x011031",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 69,
           "level": 38,
-          "exp": 450,
-          "is_boss": false,
-          "hm_present_no": 69
+          "exp": 188,
+          "repop_count": 1,
+          "repop_wait_time": 10
         },
         {
+          "comment": "Brutal Mist Hunter",
           "enemy_id": "0x011031",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 69,
           "level": 38,
-          "exp": 450,
-          "is_boss": false,
-          "hm_present_no": 69
+          "exp": 188,
+          "repop_count": 1,
+          "repop_wait_time": 10
         },
         {
+          "comment": "Brutal Mist Sorcerer",
           "enemy_id": "0x011033",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 71,
           "level": 38,
-          "exp": 450,
-          "is_boss": false,
-          "hm_present_no": 71
+          "exp": 188
         },
         {
+          "comment": "Brutal Mist Sorcerer",
           "enemy_id": "0x011033",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 71,
           "level": 38,
-          "exp": 450,
-          "is_boss": false,
-          "hm_present_no": 71
+          "exp": 188
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Bornite Ingot",
           "item_id": 7883,
           "num": 1
         },
         {
+          "comment": "Throwing Knife",
           "item_id": 9398,
           "num": 2
         },
         {
+          "comment": "Demon's Amulet",
           "item_id": 9383,
           "num": 2
         }
@@ -45,13 +48,16 @@
     {
       "stage_id": {
         "id": 89,
-        "group_id": 9
+        "group_id": 8
       },
+      "starting_index": 1,
       "enemies": [
         {
-          "enemy_id": "0x015000",
+          "comment": "Vigilant Cyclops (Club)",
+          "enemy_id": "0x015001",
+          "named_enemy_params_id": 54,
           "level": 35,
-          "exp": 6200,
+          "exp": 2880,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007_1.json
@@ -1,63 +1,64 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "After That Dragon! (II)",
-  "quest_id": 20035009,
-  "base_level": 40,
+  "comment": "A Desire to Feed (II)",
+  "quest_id": 20035007,
+  "base_level": 37,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DoweValley",
-  "news_image": 64,
+  "news_image": 537,
   "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1320
+      "amount": 1220
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 260
+      "amount": 190
     },
     {
       "type": "exp",
-      "amount": 1840
+      "amount": 1700
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Water Dragon Fang",
-          "item_id": 7765,
+          "comment": "Giant Eyeball",
+          "item_id": 7740,
           "num": 1
         },
         {
-          "comment": "Dragonleather",
-          "item_id": 7941,
+          "comment": "Topaz Pendant",
+          "item_id": 8977,
           "num": 1
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
+          "comment": "Conqueror's Talisman",
+          "item_id": 9387,
           "num": 1
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 1,
-        "group_id": 228
+        "id": 89,
+        "group_id": 8
       },
+      "starting_index": 1,
       "enemies": [
         {
-          "comment": "Dangerous Lindwurm",
-          "enemy_id": "0x015707",
-          "named_enemy_params_id": 56,
-          "level": 40,
-          "exp": 6890,
+          "comment": "Brutal Cyclops (Club)",
+          "enemy_id": "0x015001",
+          "named_enemy_params_id": 54,
+          "level": 37,
+          "exp": 2976,
           "is_boss": true
         }
       ]
@@ -66,7 +67,6 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
-      "show_marker": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Dignity Boots",
           "item_id": 9709,
           "num": 1
         },
         {
+          "comment": "Five-Herb Salad",
           "item_id": 9414,
           "num": 1
         },
         {
+          "comment": "Sprite's Amulet",
           "item_id": 9384,
           "num": 2
         }
@@ -47,11 +50,14 @@
         "id": 100,
         "group_id": 4
       },
+      "starting_index": 11,
       "enemies": [
         {
+          "comment": "Brutal Ogre",
           "enemy_id": "0x015500",
+          "named_enemy_params_id": 54,
           "level": 32,
-          "exp": 5400,
+          "exp": 2420,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008_1.json
@@ -1,63 +1,64 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "After That Dragon! (II)",
-  "quest_id": 20035009,
-  "base_level": 40,
+  "comment": "The Echoing Roars in the Tunnel (II)",
+  "quest_id": 20035008,
+  "base_level": 35,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DoweValley",
-  "news_image": 64,
+  "news_image": 535,
   "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1320
+      "amount": 1150
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 260
+      "amount": 160
     },
     {
       "type": "exp",
-      "amount": 1840
+      "amount": 1480
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Water Dragon Fang",
-          "item_id": 7765,
+          "comment": "Crest of Holy Drain Warding",
+          "item_id": 9323,
           "num": 1
         },
         {
-          "comment": "Dragonleather",
-          "item_id": 7941,
+          "comment": "Grilled Mushroom",
+          "item_id": 9415,
           "num": 1
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
-          "num": 1
+          "comment": "Throwing Skull",
+          "item_id": 9397,
+          "num": 3
         }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 1,
-        "group_id": 228
+        "id": 100,
+        "group_id": 4
       },
+      "starting_index": 11,
       "enemies": [
         {
-          "comment": "Dangerous Lindwurm",
-          "enemy_id": "0x015707",
-          "named_enemy_params_id": 56,
-          "level": 40,
-          "exp": 6890,
+          "comment": "Brutal Ogre",
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 54,
+          "level": 35,
+          "exp": 2600,
           "is_boss": true
         }
       ]
@@ -66,7 +67,6 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
-      "show_marker": false,
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009.json
@@ -28,14 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Dragon Hide",
           "item_id": 7928,
           "num": 3
         },
         {
+          "comment": "Wild Steak",
           "item_id": 9412,
           "num": 2
         },
         {
+          "comment": "Angel's Talisman",
           "item_id": 9388,
           "num": 1
         }
@@ -45,16 +48,19 @@
         "type": "random",
         "loot_pool": [
             {
+                "comment": "Small Thief's Key",
                 "item_id": 9429,
                 "num": 2,
                 "chance": 0.7
             },
             {
+                "comment": "Crest of Greater Power",
                 "item_id": 9196,
                 "num": 1,
                 "chance": 0.7
             },
             {
+                "comment": "Red Alloy Ingot",
                 "item_id": 7888,
                 "num": 1,
                 "chance": 0.7
@@ -70,10 +76,11 @@
       },
       "enemies": [
         {
+          "comment": "Dangerous Lindwurm",
           "enemy_id": "0x015707",
-          "named_enemy_params_id": 53,
+          "named_enemy_params_id": 56,
           "level": 36,
-          "exp_scheme": "Automatic",
+          "exp": 6466,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009.json
@@ -8,7 +8,6 @@
   "discoverable": false,
   "area_id": "DoweValley",
   "news_image": 64,
-  "variant_index": 0,
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "After That Dragon!",
+  "comment": "After That Dragon! (III)",
   "quest_id": 20035009,
   "base_level": 60,
   "minimum_item_rank": 0,
@@ -28,14 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Spectral Dragon Claw",
           "item_id": 7802,
           "num": 1
         },
         {
+          "comment": "Spectral Dragonscale",
           "item_id": 7922,
           "num": 1
         },
         {
+          "comment": "Panacea",
           "item_id": 41,
           "num": 3
         }
@@ -50,10 +53,11 @@
       },
       "enemies": [
         {
-          "enemy_id": "0x015710",
+          "comment": "Brutal Mist Wyrm",
+          "enemy_id": "0x015711",
           "named_enemy_params_id": 54,
           "level": 60,
-          "exp_scheme": "Automatic",
+          "exp": 9860,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Strong Hatchet",
           "item_id": 67,
           "num": 1
         },
         {
+          "comment": "Interventive",
           "item_id": 9374,
           "num": 2
         },
         {
+          "comment": "Restorative",
           "item_id": 9369,
           "num": 3
         }
@@ -49,38 +52,43 @@
       },
       "enemies": [
         {
-          "comment": "Troll",
+          "comment": "Vigilant Troll",
           "enemy_id": "0x015040",
+          "named_enemy_params_id": 53,
           "level": 18,
-          "exp": 2950,
+          "exp": 1872,
           "is_boss": true
         },
         {
-          "comment": "Mudman",
+          "comment": "Vigilant Mudman",
           "enemy_id": "0x010509",
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 150,
+          "exp": 89,
           "is_boss": false
         },
         {
-          "comment": "Mudman",
+          "comment": "Vigilant Mudman",
           "enemy_id": "0x010509",
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 150,
+          "exp": 89,
           "is_boss": false
         },
         {
-          "comment": "Mudman",
+          "comment": "Vigilant Mudman",
           "enemy_id": "0x010509",
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 150,
+          "exp": 89,
           "is_boss": false
         },
         {
-          "comment": "Mudman",
+          "comment": "Vigilant Mudman",
           "enemy_id": "0x010509",
+          "named_enemy_params_id": 53,
           "level": 16,
-          "exp": 150,
+          "exp": 89,
           "is_boss": false
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_1.json
@@ -1,44 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Glittering Horn",
-  "quest_id": 20035003,
-  "base_level": 35,
+  "comment": "Shadows in the Demon’s Den (II)",
+  "quest_id": 20055003,
+  "base_level": 57,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "area_id": "DoweValley",
+  "area_id": "MysreeForest",
+  "news_image": 113,
+  "variant_index": 1,
   "rewards": [
-    {
-      "type": "exp",
-      "amount": 3230
-    },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 2310
+      "amount": 1880
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 180
+      "amount": 300
+    },
+    {
+      "type": "exp",
+      "amount": 2250
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Superior Quality Gala Extract",
-          "item_id": 9362,
-          "num": 3
+          "comment": "Magick Lion's Large Mane",
+          "item_id": 9437,
+          "num": 1
         },
         {
-          "comment": "Superior Healing Elixir",
-          "item_id": 7553,
-          "num": 2
+          "comment": "White Lion Pelt",
+          "item_id": 7739,
+          "num": 1
         },
         {
-          "comment": "Conqueror's Amulet",
-          "item_id": 9381,
-          "num": 2
+          "comment": "Pure White Mane",
+          "item_id": 7780,
+          "num": 1
         }
       ]
     }
@@ -46,17 +48,16 @@
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 1,
-        "group_id": 487
+        "id": 160,
+        "group_id": 0
       },
-      "starting_index": 2,
       "enemies": [
         {
-          "comment": "Bounty Chimera",
-          "enemy_id": "0x015200",
-          "named_enemy_params_id": 458,
-          "level": 35,
-          "exp": 3300,
+          "comment": "Legendary White Chimera",
+          "enemy_id": "0x015202",
+          "named_enemy_params_id": 57,
+          "level": 57,
+          "exp": 5937,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_2.json
@@ -1,44 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Glittering Horn",
-  "quest_id": 20035003,
-  "base_level": 35,
+  "comment": "Shadows in the Demon’s Den (Bounty)",
+  "quest_id": 20055003,
+  "base_level": 25,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "area_id": "DoweValley",
+  "area_id": "MysreeForest",
+  "news_image": 113,
+  "variant_index": 2,
   "rewards": [
-    {
-      "type": "exp",
-      "amount": 3230
-    },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 2310
+      "amount": 1480
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 180
+      "amount": 130
+    },
+    {
+      "type": "exp",
+      "amount": 2070
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Superior Quality Gala Extract",
-          "item_id": 9362,
+          "comment": "Combat Fabric",
+          "item_id": 7938,
+          "num": 2
+        },
+        {
+          "comment": "Fortifier",
+          "item_id": 9377,
           "num": 3
         },
         {
-          "comment": "Superior Healing Elixir",
-          "item_id": 7553,
-          "num": 2
-        },
-        {
-          "comment": "Conqueror's Amulet",
-          "item_id": 9381,
-          "num": 2
+          "comment": "Throwing Rock",
+          "item_id": 9396,
+          "num": 3
         }
       ]
     }
@@ -46,17 +48,16 @@
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 1,
-        "group_id": 487
+        "id": 160,
+        "group_id": 0
       },
-      "starting_index": 2,
       "enemies": [
         {
-          "comment": "Bounty Chimera",
-          "enemy_id": "0x015200",
+          "comment": "Bounty Sphinx",
+          "enemy_id": "0x015302",
           "named_enemy_params_id": 458,
-          "level": 35,
-          "exp": 3300,
+          "level": 25,
+          "exp": 2875,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_1.json
@@ -85,7 +85,7 @@
                 "layer_no": 1
             },
             "npc_id": "Sonya",
-            "message_id": 11372
+            "message_id": 16046
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -115,7 +115,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Sonya",
-            "message_id": 11835
+            "message_id": 16048
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_2.json
@@ -74,7 +74,7 @@
                 "layer_no": 1
             },
             "npc_id": "Sonya",
-            "message_id": 11372
+            "message_id": 16046
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -104,7 +104,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Sonya",
-            "message_id": 11835
+            "message_id": 16048
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_3.json
@@ -74,7 +74,7 @@
                 "layer_no": 1
             },
             "npc_id": "Sonya",
-            "message_id": 11372
+            "message_id": 16046
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -104,7 +104,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Sonya",
-            "message_id": 11835
+            "message_id": 16048
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_4.json
@@ -74,7 +74,7 @@
                 "layer_no": 1
             },
             "npc_id": "Sonya",
-            "message_id": 11372
+            "message_id": 16046
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -104,7 +104,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Sonya",
-            "message_id": 11835
+            "message_id": 16048
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000000.json
@@ -1,0 +1,401 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Lurking in the Shadows",
+  "quest_id": 21000000,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "HidellPlains",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 9457
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Firm Protection (Health)",
+          "item_id": 16070,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Wisdom (Health)",
+          "item_id": 16074,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 87,
+        "group_id": 3
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 65,
+          "exp": 630,
+          "is_boss": true
+        },
+        {
+          "comment": "Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Wolf",
+          "enemy_id": "0x010207",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Goblin",
+          "enemy_id": "0x011120",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Goblin",
+          "enemy_id": "0x011120",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Goblin",
+          "enemy_id": "0x011120",
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 406,
+        "group_id": 3
+      },
+      "starting_index": 10,
+      "enemies": [
+        {
+          "comment": "Damned Golem",
+          "enemy_id": "0x015103",
+          "level": 60,
+          "exp": 3026,
+          "is_boss": true
+        },
+        {
+          "comment": "Damned Goblin Fighter",
+          "enemy_id": "0x011125",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Goblin Fighter",
+          "enemy_id": "0x011125",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Wolf",
+          "enemy_id": "0x010208",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Wolf",
+          "enemy_id": "0x010208",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Wolf",
+          "enemy_id": "0x010208",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Wolf",
+          "enemy_id": "0x010208",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Wolf",
+          "enemy_id": "0x010208",
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 406,
+        "group_id": 7
+      },
+      "enemies": [
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Goblin Fighter",
+          "enemy_id": "0x011125",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Goblin Fighter",
+          "enemy_id": "0x011125",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Damned Goblin Fighter",
+          "enemy_id": "0x011125",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Gigant Machina",
+          "enemy_id": "0x015850",
+          "level": 60,
+          "exp": 3026,
+          "is_boss": true
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 406,
+        "group_id": 10
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Goliath",
+          "enemy_id": "0x015102",
+          "start_think_tbl_no": 1,
+          "level": 65,
+          "exp": 15761,
+          "is_boss": true
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "start_think_tbl_no": 1,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "start_think_tbl_no": 1,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "start_think_tbl_no": 1,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "start_think_tbl_no": 1,
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 25
+          },
+          "npc_id": "Alfred",
+          "message_id": 17024
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 10,
+              "Param2": 17025
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 25
+          },
+          "npc_id": "Alfred",
+          "message_id": 17026
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "BreyaCoast",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -127,25 +128,99 @@
       ]
     }
   ],
-  "blocks": [
+  "processes": [
     {
-      "type": "DiscoverEnemy",
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0],
+          "result_commands": [ { "type": "QstLayoutFlagOn", "Param1": 3007 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
     },
     {
-      "type": "Raw",
-      "announce_type": "Accept",
-      "check_commands": [ { "type": "EmHpLess", "Param1": 824, "Param2": 4, "Param3": 5, "Param4": 35 } ] 
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [ { "type": "EmHpLess", "Param1": 824, "Param2": 4, "Param3": 5, "Param4": 35 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [1]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 5 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 7 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 8 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 9 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "reset_group": false,
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 4 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
@@ -143,8 +143,8 @@
           "comment": "Group 0 boss HP check",
           "type": "Raw",
           "check_commands": [
-            { "type": "EmHpLess", "Param1": 804, "Param2": 4, "Param3": 6, "Param4": 35 } ,
-            { "type": "EmHpLess", "Param1": 804, "Param2": 4, "Param3": 7, "Param4": 35 }
+            { "type": "EmHpLess", "Param1": 804, "Param2": 4, "Param3": 6, "Param4": 40 } ,
+            { "type": "EmHpLess", "Param1": 804, "Param2": 4, "Param3": 7, "Param4": 40 }
           ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
@@ -1,77 +1,210 @@
 {
-    "state_machine": "GenericStateMachine",
-    "type": "World",
-    "comment": "The Wandering Light",
-    "quest_id": 21000009,
-    "base_level": 60,
-    "minimum_item_rank": 0,
-    "discoverable": false,
-  "area_id": "BloodbaneIsle",	
-    "rewards": [
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Wandering Light",
+  "quest_id": 21000009,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BloodbaneIsle",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6809
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1980
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 250
+    },
+    {
+      "type": "select",
+      "loot_pool": [
         {
-            "type": "wallet",
-            "wallet_type": "Gold",
-            "amount": 1980
+          "comment": "Rock Finger",
+          "item_id": 11506,
+          "num": 3
         },
         {
-            "type": "wallet",
-            "wallet_type": "RiftPoints",
-            "amount": 250
+          "comment": "Quality Gala Mushroom",
+          "item_id": 7994,
+          "num": 7
         },
         {
-            "type": "exp",
-            "amount": 6809
-        },
-        {
-            "type": "select",
-            "loot_pool": [
-                {
-                    "item_id": 11506,
-                    "num": 3
-                },
-                {
-                    "item_id": 7994,
-                    "num": 7
-                },
-                {
-                    "item_id": 7555,
-                    "num": 3
-                }
-            ]
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
         }
-    ],
-    "enemy_groups" : [
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 320,
+        "group_id": 4
+      },
+      "starting_index": 6,
+      "enemies": [
         {
-            "stage_id": {
-                "id": 320,
-                "group_id": 11
-            },			
-            "enemies": [
-                {
-                    "enemy_id": "0x015600",
-                    "level": 60,
-                    "exp": 37000,
-                    "is_boss": true
+          "comment": "Wight",
+          "enemy_id": "0x015600",
+          "level": 60,
+          "exp": 3783,
+          "is_boss": true
         },
         {
-                    "enemy_id": "0x015600",
-                    "level": 60,
-                    "exp": 37000,
-                    "is_boss": true					
-                }
-            ]
-        }
-    ],
-    "blocks": [
-        {
-            "type": "DiscoverEnemy",
-            "groups": [0]
+          "comment": "Wight",
+          "enemy_id": "0x015600",
+          "level": 60,
+          "exp": 3783,
+          "is_boss": true
         },
         {
-            "type": "KillGroup",
-            "announce_type": "Accept",
-            "reset_group": false,
-            "groups": [0]
+          "comment": "Infected Hobgoblin Fighter (Severe)",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 60,
+          "exp": 803
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter (Severe)",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 60,
+          "exp": 803
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter (Severe)",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 60,
+          "exp": 803
         }
-    ]
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 320,
+        "group_id": 11
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Infected Direwolf (Severe)",
+          "enemy_id": "0x010209",
+          "infection_type": 2,
+          "level": 60,
+          "exp": 752
+        },
+        {
+          "comment": "Infected Direwolf (Severe)",
+          "enemy_id": "0x010209",
+          "infection_type": 2,
+          "level": 60,
+          "exp": 752
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [
+            { "type": "EmHpLess", "Param1": 804, "Param2": 4, "Param3": 6, "Param4": 35 } ,
+            { "type": "EmHpLess", "Param1": 804, "Param2": 4, "Param3": 7, "Param4": 35 }
+          ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 804, "Param2": 4, "Param3": 6 } ,
+              { "type": "DieEnemy", "Param1": 804, "Param2": 4, "Param3": 7 } ,
+              { "type": "DieEnemy", "Param1": 804, "Param2": 4, "Param3": 8 } ,
+              { "type": "DieEnemy", "Param1": 804, "Param2": 4, "Param3": 9 } ,
+              { "type": "DieEnemy", "Param1": 804, "Param2": 4, "Param3": 10 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 804, "Param2": 11, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 804, "Param2": 11, "Param3": 2 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
+    }
+  ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
@@ -136,7 +136,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 502, "Param2": 1, "Param3": 9, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 502, "Param2": 1, "Param3": 9, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "HidellPlains",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -26,17 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
-		  "comment": "Sacred Blessed Cloth",
+          "comment": "Sacred Blessed Cloth",
           "item_id": 7943,
           "num": 1
         },
         {
-		  "comment": "Cedar Wood",
+          "comment": "Cedar Wood",
           "item_id": 7967,
           "num": 2
         },
         {
-		  "comment": "Superior Healing Remedy",
+          "comment": "Superior Healing Remedy",
           "item_id": 7555,
           "num": 3
         }
@@ -49,7 +50,7 @@
         "id": 87,
         "group_id": 1
       },
-	  "starting_index": 9,
+      "starting_index": 9,
       "enemies": [
         {
           "comment": "Infected Gorecyclops (Severe)",
@@ -67,61 +68,131 @@
         "group_id": 7
       },
       "enemies": [
-	    {
-		  "comment": "Goblin Bomber",
-		  "enemy_id": "0x011150",
-		  "level": 57,
-		  "exp": 656
-		},
-		{
-		  "comment": "Goblin Bomber",
-		  "enemy_id": "0x011150",
-		  "level": 57,
-		  "exp": 656
-	    },
-		{
-		  "comment": "Goblin Bomber",
-		  "enemy_id": "0x011150",
-		  "level": 57,
-		  "exp": 656
-		},
-		{
-		  "comment": "Goblin Bomber",
-		  "enemy_id": "0x011150",
-		  "level": 57,
-		  "exp": 656
-		},
-		{
-		  "comment": "Goblin Bomber",
-		  "enemy_id": "0x011150",
-		  "level": 57,
-		  "exp": 656
-		}
+        {
+          "comment": "Goblin Bomber",
+          "enemy_id": "0x011150",
+          "level": 57,
+          "exp": 656
+        },
+        {
+          "comment": "Goblin Bomber",
+          "enemy_id": "0x011150",
+          "level": 57,
+          "exp": 656
+        },
+        {
+          "comment": "Goblin Bomber",
+          "enemy_id": "0x011150",
+          "level": 57,
+          "exp": 656
+        },
+        {
+          "comment": "Goblin Bomber",
+          "enemy_id": "0x011150",
+          "level": 57,
+          "exp": 656
+        },
+        {
+          "comment": "Goblin Bomber",
+          "enemy_id": "0x011150",
+          "level": 57,
+          "exp": 656
+        }
       ]
     }
   ],
-  "blocks": [
+  "processes": [
     {
-      "type": "DiscoverEnemy",
-      "groups": [0]
+      "blocks": [
+        {
+          "comment": "This dungeon is unlocked early, so a check is necessary",
+          "type": "Raw",
+          "check_commands": [ { "type": "CheckAreaRank", "Param1": 1, "Param1": 13 } ]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
     },
     {
-      "type": "WeakenGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [0],
-	  "percent": 35
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [ { "type": "EmHpLess", "Param1": 502, "Param2": 1, "Param3": 9, "Param4": 35 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands":  [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [1]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [ { "type": "DieEnemy", "Param1": 502, "Param2": 1, "Param3": 9 } ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 502, "Param2": 7, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 502, "Param2": 7, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 502, "Param2": 7, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 502, "Param2": 7, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 502, "Param2": 7, "Param3": 4 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
@@ -1,0 +1,131 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Punish Grave-Robbing",
+  "quest_id": 21000017,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MysreeForest",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 13814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Unappraised Star Trinket (General)",
+          "item_id": 13480,
+          "num": 3
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 430,
+        "group_id": 3
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops (Slight)",
+          "enemy_id": "0x015012",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 6675,
+          "is_boss": true
+        },
+        {
+          "comment": "Troll",
+          "enemy_id": "0x015040",
+          "level": 65,
+          "exp": 6675,
+          "is_boss": true
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 430,
+        "group_id": 16
+      },
+      "enemies": [
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 70,
+          "exp": 1335
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [0]
+    },
+    {
+      "type": "Raw",
+      "announce_type": "Accept",
+      "check_commands": [ { "type": "EmHpLess", "Param1": 870, "Param2": 3, "Param3": 4, "Param4": 35 } ] 
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "reset_group": false,
+      "groups": [0]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "MysreeForest",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 3, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -107,25 +108,96 @@
       ]
     }
   ],
-  "blocks": [
+  "processes": [
     {
-      "type": "DiscoverEnemy",
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
     },
     {
-      "type": "Raw",
-      "announce_type": "Accept",
-      "check_commands": [ { "type": "EmHpLess", "Param1": 870, "Param2": 3, "Param3": 4, "Param4": 35 } ] 
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [ { "type": "EmHpLess", "Param1": 870, "Param2": 3, "Param3": 4, "Param4": 35 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [1]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [
+            { "type": "DieEnemy", "Param1": 870, "Param2": 3, "Param3": 4 } ,
+            { "type": "DieEnemy", "Param1": 870, "Param2": 3, "Param3": 5 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "reset_group": false,
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 870, "Param2": 16, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 870, "Param2": 16, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 870, "Param2": 16, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 870, "Param2": 16, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 870, "Param2": 16, "Param3": 4 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
@@ -138,7 +138,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 870, "Param2": 3, "Param3": 4, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 870, "Param2": 3, "Param3": 4, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
@@ -118,7 +118,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 583, "Param2": 3, "Param3": 4, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 583, "Param2": 3, "Param3": 4, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
@@ -1,107 +1,84 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Place of Regrets",
-  "quest_id": 21000090,
+  "comment": "A Gush of Wickedness",
+  "quest_id": 21000033,
   "base_level": 65,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "area_id": "MergodaRuins",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
+  "area_id": "VoldenMines",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 13 } ],
   "rewards": [
+    {
+      "type": "exp",
+      "amount": 7034
+    },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 2243
+      "amount": 2144
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 290
-    },
-    {
-      "type": "exp",
-      "amount": 10665
+      "amount": 275
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Gold-Stained Animal Fur",
-          "item_id": 11803,
-          "num": 3
+          "comment": "Gold Ingot",
+          "item_id": 7877,
+          "num": 2
         },
         {
-          "comment": "Superior Healing Remedy",
-          "item_id": 7555,
-          "num": 3
+          "comment": "Moonglow",
+          "item_id": 7981,
+          "num": 5
         },
         {
-          "comment": "Superior Strong Gala Extract",
-          "item_id": 9364,
+          "comment": "Panacea",
+          "item_id": 41,
           "num": 3
         }
       ]
     }
   ],
-  "enemy_groups": [
+  "enemy_groups" : [
     {
       "stage_id": {
-        "id": 424,
-        "group_id": 2
+        "id": 152,
+        "group_id": 3
       },
-      "starting_index": 9,
+      "starting_index": 4,
       "enemies": [
         {
-          "comment": "Infected Gorecyclops - Severe",
+          "comment": "Infected Gorecyclops (Severe)",
           "enemy_id": "0x015012",
-          "infection_type": 2,
           "level": 65,
-          "exp": 3743,
-          "is_boss": true
+          "exp": 3908,
+          "is_boss": true,
+          "infection_type": 2
         }
       ]
     },
     {
       "stage_id": {
-        "id": 424,
-        "group_id": 6
+        "id": 152,
+        "group_id": 8
       },
       "enemies": [
         {
-          "comment": "Bolt Skeleton",
-          "enemy_id": "0x010316",
-          "start_think_tbl_no": 2,
+          "comment": "Skull Lord",
+          "enemy_id": "0x010313",
           "level": 65,
-          "exp": 788
+          "exp": 781
         },
         {
-          "comment": "Bolt Skeleton",
-          "enemy_id": "0x010316",
-          "start_think_tbl_no": 2,
+          "comment": "Skull Lord",
+          "enemy_id": "0x010313",
           "level": 65,
-          "exp": 788
-        },
-        {
-          "comment": "Bolt Skeleton",
-          "enemy_id": "0x010316",
-          "start_think_tbl_no": 2,
-          "level": 65,
-          "exp": 788
-        },
-        {
-          "comment": "Bolt Skeleton",
-          "enemy_id": "0x010316",
-          "start_think_tbl_no": 2,
-          "level": 65,
-          "exp": 788
-        },
-        {
-          "comment": "Bolt Skeleton",
-          "enemy_id": "0x010316",
-          "start_think_tbl_no": 2,
-          "level": 65,
-          "exp": 788
+          "exp": 781
         }
       ]
     }
@@ -109,6 +86,11 @@
   "processes": [
     {
       "blocks": [
+        {
+          "comment": "This dungeon is unlocked early, so a check is necessary",
+          "type": "Raw",
+          "check_commands": [ { "type": "CheckAreaRank", "Param1": 4, "Param1": 13 } ]
+        },
         {
           "type": "DiscoverEnemy",
           "groups": [0]
@@ -136,7 +118,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 843, "Param2": 2, "Param3": 9, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 583, "Param2": 3, "Param3": 4, "Param4": 35 } ]
         },
         {
           "type": "SpawnGroup",
@@ -150,7 +132,7 @@
         {
           "comment": "Group 1 is dead and group 0 is still alive, update announcement",
           "type": "Raw",
-          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+          "result_commands":  [ { "type": "UpdateAnnounce", "Param1": 3 } ]
         }
       ]
     },
@@ -163,7 +145,7 @@
         {
           "comment": "Is group 0 dead",
           "type": "Raw",
-          "check_commands": [ { "type": "DieEnemy", "Param1": 843, "Param2": 2, "Param3": 9 } ]
+          "check_commands": [ { "type": "DieEnemy", "Param1": 583, "Param2": 3, "Param3": 4 } ]
         },
         {
           "type": "MyQstFlags",
@@ -175,17 +157,14 @@
       "blocks": [
         {
           "type": "Raw",
-          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
         },
         {
           "comment": "Is group 1 dead",
           "type": "Raw",
           "check_commands": [
-              { "type": "DieEnemy", "Param1": 843, "Param2": 6, "Param3": 0 } ,
-              { "type": "DieEnemy", "Param1": 843, "Param2": 6, "Param3": 1 } ,
-              { "type": "DieEnemy", "Param1": 843, "Param2": 6, "Param3": 2 } ,
-              { "type": "DieEnemy", "Param1": 843, "Param2": 6, "Param3": 3 } ,
-              { "type": "DieEnemy", "Param1": 843, "Param2": 6, "Param3": 4 }
+              { "type": "DieEnemy", "Param1": 583, "Param2": 8, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 583, "Param2": 8, "Param3": 1 } 
           ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000037.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000037.json
@@ -1,96 +1,223 @@
 {
-    "state_machine": "GenericStateMachine",
-    "type": "World",
-    "comment": "Within This Beautiful Scenery",
-    "quest_id": 21000037,
-    "base_level": 63,
-    "minimum_item_rank": 0,
-    "discoverable": false,
-	"area_id": "BloodbaneIsle",	
-    "rewards": [
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Within This Beautiful Scenery",
+  "quest_id": 21000037,
+  "base_level": 63,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BloodbaneIsle",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 13, "Param2": 4 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 6976
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2078
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 265
+    },
+    {
+      "type": "select",
+      "loot_pool": [
         {
-            "type": "wallet",
-            "wallet_type": "Gold",
-            "amount": 2078
+          "comment": "Discolored Spore-covered Feather",
+          "item_id": 13223,
+          "num": 1
         },
         {
-            "type": "wallet",
-            "wallet_type": "RiftPoints",
-            "amount": 265
+          "comment": "Moonglow",
+          "item_id": 7981,
+          "num": 5
         },
         {
-            "type": "exp",
-            "amount": 6976
-        },
-        {
-            "type": "select",
-            "loot_pool": [
-                {
-                    "item_id": 13223,
-                    "num": 1
-                },
-                {
-                    "item_id": 7981,
-                    "num": 5
-                },
-                {
-                    "item_id": 7555,
-                    "num": 3
-                }
-            ]
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
         }
-    ],
-    "enemy_groups" : [
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 335,
+        "group_id": 1
+      },
+      "starting_index": 2,
+      "enemies": [
         {
-            "stage_id": {
-                "id": 335,
-                "group_id": 11
-            },			
-            "enemies": [
-                {
-                    "enemy_id": "0x015306",
-                    "level": 63,
-                    "exp": 42000,
-                    "is_boss": true,
-                    "infection_type": 2	
+          "comment": "Infected Griffin (Slight)",
+          "enemy_id": "0x015306",
+          "infection_type": 1,
+          "level": 63,
+          "exp": 8800,
+          "is_boss": true
         },
         {
-                    "enemy_id": "0x010603",
-                    "level": 63,
-                    "exp": 2000,
-                    "is_boss": false
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 63,
+          "exp": 352,
+          "repop_count": 1,
+          "repop_wait_second": 10
         },
         {
-                    "enemy_id": "0x010603",
-                    "level": 63,
-                    "exp": 2000,
-                    "is_boss": false
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 63,
+          "exp": 352
         },
         {
-                    "enemy_id": "0x010603",
-                    "level": 63,
-                    "exp": 2000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010160",
-                    "level": 63,
-                    "exp": 2000,
-                    "is_boss": false					
-                }
-            ]
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 63,
+          "exp": 352
         }
-    ],
-    "blocks": [
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 335,
+        "group_id": 11
+      },
+      "enemies": [
         {
-            "type": "DiscoverEnemy",
-            "groups": [0]
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 3,
+          "level": 63,
+          "exp": 457
         },
         {
-            "type": "KillGroup",
-            "announce_type": "Accept",
-            "reset_group": false,
-            "groups": [0]
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 3,
+          "level": 63,
+          "exp": 457
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 3,
+          "level": 63,
+          "exp": 457
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 3,
+          "level": 63,
+          "exp": 457
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 3,
+          "level": 63,
+          "exp": 457
         }
-    ]
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [ { "type": "EmHpLess", "Param1": 110, "Param2": 1, "Param3": 2, "Param4": 40 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 110, "Param2": 1, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 1, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 1, "Param3": 4 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 1, "Param3": 5 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 110, "Param2": 11, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 11, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 11, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 11, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 110, "Param2": 11, "Param3": 4 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
+    }
+  ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000040.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000040.json
@@ -1,13 +1,13 @@
-{
+	{
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Monstrous Rampage",
-  "quest_id": 21000003,
-  "base_level": 63,
+  "comment": "The Cursed Sanctuary",
+  "quest_id": 21000040,
+  "base_level": 60,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "area_id": "BreyaCoast",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 13 } ],
+  "area_id": "MysreeGrove",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -27,14 +27,14 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Corroded Giant Eyeball",
-          "item_id": 11774,
+          "comment": "Discolored Spore-Covered Feather",
+          "item_id": 13223,
           "num": 1
         },
         {
-          "comment": "Quality Gala Mushroom",
-          "item_id": 7994,
-          "num": 7
+          "comment": "Blue Alluvial Gold",
+          "item_id": 7848,
+          "num": 3
         },
         {
           "comment": "Superior Healing Remedy",
@@ -47,81 +47,90 @@
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 333,
-        "group_id": 4
+        "id": 427,
+        "group_id": 10
       },
-      "placement_type": "manual",
+      "starting_index": 7,
       "enemies": [
         {
-          "comment": "Infected Gorecyclops (Slight)",
-          "enemy_id": "0x015012",
+          "comment": "Infected Griffin (Severe)",
+          "enemy_id": "0x015306",
+          "infection_type": 2,
           "level": 60,
           "exp": 3783,
-          "is_boss": true,
-          "infection_type": 1,
-          "index": 5
+          "is_boss": true
         },
         {
-          "comment": "Infected Direwolf",
-          "enemy_id": "0x010209",
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
           "level": 60,
-          "exp": 756,
-          "index": 7
+          "exp": 756
         },
         {
-          "comment": "Infected Direwolf",
-          "enemy_id": "0x010209",
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
           "level": 60,
-          "exp": 756,
-          "index": 8
+          "exp": 756
         },
         {
-          "comment": "Infected Direwolf",
-          "enemy_id": "0x010209",
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
           "level": 60,
-          "exp": 756,
-          "index": 9
+          "exp": 756
         }
       ]
     },
     {
       "stage_id": {
-        "id": 333,
-        "group_id": 9
+        "id": 427,
+        "group_id": 17
       },
       "enemies": [
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
-          "start_think_tbl_no": 2,
+          "comment": "Infected Snow Harpy (Severe)",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "start_think_tbl_no": 3,
           "level": 60,
           "exp": 756
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
-          "start_think_tbl_no": 2,
+          "comment": "Infected Snow Harpy (Severe)",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "start_think_tbl_no": 3,
           "level": 60,
           "exp": 756
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
-          "start_think_tbl_no": 2,
+          "comment": "Infected Snow Harpy (Severe)",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "start_think_tbl_no": 3,
           "level": 60,
           "exp": 756
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
-          "start_think_tbl_no": 2,
+          "comment": "Infected Snow Harpy (Severe)",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "start_think_tbl_no": 3,
           "level": 60,
           "exp": 756
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
-          "start_think_tbl_no": 2,
+          "comment": "Infected Snow Harpy (Severe)",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "start_think_tbl_no": 3,
+          "level": 60,
+          "exp": 756
+        },
+        {
+          "comment": "Infected Snow Harpy (Severe)",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "start_think_tbl_no": 3,
           "level": 60,
           "exp": 756
         }
@@ -133,8 +142,7 @@
       "blocks": [
         {
           "type": "DiscoverEnemy",
-          "groups": [0],
-          "result_commands": [ { "type": "QstLayoutFlagOn", "Param1": 3007 } ]
+          "groups": [0]
         },
         {
           "type": "KillGroup",
@@ -159,7 +167,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 824, "Param2": 4, "Param3": 5, "Param4": 40 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 850, "Param2": 10, "Param3": 7, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",
@@ -187,10 +195,10 @@
           "comment": "Is group 0 dead",
           "type": "Raw",
           "check_commands": [
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 5 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 7 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 8 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 9 }
+              { "type": "DieEnemy", "Param1": 850, "Param2": 10, "Param3": 7 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 10, "Param3": 8 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 10, "Param3": 9 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 10, "Param3": 10 }
           ]
         },
         {
@@ -209,11 +217,12 @@
           "comment": "Is group 1 dead",
           "type": "Raw",
           "check_commands": [
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 0 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 1 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 2 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 3 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 4 }
+              { "type": "DieEnemy", "Param1": 850, "Param2": 17, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 17, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 17, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 17, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 17, "Param3": 4 } ,
+              { "type": "DieEnemy", "Param1": 850, "Param2": 17, "Param3": 5 }
           ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000050.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000050.json
@@ -1,0 +1,162 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Pain of Homesickness",
+  "quest_id": 21000050,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 12014
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Manticore's Scorpion Tail",
+          "item_id": 11805,
+          "num": 1
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 117,
+        "group_id": 2
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Manticore",
+          "enemy_id": "0x015210",
+          "start_think_tbl_no": 1,
+          "level": 70,
+          "exp": 6675,
+          "is_boss": true
+        },
+        {
+          "comment": "Bolt Corpse Torturer",
+          "enemy_id": "0x010518",
+          "start_think_tbl_no": 1,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Corpse Torturer",
+          "enemy_id": "0x010518",
+          "start_think_tbl_no": 1,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Lux Corpse Torturer",
+          "enemy_id": "0x010519",
+          "start_think_tbl_no": 1,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Lux Corpse Torturer",
+          "enemy_id": "0x010519",
+          "start_think_tbl_no": 1,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Lux Corpse Torturer",
+          "enemy_id": "0x010519",
+          "start_think_tbl_no": 1,
+          "level": 70,
+          "exp": 1335
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 14
+      },
+      "npc_id": "Mubarak",
+      "message_id": 17256
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 14
+      },
+      "npc_id": "Mubarak",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1503,
+          "Param2": 17257
+        }
+      ],
+      "items": [
+        {
+          "comment": "Electrum Plate",
+          "id": 7891,
+          "amount": 2
+        }
+      ],
+      "message_id": 17258
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1600,
+          "Param2": 17259
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 14
+      },
+      "announce_type": "Update",
+      "npc_id": "Mubarak",
+      "message_id": 17260
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
@@ -151,7 +151,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 820, "Param2": 7, "Param3": 3, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 820, "Param2": 7, "Param3": 3, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DoweValley",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 5, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -120,25 +121,97 @@
       ]
     }
   ],
-  "blocks": [
+  "processes": [
     {
-      "type": "DiscoverEnemy",
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
     },
     {
-      "type": "Raw",
-      "announce_type": "Accept",
-      "check_commands": [ { "type": "EmHpLess", "Param1": 820, "Param2": 7, "Param3": 3, "Param4": 35 } ] 
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [ { "type": "EmHpLess", "Param1": 820, "Param2": 7, "Param3": 3, "Param4": 35 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [1]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 820, "Param2": 7, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 820, "Param2": 7, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 820, "Param2": 7, "Param3": 4 } ,
+              { "type": "DieEnemy", "Param1": 820, "Param2": 7, "Param3": 6 } 
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "reset_group": false,
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 820, "Param2": 8, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 820, "Param2": 8, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 820, "Param2": 8, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 820, "Param2": 8, "Param3": 3 } 
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
@@ -1,0 +1,144 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "A Situation in the Waterway",
+  "quest_id": 21000051,
+  "base_level": 68,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 10665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2243
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 290
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Prism Crystal",
+          "item_id": 11808,
+          "num": 3
+        },
+        {
+          "comment": "Gleipnir",
+          "item_id": 7959,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 329,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 68,
+          "exp": 1185,
+          "index": 0
+        },
+        {
+          "comment": "Infected Gorecyclops (Severe)",
+          "enemy_id": "0x015012",
+          "level": 60,
+          "exp": 5925,
+          "is_boss": true,
+          "infection_type": 2,
+          "index": 3
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 60,
+          "exp": 1185,
+          "index": 4
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 60,
+          "exp": 1185,
+          "index": 6
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 329,
+        "group_id": 8
+      },
+      "enemies": [
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "start_think_tbl_no": 2,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "start_think_tbl_no": 2,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "start_think_tbl_no": 2,
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "start_think_tbl_no": 2,
+          "level": 68,
+          "exp": 1185
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [0]
+    },
+    {
+      "type": "Raw",
+      "announce_type": "Accept",
+      "check_commands": [ { "type": "EmHpLess", "Param1": 820, "Param2": 7, "Param3": 3, "Param4": 35 } ] 
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "reset_group": false,
+      "groups": [0]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000052.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000052.json
@@ -1,0 +1,158 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "An Unworthy Opponent",
+  "quest_id": 21000052,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 7092
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Unappraised Star Trinket (Soldier)",
+          "item_id": 13479,
+          "num": 3
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 332,
+        "group_id": 10
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Sphinx",
+          "enemy_id": "0x015302",
+          "level": 65,
+          "exp": 3940,
+          "is_boss": true
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 788
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Goltas",
+      "message_id": 17261
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 1504,
+          "Param2": 17262
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 1
+      },
+      "announce_type": "Update",
+      "npc_id": "Goltas",
+      "message_id": 17263
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
@@ -136,7 +136,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 851, "Param2": 5, "Param3": 5, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 851, "Param2": 5, "Param3": 5, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DeenanWoods",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
   "rewards": [
     {
       "type": "wallet",
@@ -104,29 +105,94 @@
         }
       ]
     }
-  ], 
-  "blocks": [
+  ],
+  "processes": [
     {
-      "type": "DiscoverEnemy",
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
     },
     {
-      "type": "WeakenGroup",
-      "announce_type": "Accept",
-      "reset_group": false,
-      "groups": [0],
-      "percent": 35
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [ { "type": "EmHpLess", "Param1": 851, "Param2": 5, "Param3": 5, "Param4": 35 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [1]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [ { "type": "DieEnemy", "Param1": 851, "Param2": 5, "Param3": 5 } ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 851, "Param2": 14, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 851, "Param2": 14, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 851, "Param2": 14, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 851, "Param2": 14, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 851, "Param2": 14, "Param3": 4 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000061.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000061.json
@@ -1,44 +1,44 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Monstrous Rampage",
-  "quest_id": 21000003,
-  "base_level": 63,
+  "comment": "The Evil Resounding in the Cave",
+  "quest_id": 21000061,
+  "base_level": 65,
   "minimum_item_rank": 0,
   "discoverable": false,
-  "area_id": "BreyaCoast",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 13 } ],
+  "area_id": "BloodbaneIsle",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 13, "Param2": 11 } ],
   "rewards": [
     {
       "type": "exp",
-      "amount": 6976
+      "amount": 28000
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 2078
+      "amount": 3630
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 265
+      "amount": 360
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Corroded Giant Eyeball",
-          "item_id": 11774,
-          "num": 1
-        },
-        {
-          "comment": "Quality Gala Mushroom",
-          "item_id": 7994,
-          "num": 7
-        },
-        {
           "comment": "Superior Healing Remedy",
           "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
           "num": 3
         }
       ]
@@ -47,83 +47,82 @@
   "enemy_groups": [
     {
       "stage_id": {
-        "id": 333,
-        "group_id": 4
+        "id": 408,
+        "group_id": 1
       },
-      "placement_type": "manual",
+      "starting_index": 4,
       "enemies": [
         {
-          "comment": "Infected Gorecyclops (Slight)",
-          "enemy_id": "0x015012",
-          "level": 60,
-          "exp": 3783,
-          "is_boss": true,
-          "infection_type": 1,
-          "index": 5
+          "comment": "Bounty Frost Machina",
+          "enemy_id": "0x015851",
+          "named_enemy_params_id": 458,
+          "level": 65,
+          "exp": 55167,
+          "is_boss": true
         },
         {
-          "comment": "Infected Direwolf",
+          "comment": "Bounty Infected Direwolf (Severe)",
           "enemy_id": "0x010209",
-          "level": 60,
-          "exp": 756,
-          "index": 7
+          "named_enemy_params_id": 458,
+          "infection_type": 2,
+          "level": 65,
+          "exp": 720
         },
         {
-          "comment": "Infected Direwolf",
+          "comment": "Bounty Infected Direwolf (Severe)",
           "enemy_id": "0x010209",
-          "level": 60,
-          "exp": 756,
-          "index": 8
-        },
-        {
-          "comment": "Infected Direwolf",
-          "enemy_id": "0x010209",
-          "level": 60,
-          "exp": 756,
-          "index": 9
+          "named_enemy_params_id": 458,
+          "infection_type": 2,
+          "level": 65,
+          "exp": 720
         }
       ]
     },
     {
       "stage_id": {
-        "id": 333,
-        "group_id": 9
+        "id": 408,
+        "group_id": 16
       },
       "enemies": [
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
+          "comment": "Bounty Flame Skeleton",
+          "enemy_id": "0x010314",
+          "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
-          "level": 60,
-          "exp": 756
+          "level": 65,
+          "exp": 792
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
+          "comment": "Bounty Flame Skeleton",
+          "enemy_id": "0x010314",
+          "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
-          "level": 60,
-          "exp": 756
+          "level": 65,
+          "exp": 792
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
+          "comment": "Bounty Flame Skeleton",
+          "enemy_id": "0x010314",
+          "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
-          "level": 60,
-          "exp": 756
+          "level": 65,
+          "exp": 792
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
+          "comment": "Bounty Flame Skeleton",
+          "enemy_id": "0x010314",
+          "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
-          "level": 60,
-          "exp": 756
+          "level": 65,
+          "exp": 792
         },
         {
-          "comment": "Lux Skeleton",
-          "enemy_id": "0x010317",
+          "comment": "Bounty Flame Skeleton",
+          "enemy_id": "0x010314",
+          "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
-          "level": 60,
-          "exp": 756
+          "level": 65,
+          "exp": 792
         }
       ]
     }
@@ -133,8 +132,7 @@
       "blocks": [
         {
           "type": "DiscoverEnemy",
-          "groups": [0],
-          "result_commands": [ { "type": "QstLayoutFlagOn", "Param1": 3007 } ]
+          "groups": [0]
         },
         {
           "type": "KillGroup",
@@ -159,7 +157,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 824, "Param2": 4, "Param3": 5, "Param4": 40 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 807, "Param2": 1, "Param3": 4, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",
@@ -187,10 +185,9 @@
           "comment": "Is group 0 dead",
           "type": "Raw",
           "check_commands": [
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 5 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 7 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 8 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 4, "Param3": 9 }
+              { "type": "DieEnemy", "Param1": 807, "Param2": 1, "Param3": 4 } ,
+              { "type": "DieEnemy", "Param1": 807, "Param2": 1, "Param3": 5 } ,
+              { "type": "DieEnemy", "Param1": 807, "Param2": 1, "Param3": 6 }
           ]
         },
         {
@@ -209,11 +206,11 @@
           "comment": "Is group 1 dead",
           "type": "Raw",
           "check_commands": [
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 0 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 1 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 2 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 3 } ,
-              { "type": "DieEnemy", "Param1": 824, "Param2": 9, "Param3": 4 }
+              { "type": "DieEnemy", "Param1": 807, "Param2": 16, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 807, "Param2": 16, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 807, "Param2": 16, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 807, "Param2": 16, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 807, "Param2": 16, "Param3": 4 }
           ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000064.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000064.json
@@ -1,0 +1,403 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Desolate Land",
+  "quest_id": 21000064,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DoweValley",
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 18420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Herculean Power (Burning)",
+          "item_id": 16030,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Superior Magick (Burning)",
+          "item_id": 16035,
+          "num": 1
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 165,
+        "group_id": 2
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Medusa",
+          "enemy_id": "0x015610",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1185
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 364,
+        "group_id": 2
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 364,
+        "group_id": 5
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Dread Ape",
+          "enemy_id": "0x015502",
+          "level": 70,
+          "exp": 5925,
+          "is_boss": true
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 364,
+        "group_id": 4
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Lindwurm",
+          "enemy_id": "0x015707",
+          "level": 70,
+          "exp": 6675,
+          "is_boss": true
+        },
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1185
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 48
+          },
+          "npc_id": "Hayden",
+          "message_id": 17265
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 1508,
+              "Param2": 17266
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 48
+          },
+          "npc_id": "Hayden",
+          "message_id": 17267
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000070.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000070.json
@@ -1,0 +1,239 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Living Hell",
+  "quest_id": 21000070,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "NorthernBetlandPlains",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 9, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 12014
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Medusa's Serpent Hair",
+          "item_id": 13224,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 334,
+        "group_id": 6
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Medusa",
+          "enemy_id": "0x015610",
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Medusa",
+          "enemy_id": "0x015610",
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Dark Corpse Punisher",
+          "enemy_id": "0x010516",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 5
+        },
+        {
+          "comment": "Dark Corpse Punisher",
+          "enemy_id": "0x010516",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 6
+        },
+        {
+          "comment": "Dark Corpse Punisher",
+          "enemy_id": "0x010516",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 7
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 334,
+        "group_id": 9
+      },
+      "enemies": [
+        {
+          "comment": "Infected Orc Vanguard (Severe)",
+          "enemy_id": "0x015815",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Orc Vanguard (Severe)",
+          "enemy_id": "0x015815",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Orc Vanguard (Severe)",
+          "enemy_id": "0x015815",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Orc Vanguard (Severe)",
+          "enemy_id": "0x015815",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Infected Orc Vanguard (Severe)",
+          "enemy_id": "0x015815",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1335
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "DiscoverEnemy",
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "announce_type": "Accept",
+          "groups": [0],
+          "result_commands": [ { "type": "MyQstFlagOn",  "Param1": 2 } ]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "groups": [1]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Group 0 boss HP check",
+          "type": "Raw",
+          "check_commands": [
+            { "type": "EmHpLess", "Param1": 825, "Param2": 6, "Param3": 0, "Param4": 40 } ,
+            { "type": "EmHpLess", "Param1": 825, "Param2": 6, "Param3": 1, "Param4": 40 }
+          ]
+        },
+        {
+          "type": "SpawnGroup",
+          "announce_type": "Update",
+          "groups": [1],
+          "check_commands": [
+            { "type": "MyQstFlagOff", "Param1": 0 },
+            { "type": "MyQstFlagOn",  "Param1": 1 }
+          ]
+        },
+        {
+          "comment": "Group 1 is dead and group 0 is still alive, update announcement",
+          "type": "Raw",
+          "result_commands": [ { "type": "UpdateAnnounce", "Param1": 3 } ]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 0 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 825, "Param2": 6, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 6, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 6, "Param3": 5 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 6, "Param3": 6 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 6, "Param3": 7 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [0]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 2 } ]
+        },
+        {
+          "comment": "Is group 1 dead",
+          "type": "Raw",
+          "check_commands": [
+              { "type": "DieEnemy", "Param1": 825, "Param2": 9, "Param3": 0 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 9, "Param3": 1 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 9, "Param3": 2 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 9, "Param3": 3 } ,
+              { "type": "DieEnemy", "Param1": 825, "Param2": 9, "Param3": 4 }
+          ]
+        },
+        {
+          "type": "MyQstFlags",
+          "set_flags": [1]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000090.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000090.json
@@ -136,7 +136,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [ { "type": "EmHpLess", "Param1": 843, "Param2": 2, "Param3": 9, "Param4": 35 } ]
+          "check_commands": [ { "type": "EmHpLess", "Param1": 843, "Param2": 2, "Param3": 9, "Param4": 40 } ]
         },
         {
           "type": "SpawnGroup",


### PR DESCRIPTION
Notable changes:

q20000014 - Variants base level changed.

q20020000 - Added variant.

q20030001 - Stage ID and delivery item updated.
q20030002 - Added variant.
q20030003 and variants - Index moved to 4.
q20030004 and variant - Minor rewards change, behaviour changed to stand still.
q20030005 and variant - Indexes moved, Mudmen are now summoned by the Empress Ghost.
q20030007 - Index moved to 7, added two variants.
q20030008 - Rewards change, index moved to 1.

q20035001 - Index moved to 1, rewards change, added variant.
q20035002 - Index moved to 9 and above, added two variants.
q20035003 - Added.
q20035004 - Added, plus a variant.
q20035005 - Indexes moved across variants, random rewards change for the first index.
q20035006 - Clear rewards updated, indexes moved, added repops.
q20035007 - Group ID moved to 8, index moved to 1, added variant.
q20035008 - Index moved to 11, so boss is now behind a breakable wall. (yes, that is really intended. https://www.youtube.com/watch?v=04gjNLLuB6A)
q20035009_2 - Boss changed from Mist Drake to Mist Wyrm.

q21000000 - Added, but indexes are probably not very accurate for the last group. If you've got time, help a lad out! https://www.youtube.com/watch?v=tZSixc8wH-k
q21000017 - Added.
q21000033 - Added.
q21000050 - Added.
q21000051 - Added.
q21000052 - Added.
q21000064 - Added, but enemy exp is probably inaccurate.

q21000003 - Reworked to fix the following issues:
- If you teleported back to WDT or quit the game before completing the quest, the required monsters would not spawn.
- If you killed the newly spawned group before the first, you were supposed to get an announcement update.
q21000013 - Ditto, and added an area rank check raw block.
q21000053 - Ditto.
q21000090 - Ditto.

q21000009 - Reviewed, now works like the quests above.