### PR TITLE
feat: Add support to reward JP from items

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ExpManager.cs
@@ -587,6 +587,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
         {
             PacketQueue packets = new(); // Only ever has one packet, but has to exist because there are problems with returning interface types
             CDataCharacterJobData? activeCharacterJobData = characterToJpExpTo.ActiveCharacterJobData;
+
+            uint totalJobPoint = activeCharacterJobData.JobPoint + gainedJp;
+            if (totalJobPoint > _Server.GameSettings.GameServerSettings.JobPointMax)
+            {
+                uint extra = (totalJobPoint - _Server.GameSettings.GameServerSettings.JobPointMax);
+                gainedJp = (extra > gainedJp) ? 0 : (gainedJp - extra);
+            }
+            
             activeCharacterJobData.JobPoint += gainedJp;
 
             if (characterToJpExpTo is Character)
@@ -613,8 +621,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 client.Enqueue(jpNtc, packets);
             }
 
-            // PERSIST CHANGES IN DB
-            _Server.Database.UpdateCharacterJobData(characterToJpExpTo.CommonId, activeCharacterJobData, connectionIn);
+            if (gainedJp > 0)
+            {
+                // PERSIST CHANGES IN DB
+                _Server.Database.UpdateCharacterJobData(characterToJpExpTo.CommonId, activeCharacterJobData, connectionIn);
+            }
 
             return packets;
         }

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using Arrowgene.Ddon.Database;
 using Arrowgene.Ddon.Database.Model;
+using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
@@ -91,6 +92,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             {ItemId.ExperienceCrystal0, (PointType.ExperiencePoints, 10)},
             {ItemId.ExperienceCrystal1, (PointType.ExperiencePoints, 10000)},
             {ItemId.ExperienceCrystal2, (PointType.ExperiencePoints, 63000)},
+            {ItemId.JobPoint, (PointType.JobPoints, 10)}
         };
 
         private static readonly Dictionary<ItemId, uint> AbilityItems = new Dictionary<ItemId, uint>()
@@ -246,6 +248,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
                         break;
                     case PointType.PlayPoints:
                         queue.Enqueue(client, _Server.PPManager.AddPlayPoint(client, gainedPoints, connectionIn: connectionIn));
+                        break;
+                    case PointType.JobPoints:
+                        queue.AddRange(_Server.ExpManager.AddJp(client, client.Character, gainedPoints.Item1, RewardSource.Enemy, connectionIn: connectionIn));
                         break;
                 }
                 return (queue, true);

--- a/Arrowgene.Ddon.GameServer/Handler/ServerGetGameSettingHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ServerGetGameSettingHandler.cs
@@ -21,6 +21,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var res = new S2CServerGetGameSettingRes.Serializer().Read(GameDump.Dump_10.AsBuffer());
 
             res.GameSetting.JobLevelMax = Server.GameSettings.GameServerSettings.JobLevelMax;
+            res.GameSetting.JobPointMax = Server.GameSettings.GameServerSettings.JobPointMax;
+
             res.GameSetting.ExpRequiredPerLevel[0].ExpList = res.GameSetting.ExpRequiredPerLevel[0].ExpList.Take((int)res.GameSetting.JobLevelMax).ToList();
 
             res.GameSetting.EnableVisualEquip = Server.GameSettings.GameServerSettings.EnableVisualEquip;

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -368,6 +368,25 @@ namespace Arrowgene.Ddon.Server.Settings
         private const uint _JobLevelMax = 120;
 
         /// <summary>
+        /// The maximum job points which a job can own at a given time.
+        /// job points past this point will trigger a UI message saying
+        /// you can't earn anymore.
+        /// </summary>
+        [DefaultValue(_JobPointMax)]
+        public uint JobPointMax
+        {
+            set
+            {
+                SetSetting("JobPointMax", value);
+            }
+            get
+            {
+                return TryGetSetting("JobPointMax", _JobPointMax);
+            }
+        }
+        private const uint _JobPointMax = 500000;
+
+        /// <summary>
         /// Maximum number of members in a single clan. 
         /// Shared with the login server.
         /// </summary>


### PR DESCRIPTION
- Added support to earn JP by consuming job point items.
- Added a new game server setting to configure the maximum amount of JP which can be held at once per job. Set the default value to 50000 which was found in pcap.