### PR TITLE
Fix Partner Pawn Rewards - by Bunie

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 53;
+    public const uint Version = 54;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards_new"
+CREATE TABLE "ddon_partner_pawn_pending_rewards_new"
 (
     "character_id" INTEGER NOT NULL,
     "pawn_id"      INTEGER NOT NULL,
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards_new"
     CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );
 
-INSERT OR IGNORE INTO "ddon_partner_pawn_pending_rewards_new" ("character_id", "pawn_id", "reward_level")
+INSERT INTO "ddon_partner_pawn_pending_rewards_new" ("character_id", "pawn_id", "reward_level")
 SELECT "character_id", "pawn_id", "reward_level" FROM "ddon_partner_pawn_pending_rewards";
 
 DROP TABLE "ddon_partner_pawn_pending_rewards";

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
@@ -5,6 +5,7 @@ CREATE TABLE "ddon_partner_pawn_pending_rewards_new"
     "reward_level" INTEGER NOT NULL,
     CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id", "reward_level"),
     CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_pawn_id" FOREIGN KEY ("pawn_id") REFERENCES "ddon_pawn" ("pawn_id") ON DELETE CASCADE
 );
 
 INSERT INTO "ddon_partner_pawn_pending_rewards_new" ("character_id", "pawn_id", "reward_level")

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
@@ -4,7 +4,7 @@ CREATE TABLE "ddon_partner_pawn_pending_rewards_new"
     "pawn_id"      INTEGER NOT NULL,
     "reward_level" INTEGER NOT NULL,
     CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id", "reward_level"),
-    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE,
     CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_pawn_id" FOREIGN KEY ("pawn_id") REFERENCES "ddon_pawn" ("pawn_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_partner_pawn_pending_rewards_pk.sql‎
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards_new"
+(
+    "character_id" INTEGER NOT NULL,
+    "pawn_id"      INTEGER NOT NULL,
+    "reward_level" INTEGER NOT NULL,
+    CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id", "reward_level"),
+    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+);
+
+INSERT OR IGNORE INTO "ddon_partner_pawn_pending_rewards_new" ("character_id", "pawn_id", "reward_level")
+SELECT "character_id", "pawn_id", "reward_level" FROM "ddon_partner_pawn_pending_rewards";
+
+DROP TABLE "ddon_partner_pawn_pending_rewards";
+
+ALTER TABLE "ddon_partner_pawn_pending_rewards_new" RENAME TO "ddon_partner_pawn_pending_rewards";

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -867,6 +867,7 @@ CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards"
     "reward_level" INTEGER NOT NULL,
     CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id", "reward_level"),
     CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_pawn_id" FOREIGN KEY ("pawn_id") REFERENCES "ddon_pawn" ("pawn_id") ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS "ddon_achievement_progress"

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -866,7 +866,7 @@ CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards"
     "pawn_id"      INTEGER NOT NULL,
     "reward_level" INTEGER NOT NULL,
     CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id", "reward_level"),
-    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
+    CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE,
     CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_pawn_id" FOREIGN KEY ("pawn_id") REFERENCES "ddon_pawn" ("pawn_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -865,7 +865,7 @@ CREATE TABLE IF NOT EXISTS "ddon_partner_pawn_pending_rewards"
     "character_id" INTEGER NOT NULL,
     "pawn_id"      INTEGER NOT NULL,
     "reward_level" INTEGER NOT NULL,
-    CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id"),
+    CONSTRAINT "pk_ddon_partner_pawn_pending_rewards" PRIMARY KEY ("character_id", "pawn_id", "reward_level"),
     CONSTRAINT "fk_ddon_partner_pawn_pending_rewards_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );
 

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000054_PartnerPawnPendingRewardsPKMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000054_PartnerPawnPendingRewardsPKMigration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class PartnerPawnPendingRewardsPKMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 53;
+        public uint To => 54;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/migration_partner_pawn_pending_rewards_pk.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
This is a quick fix to the SQL Database to prevent the Server from throwing an Error when:
1. a Player tries to craft something while being close to an Affinity-Up with their Main Pawn.
2. there already is a Gift stored in the SQL Database

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
