### PR TITLE
Lestania WQ revisions 1/2

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020001.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Loneliness Gloves",
           "item_id": 9659,
           "num": 1
         },
         {
+          "comment": "Blue Whiskey",
           "item_id": 9417,
           "num": 1
         },
         {
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 2
         }
@@ -47,27 +50,43 @@
         "id": 1,
         "group_id": 264
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Brutal Rogue Seeker",
           "enemy_id": "0x011001",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 46,
           "level": 31,
-          "exp": 400,
-          "is_boss": false,
-          "hm_present_no": 46
+          "exp": 138,
+          "index": 0
         },
         {
+          "comment": "Brutal Rogue Seeker",
           "enemy_id": "0x011001",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 46,
           "level": 31,
-          "exp": 400,
-          "is_boss": false,
-          "hm_present_no": 46
+          "exp": 138,
+          "index": 8
         },
         {
+          "comment": "Brutal Rogue Hunter",
           "enemy_id": "0x011002",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 47,
           "level": 31,
-          "exp": 400,
-          "is_boss": false,
-          "hm_present_no": 47
+          "exp": 138,
+          "index": 14
+        },
+        {
+          "comment": "Brutal Rogue Seeker",
+          "enemy_id": "0x011001",
+          "named_enemy_params_id": 54,
+          "hm_present_no": 46,
+          "level": 31,
+          "exp": 138,
+          "index": 15
         }
       ]
     }
@@ -89,12 +108,26 @@
         "layer_no": 1
       },
       "npc_id": "ArisenCorpsRegimentalSoldier10",
-      "message_id": 11372
+      "message_id": 8636
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Soldier10",
+          "type": "QstTalkChg",
+          "Param1": 533,
+          "Param2": 8646
+        },
+        {
+          "comment": "Idle dialogue - Soldier7",
+          "type": "QstTalkChg",
+          "Param1": 530,
+          "Param2": 14839
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -119,7 +152,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier7",
-      "message_id": 11372
+      "message_id": 8639
     },
     {
       "type": "NewTalkToNpc",
@@ -130,7 +163,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier10",
-      "message_id": 11842
+      "message_id": 8640
     },
     {
       "type": "TalkToNpc",
@@ -141,7 +174,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Vanessa0",
-      "message_id": 11842
+      "message_id": 8641
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 948,
+          "comment": "Angel Circlet",
+          "item_id": 9574,
           "num": 1
         },
         {
+          "comment": "Conqueror's Talisman",
           "item_id": 9387,
           "num": 1
         },
         {
+          "comment": "Rare Meat Paté",
           "item_id": 9420,
           "num": 1
         }
@@ -49,28 +52,53 @@
       },
       "enemies": [
         {
+          "comment": "Brutal Orc Captain",
           "enemy_id": "0x015820",
+          "named_enemy_params_id": 54,
           "level": 37,
-          "exp": 550,
-          "is_boss": false
+          "exp": 483
         },
         {
+          "comment": "Brutal Orc Captain",
           "enemy_id": "0x015820",
+          "named_enemy_params_id": 54,
           "level": 37,
-          "exp": 550,
-          "is_boss": false
+          "exp": 483
         },
         {
+          "comment": "Vigilant Grimwarg",
           "enemy_id": "0x010205",
+          "named_enemy_params_id": 53,
           "level": 35,
-          "exp": 320,
-          "is_boss": false
+          "exp": 190
         },
         {
+          "comment": "Vigilant Grimwarg",
           "enemy_id": "0x010205",
+          "named_enemy_params_id": 53,
           "level": 35,
-          "exp": 320,
-          "is_boss": false
+          "exp": 190
+        },
+        {
+          "comment": "Vigilant Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 53,
+          "level": 35,
+          "exp": 190
+        },
+        {
+          "comment": "Vigilant Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 53,
+          "level": 35,
+          "exp": 190
+        },
+        {
+          "comment": "Vigilant Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 53,
+          "level": 35,
+          "exp": 190
         }
       ]
     }
@@ -92,12 +120,20 @@
         "layer_no": 1
       },
       "npc_id": "ArisenCorpsRegimentalSoldier6",
-      "message_id": 11372
+      "message_id": 11125
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 529,
+          "Param2": 11131
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -114,7 +150,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier6",
-      "message_id": 11842
+      "message_id": 11128
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020004.json
@@ -1,9 +1,9 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Liz’s Lost Property",
+  "comment": "Lise’s Lost Property",
   "quest_id": 20020004,
-  "base_level": 41,
+  "base_level": 42,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
@@ -27,66 +27,161 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "King Bay Leaf",
           "item_id": 7983,
           "num": 3
         },
         {
+          "comment": "Superior Quality Gala Extract",
           "item_id": 9362,
           "num": 3
         },
         {
+          "comment": "Throwing Knife",
           "item_id": 9398,
           "num": 3
         }
       ]
     }
   ],
-  "blocks": [
+  "enemy_groups": [
     {
-      "type": "NewNpcTalkAndOrder",
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 999,
-          "comment": "Spawns Lise0 NPC"
-        }
-      ],
-      "stage_id": {
-        "id": 66,
-        "group_id": 1,
-        "layer_no": 1
-      },
-      "npc_id": "Lise0",
-      "message_id": 11372
-    },
-    {
-      "type": "CollectItem",
-      "announce_type": "Accept",
       "stage_id": {
         "id": 118,
-        "group_id": 1,
-        "layer_no": 1
+        "group_id": 0
       },
-      "flags": [
+      "enemies": [
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1145,
-          "comment": "Spawns Glowing Item"
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 239,
+          "is_required": false
         }
       ]
     },
     {
-      "type": "NewTalkToNpc",
       "stage_id": {
-        "id": 66,
-        "group_id": 1,
-        "layer_no": 1
+        "id": 118,
+        "group_id": 2
       },
-      "announce_type": "Update",
-      "npc_id": "Lise0",
-      "message_id": 11842
+      "enemies": [
+        {
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 239,
+          "is_required": false
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 118,
+        "group_id": 3
+      },
+      "enemies": [
+        {
+          "comment": "Vigilant Orc Vanguard",
+          "enemy_id": "0x015802",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 239,
+          "is_required": false
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NewNpcTalkAndOrder",
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 999,
+              "comment": "Spawns Lise0 NPC"
+            }
+          ],
+          "stage_id": {
+            "id": 66,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "npc_id": "Lise0",
+          "message_id": 11133
+        },
+        {
+          "type": "CollectItem",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue - Lise",
+              "type": "QstTalkChg",
+              "Param1": 13,
+              "Param2": 11141
+            },
+            {
+              "comment": "Idle dialogue - Plum",
+              "type": "QstTalkChg",
+              "Param1": 500,
+              "Param2": 11143
+            }
+          ],
+          "stage_id": {
+            "id": 118,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1145,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
+        },
+        {
+          "type": "NewTalkToNpc",
+          "stage_id": {
+            "id": 66,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "announce_type": "Update",
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 0
+            },
+            {
+              "comment": "Idle dialogue - Plum",
+              "type": "QstTalkChg",
+              "Param1": 500,
+              "Param2": 11144
+            }
+          ],
+          "npc_id": "Lise0",
+          "message_id": 11138
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 0 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "groups": [0, 1, 2]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020005.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Ruby Pendant",
           "item_id": 8975,
           "num": 1
         },
         {
+          "comment": "Angel's Talisman",
           "item_id": 9388,
           "num": 1
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         }
@@ -45,14 +48,16 @@
     {
       "stage_id": {
         "id": 74,
-        "group_id": 1
+        "group_id": 0
       },
+      "starting_index": 3,
       "enemies": [
         {
+          "comment": "Vigilant Grimwarg",
           "enemy_id": "0x010205",
-          "level": 37,
-          "exp": 550,
-          "is_boss": false
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 202
         }
       ]
     },
@@ -61,18 +66,22 @@
         "id": 74,
         "group_id": 14
       },
+      "starting_index": 2,
       "enemies": [
         {
-          "enemy_id": "0x010205",
-          "level": 37,
-          "exp": 550,
-          "is_boss": false
+          "comment": "Vigilant Colossus",
+          "enemy_id": "0x015020",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 3528,
+          "is_boss": true
         },
         {
-          "enemy_id": "0x015020",
+          "comment": "Vigilant Grimwarg",
+          "enemy_id": "0x010205",
+          "named_enemy_params_id": 53,
           "level": 38,
-          "exp": 8200,
-          "is_boss": true
+          "exp": 202
         }
       ]
     }
@@ -94,12 +103,20 @@
         "layer_no": 1
       },
       "npc_id": "ArisenCorpsRegimentalSoldier8",
-      "message_id": 11372
+      "message_id": 11145
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 531,
+          "Param2": 11152
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -127,7 +144,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier8",
-      "message_id": 11842
+      "message_id": 11148
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006.json
@@ -27,68 +27,77 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Scroll of Great Strength",
           "item_id": 8007,
-          "num": 2
+          "num": 3
         },
         {
+          "comment": "Throwblast",
           "item_id": 52,
           "num": 3
         },
         {
+          "comment": "Throwing Knife",
           "item_id": 9398,
           "num": 2
         }
       ]
-  },
-  {
+    },
+    {
       "type": "random",
       "loot_pool": [
-          {
-              "item_id": 35,
-              "num": 2,
-              "chance": 1.0
-          }
+        {
+          "comment": "Superior Healing Potion",
+          "item_id": 35,
+          "num": 2,
+          "chance": 1.0
+        }
       ]
-  }
+    }
   ],
   "enemy_groups": [
     {
       "stage_id": {
         "id": 1,
-        "group_id": 263
+        "group_id": 240
       },
+      "placement_type": "manual",
       "enemies": [
        {
+          "comment": "Vigilant Orc Vanguard",
           "enemy_id": "0x015802",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 1264,
-          "is_boss": false
+          "exp": 186,
+          "index": 2
         },
         {
-          "enemy_id": "0x015820",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 35,
-          "exp": 1336,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Grimwarg",
           "enemy_id": "0x010205",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 1264,
-          "is_boss": false
+          "exp": 186,
+          "index": 3
         },
         {
+          "comment": "Vigilant Orc Captain",
+          "enemy_id": "0x015820",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 35,
+          "exp": 465,
+          "index": 4
+        },
+        {
+          "comment": "Vigilant Orc Vanguard",
           "enemy_id": "0x015802",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 1264,
-          "is_boss": false
+          "exp": 186,
+          "index": 7
         }
       ]
     },
@@ -97,31 +106,31 @@
         "id": 1,
         "group_id": 253
       },
+      "starting_index": 1,
       "enemies": [
-        
         {
+          "comment": "Vigilant Undead Swordsman",
+          "enemy_id": "0x010503",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 33,
+          "exp": 129
+        },
+        {
+          "comment": "Vigilant Undead Swordsman",
+          "enemy_id": "0x010503",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 33,
+          "exp": 129
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
           "enemy_id": "0x010309",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 53,
           "level": 35,
-          "exp": 1336,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010503",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 33,
-          "exp": 1194,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010503",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 33,
-          "exp": 1194,
-          "is_boss": false
+          "exp": 158
         }
       ]
     },
@@ -130,31 +139,24 @@
         "id": 1,
         "group_id": 261
       },
+      "starting_index": 2,
       "enemies": [
-       
         {
+          "comment": "Vigilant Grimwarg",
+          "enemy_id": "0x010205",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 186
+        },
+        {
+          "comment": "Brutal Chimera",
           "enemy_id": "0x015200",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 35,
-          "exp": 5446,
+          "exp": 3300,
           "is_boss": true
-        },
-        {
-          "enemy_id": "0x010205",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 34,
-          "exp": 1264,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010205",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 34,
-          "exp": 1264,
-          "is_boss": false
         }
       ]
     }
@@ -171,13 +173,21 @@
             "layer_no": 1
           },
           "npc_id": "Vanessa0",
-          "message_id": 11372
+          "message_id": 11387
         },
         {
           "type": "MyQstFlags",
           "announce_type": "Accept",
           "set_flags": [ 1 ],
-          "check_flags": [ 2, 3, 4 ]
+          "check_flags": [ 2, 3, 4 ],
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 11,
+              "Param2": 12006
+            }
+          ]
         },
         {
           "type": "TalkToNpc",
@@ -188,7 +198,7 @@
           },
           "announce_type": "Update",
           "npc_id": "Vanessa0",
-          "message_id": 11842
+          "message_id": 12003
         }
       ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Urgent Directive: Eliminate the Demons to the North",
+  "comment": "Urgent Directive: Eliminate the Demons to the North (II)",
   "quest_id": 20020006,
   "base_level": 41,
   "minimum_item_rank": 0,
@@ -28,14 +28,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Rosewood",
           "item_id": 7966,
           "num": 3
         },
         {
-          "item_id":9387,
+          "comment": "Conqueror's Talisman",
+          "item_id": 9387,
           "num": 1
         },
         {
+          "comment": "Five-Herb Salad",
           "item_id": 9414,
           "num": 2
         }
@@ -45,6 +48,7 @@
       "type": "random",
       "loot_pool": [
           {
+              "comment": "Crest of Freezing",
               "item_id": 9259,
               "num": 1,
               "chance": 1.0
@@ -56,40 +60,45 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 263
+        "group_id": 240
       },
+      "placement_type": "manual",
       "enemies": [
        {
+          "comment": "Brutal Orc Trooper",
           "enemy_id": "0x015812",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 4200,
-          "is_boss": false
+          "exp": 250,
+          "index": 2
         },
         {
-          "enemy_id": "0x015820",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false
-        },
-        {
+          "comment": "Brutal Grimwarg",
           "enemy_id": "0x010205",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 40,
-          "exp": 3742,
-          "is_boss": false
+          "exp": 210,
+          "index": 3
         },
         {
+          "comment": "Brutal Orc Captain",
+          "enemy_id": "0x015820",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 519,
+          "index": 4
+        },
+        {
+          "comment": "Brutal Orc Trooper",
           "enemy_id": "0x015812",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 4200,
-          "is_boss": false
+          "exp": 250,
+          "index": 7
         }
       ]
     },
@@ -98,30 +107,31 @@
         "id": 1,
         "group_id": 253
       },
+      "starting_index": 1,
       "enemies": [
         {
+          "comment": "Brutal Undead Swordsman",
+          "enemy_id": "0x010503",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 153
+        },
+        {
+          "comment": "Brutal Undead Swordsman",
+          "enemy_id": "0x010503",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 153
+        },
+        {
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
+          "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 4200,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010503",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010503",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 56,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false
+          "exp": 181
         }
       ]
     },
@@ -130,31 +140,24 @@
         "id": 1,
         "group_id": 261
       },
+      "starting_index": 2,
       "enemies": [
-       
         {
+          "comment": "Brutal Grimwarg",
+          "enemy_id": "0x010205",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 54,
+          "level": 40,
+          "exp": 210
+        },
+        {
+          "comment": "Brutal Chimera",
           "enemy_id": "0x015200",
           "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 6040,
+          "exp": 3660,
           "is_boss": true
-        },
-        {
-          "enemy_id": "0x010205",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010205",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 54,
-          "level": 41,
-          "exp": 4200,
-          "is_boss": false
         }
       ]
     }
@@ -171,13 +174,21 @@
             "layer_no": 1
           },
           "npc_id": "Vanessa0",
-          "message_id": 11372
+          "message_id": 11387
         },
         {
           "type": "MyQstFlags",
           "announce_type": "Accept",
           "set_flags": [ 1 ],
-          "check_flags": [ 2, 3, 4 ]
+          "check_flags": [ 2, 3, 4 ],
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 11,
+              "Param2": 12006
+            }
+          ]
         },
         {
           "type": "TalkToNpc",
@@ -188,7 +199,7 @@
           },
           "announce_type": "Update",
           "npc_id": "Vanessa0",
-          "message_id": 11842
+          "message_id": 12003
         }
       ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020007_1.json
@@ -1,22 +1,23 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Situation on the Mountain Road",
+  "comment": "A Situation on the Mountain Road (II)",
   "quest_id": 20020007,
-  "base_level": 36,
+  "base_level": 56,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 43,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "exp",
-      "amount": 1660
+      "amount": 2580
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1180
+      "amount": 1840
     },
     {
       "type": "wallet",
@@ -27,18 +28,18 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Shiny Hands",
-          "item_id": 9664,
+          "comment": "Cockatrice Gastrolith",
+          "item_id": 9440,
           "num": 1
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
+          "comment": "Cockatrice Poison Gland",
+          "item_id": 7745,
           "num": 1
         },
         {
-          "comment": "Throwing Knife",
-          "item_id": 9398,
+          "comment": "Cockatrice Liquor",
+          "item_id": 7842,
           "num": 1
         }
       ]
@@ -53,11 +54,11 @@
       "starting_index": 5,
       "enemies": [
         {
-          "comment": "Brutal Griffin",
-          "enemy_id": "0x015300",
-          "named_enemy_params_id": 54,
-          "level": 36,
-          "exp": 4200,
+          "comment": "Dangerous Cockatrice",
+          "enemy_id": "0x015301",
+          "named_enemy_params_id": 56,
+          "level": 56,
+          "exp": 5974,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020007_2.json
@@ -1,45 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Situation on the Mountain Road",
+  "comment": "A Situation on the Mountain Road (Bounty)",
   "quest_id": 20020007,
-  "base_level": 36,
+  "base_level": 35,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 43,
+  "variant_index": 2,
   "rewards": [
     {
       "type": "exp",
-      "amount": 1660
+      "amount": 3230
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1180
+      "amount": 2310
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 190
+      "amount": 180
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Shiny Hands",
-          "item_id": 9664,
-          "num": 1
+          "comment": "Superior Healing Elixir",
+          "item_id": 7553,
+          "num": 3
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
-          "num": 1
+          "comment": "Superior Quality Gala Extract",
+          "item_id": 9362,
+          "num": 3
         },
         {
-          "comment": "Throwing Knife",
-          "item_id": 9398,
-          "num": 1
+          "comment": "Enhanced Lockpick",
+          "item_id": 9403,
+          "num": 3
         }
       ]
     }
@@ -53,11 +54,11 @@
       "starting_index": 5,
       "enemies": [
         {
-          "comment": "Brutal Griffin",
+          "comment": "Bounty Griffin",
           "enemy_id": "0x015300",
-          "named_enemy_params_id": 54,
-          "level": 36,
-          "exp": 4200,
+          "named_enemy_params_id": 458,
+          "level": 35,
+          "exp": 4125,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020008.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Agate",
           "item_id": 7894,
           "num": 5
         },
         {
+          "comment": "Enhanced Lumber Knife",
           "item_id": 9402,
           "num": 3
         },
         {
+          "comment": "Grilled Mushroom",
           "item_id": 9415,
           "num": 1
         }
@@ -44,6 +47,7 @@
       "type": "random",
       "loot_pool": [
         {
+          "comment": "Necrophagous Bristle",
           "item_id": 7777,
           "num": 1,
           "chance": 1.0
@@ -57,46 +61,47 @@
         "id": 1,
         "group_id": 268
       },
+      "starting_index": 5,
       "enemies": [
         {
+          "comment": "Vigilant Rogue Fighter",
           "enemy_id": "0x011000",
           "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 1264,
-          "is_boss": false,
+          "exp": 148,
           "hm_present_no": 45
         },
         {
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 53,
-          "level": 34,
-          "exp": 1264,
-          "is_boss": false,
-          "hm_present_no": 45
-        },
-        {
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 53,
-          "level": 34,
-          "exp": 1264,
-          "is_boss": false,
-          "hm_present_no": 45
-        },
-        {
+          "comment": "Vigilant Rogue Healer",
           "enemy_id": "0x011003",
           "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 1264,
-          "is_boss": false,
+          "exp": 148,
           "hm_present_no": 48
         },
         {
+          "comment": "Vigilant Rogue Healer",
           "enemy_id": "0x011003",
           "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 1264,
-          "is_boss": false,
+          "exp": 148,
           "hm_present_no": 48
+        },
+        {
+          "comment": "Vigilant Rogue Fighter",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 148,
+          "hm_present_no": 45
+        },
+        {
+          "comment": "Vigilant Rogue Fighter",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 148,
+          "hm_present_no": 45
         }
       ]
     }
@@ -118,12 +123,20 @@
         "layer_no": 1
       },
       "npc_id": "ArisenCorpsRegimentalSoldier7",
-      "message_id": 11372
+      "message_id": 11389
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 530,
+          "Param2": 12593
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -140,7 +153,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier7",
-      "message_id": 11842
+      "message_id": 12589
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020009_1.json
@@ -1,44 +1,45 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Residents of Darkness",
+  "comment": "The Residents of Darkness (II)",
   "quest_id": 20020009,
-  "base_level": 40,
+  "base_level": 41,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 546,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "exp",
-      "amount": 1320
+      "amount": 1350
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1100
+      "amount": 1120
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 170
+      "amount": 180
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Strong Thread",
-          "item_id": 7956,
-          "num": 3
+          "comment": "Protective Cloth",
+          "item_id": 7940,
+          "num": 2
         },
         {
-          "comment": "Sprite's Talisman",
-          "item_id": 9390,
+          "comment": "Angel's Talisman",
+          "item_id": 9388,
           "num": 1
         },
         {
-          "comment": "Five-Herb Salad",
-          "item_id": 9414,
+          "comment": "Grilled Mushroom",
+          "item_id": 9415,
           "num": 2
         }
       ]
@@ -50,35 +51,60 @@
         "id": 91,
         "group_id": 3
       },
-      "starting_index": 7,
+      "placement_type": "manual",
       "enemies": [
         {
-          "comment": "Vigilant Skeleton Mage",
-          "enemy_id": "0x010308",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 154
-        },
-        {
-          "comment": "Vigilant Skeleton Mage",
-          "enemy_id": "0x010308",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 154
-        },
-        {
-          "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 177
+          "level": 41,
+          "exp": 181,
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "is_manual_set": true,
+          "is_required": false,
+          "index": 6
         },
         {
-          "comment": "Vigilant Skeleton Sorcerer",
+          "comment": "Brutal Witch",
+          "enemy_id": "0x015604",
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 2772,
+          "is_boss": true,
+          "index": 8
+        },
+        {
+          "comment": "Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 177
+          "level": 41,
+          "exp": 181,
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "is_manual_set": true,
+          "is_required": false,
+          "index": 9
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 41,
+          "exp": 181,
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "is_manual_set": true,
+          "is_required": false,
+          "index": 10
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 41,
+          "exp": 181,
+          "start_think_tbl_no": 8,
+          "repop_count": 1,
+          "is_manual_set": true,
+          "is_required": false,
+          "index": 11
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020010.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Red Alloy Ingot",
           "item_id": 7888,
           "num": 1
         },
         {
+          "comment": "Harvest Salad",
           "item_id": 9418,
           "num": 1
         },
         {
+          "comment": "Grilled Mushroom",
           "item_id": 9415,
           "num": 2
         }
@@ -49,33 +52,46 @@
       },
       "enemies": [
         {
-          "enemy_id": "0x011002",
-          "level": 39,
-          "exp": 550,
-          "is_boss": false,
-          "hm_present_no": 47
-        },
-        {
-          "enemy_id": "0x011002",
-          "level": 39,
-          "exp": 550,
-          "is_boss": false,
-          "hm_present_no": 47
-        },
-        {
+          "comment": "Vigilant Rogue Healer",
           "enemy_id": "0x011003",
+          "named_enemy_params_id": 53,
           "level": 39,
-          "exp": 550,
-          "is_boss": false,
+          "exp": 167,
           "hm_present_no": 48
         },
         {
+          "comment": "Vigilant Rogue Healer",
           "enemy_id": "0x011003",
+          "named_enemy_params_id": 53,
           "level": 39,
-          "exp": 550,
-          "is_boss": false,
+          "exp": 167,
           "hm_present_no": 48
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 39,
+          "exp": 167,
+          "hm_present_no": 47
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 39,
+          "exp": 167,
+          "hm_present_no": 47
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 39,
+          "exp": 167,
+          "hm_present_no": 47
         }
+
       ]
     }
   ],
@@ -96,12 +112,20 @@
         "layer_no": 1
       },
       "npc_id": "LightlyEquippedSoldier",
-      "message_id": 11372
+      "message_id": 11391
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 539,
+          "Param2": 12610
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -205,7 +229,7 @@
       },
       "announce_type": "Update",
       "npc_id": "LightlyEquippedSoldier",
-      "message_id": 11842
+      "message_id": 12604
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020011.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Lapis Lazuli",
           "item_id": 7902,
           "num": 3
         },
         {
+          "comment": "Enhanced Lockpick",
           "item_id": 9403,
           "num": 3
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 1
         }
@@ -49,28 +52,44 @@
       },
       "enemies": [
         {
-          "enemy_id": "0x010309",
-          "level": 34,
-          "exp": 400,
-          "is_boss": false
-        },
-        {
-          "enemy_id": "0x010309",
-          "level": 34,
-          "exp": 400,
-          "is_boss": false
-        },
-        {
+          "comment": "Vigilant Orc Tosser",
           "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 400,
-          "is_boss": false
+          "exp": 186,
+          "index": 0
         },
         {
-          "enemy_id": "0x015801",
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
           "level": 34,
-          "exp": 400,
-          "is_boss": false
+          "exp": 154,
+          "index": 1
+        },
+        {
+          "comment": "Vigilant Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 154,
+          "index": 2
+        },
+        {
+          "comment": "Vigilant Orc Tosser",
+          "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 186,
+          "index": 3
+        },
+        {
+          "comment": "Vigilant Orc Tosser",
+          "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
+          "level": 34,
+          "exp": 186,
+          "index": 4
         }
       ]
     }
@@ -92,12 +111,20 @@
         "layer_no": 1
       },
       "npc_id": "ArisenCorpsRegimentalSoldier10",
-      "message_id": 11372
+      "message_id": 11392
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
       "announce_type": "Accept",
-      "groups": [ 0 ]
+      "groups": [ 0 ],
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 533,
+          "Param2": 12618
+        }
+      ]
     },
     {
       "type": "KillGroup",
@@ -114,7 +141,7 @@
       },
       "announce_type": "Update",
       "npc_id": "ArisenCorpsRegimentalSoldier10",
-      "message_id": 11842
+      "message_id": 12615
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025000.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Incineration",
           "item_id": 9258,
           "num": 1
         },
         {
+          "comment": "Special Mushroom Dip",
           "item_id": 9419,
           "num": 1
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 2
         }
@@ -47,13 +50,14 @@
         "id": 74,
         "group_id": 7
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Brutal Chimera",
           "enemy_id": "0x015200",
-          "start_think_tbl_no": 1,
           "named_enemy_params_id": 54,
           "level": 38,
-          "exp": 6254,
+          "exp": 3480,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025001.json
@@ -27,16 +27,19 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Permafrost",
           "item_id": 9260,
           "num": 1
         },
         {
+          "comment": "Rare Meat Paté",
           "item_id": 9420,
           "num": 1
         },
         {
+          "comment": "Blue Whiskey",
           "item_id": 9417,
-          "num": 1
+          "num": 2
         }
       ]
     }
@@ -47,11 +50,14 @@
         "id": 74,
         "group_id": 2
       },
+      "starting_index": 2,
       "enemies": [
         {
-          "enemy_id": "0x015002",
+          "comment": "Brutal Armored Cyclops (Club)",
+          "enemy_id": "0x015003",
+          "named_enemy_params_id": 54,
           "level": 38,
-          "exp": 6500,
+          "exp": 3339,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025002.json
@@ -8,6 +8,10 @@
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 551,
+  "order_conditions": [
+    {"type": "MinimumLevel", "Param1": 55},
+    {"type": "MainQuestCompleted", "Param1": 30}
+  ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Red Alloy Ingot",
           "item_id": 7888,
           "num": 1
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         },
         {
+          "comment": "Throwblast",
           "item_id": 52,
           "num": 3
         }
@@ -47,30 +50,39 @@
         "id": 91,
         "group_id": 2
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Vigilant Orc Tosser",
           "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
           "level": 37,
-          "exp": 500,
-          "is_boss": false
+          "exp": 200,
+          "index": 0
         },
         {
+          "comment": "Vigilant Orc Tosser",
           "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
           "level": 37,
-          "exp": 500,
-          "is_boss": false
+          "exp": 200,
+          "index": 1
         },
         {
-          "enemy_id": "0x015801",
-          "level": 37,
-          "exp": 500,
-          "is_boss": false
+          "comment": "Brutal Orc Captain",
+          "enemy_id": "0x015820",
+          "named_enemy_params_id": 54,
+          "level": 38,
+          "exp": 492,
+          "index": 2
         },
         {
+          "comment": "Vigilant Orc Tosser",
           "enemy_id": "0x015801",
+          "named_enemy_params_id": 53,
           "level": 37,
-          "exp": 500,
-          "is_boss": false
+          "exp": 200,
+          "index": 6
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Scroll of Great Strength",
           "item_id": 8007,
-          "num": 2
-        },
-        {
-          "item_id": 9410,
           "num": 3
         },
         {
+          "comment": "Three-Herb Salad",
+          "item_id": 9410,
+          "num": 2
+        },
+        {
+          "comment": "Blue Whiskey",
           "item_id": 9417,
           "num": 1
         }
@@ -47,11 +50,14 @@
         "id": 120,
         "group_id": 3
       },
+      "starting_index": 7,
       "enemies": [
         {
+          "comment": "Brutal Armored Cyclops",
           "enemy_id": "0x015002",
+          "named_enemy_params_id": 54,
           "level": 34,
-          "exp": 6450,
+          "exp": 3127,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Huge Armored Creature Appears!",
+  "comment": "A Huge Armored Creature Appears! (II)",
   "quest_id": 20025005,
   "base_level": 41,
   "minimum_item_rank": 0,
@@ -13,29 +13,32 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1120
+      "amount": 1350
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 200
+      "amount": 270
     },
     {
       "type": "exp",
-      "amount": 1430
+      "amount": 1890
     },
     {
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Greater Protection",
           "item_id": 9288,
           "num": 1
         },
         {
+          "comment": "Demon's Talisman",
           "item_id": 9389,
           "num": 1
         },
         {
+          "comment": "Exquisite Fried Meat",
           "item_id": 9416,
           "num": 2
         }
@@ -58,43 +61,36 @@
         "id": 120,
         "group_id": 3
       },
-      "placement_type": "manual",
+      "starting_index": 7,
       "enemies": [
         {
+          "comment": "Dangerous Armored Cyclops",
           "enemy_id": "0x015002",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
+          "named_enemy_params_id": 56,
           "level": 41,
-          "exp": 6590,
-          "is_boss": true,
-          "index": 10
+          "exp": 3498,
+          "is_boss": true
         },
         {
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 8
+          "exp": 181
         },
         {
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 9
+          "exp": 181
         },
         {
+          "comment": "Brutal Skeleton Sorcerer",
           "enemy_id": "0x010309",
-          "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 54,
+          "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 4200,
-          "is_boss": false,
-          "index": 7
+          "exp": 181
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025006.json
@@ -27,18 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
-          "item_id": 7894,
-          "num": 3
-        },
-        {
-          "item_id": 9411,
-          "num": 2
-        },
-        {
+          "comment": "Necrophagous Bristle",
           "item_id": 7777,
           "num": 1
         },
         {
+          "comment": "Agate",
+          "item_id": 7894,
+          "num": 5
+        },
+        {
+          "comment": "Throwblast",
           "item_id": 52,
           "num": 3
         }
@@ -51,29 +50,27 @@
         "id": 1,
         "group_id": 255
       },
-         "placement_type": "manual",
+      "starting_index": 2,
       "enemies": [
-        
         {
+          "comment": "Vigilant Ogre",
           "enemy_id": "0x015500",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
-          "level": 36,
-          "exp": 6040,
-          "scale": 140,
-          "is_boss": true,
-          "index": 0
+          "named_enemy_params_id": 53,
+          "level": 32,
+          "exp": 2420,
+          "scale": 90,
+          "is_boss": true
         },
-        
         {
+          "comment": "Brutal Ogre",
           "enemy_id": "0x015500",
           "start_think_tbl_no": 2,
-		      "named_enemy_params_id": 459,
-          "level": 32,
-          "exp": 5636,
-          "scale": 90,
-          "is_boss": true,
-          "index": 2
+          "named_enemy_params_id": 54,
+          "level": 36,
+          "exp": 2660,
+          "scale": 140,
+          "is_boss": true
         }
       ]
     }
@@ -81,8 +78,6 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "(18 * 3600000) + (0 * 60000)",
-      "spawn_time_end": "(6 * 3600000) + (59 * 60000)",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025007.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Crest of Unburdening",
           "item_id": 9286,
           "num": 1
         },
         {
+          "comment": "Throwing Knife",
           "item_id": 9398,
           "num": 3
         },
         {
+          "comment": "Enhanced Pickaxe",
           "item_id": 9401,
           "num": 3
         }
@@ -47,36 +50,49 @@
         "id": 40,
         "group_id": 2
       },
+      "starting_index": 6,
       "enemies": [
         {
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
           "level": 38,
-          "exp": 540,
-          "is_boss": false
+          "exp": 155
         },
         {
+          "comment": "Vigilant Skeleton Knight",
           "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
           "level": 38,
-          "exp": 540,
-          "is_boss": false
+          "exp": 155
         },
         {
-          "enemy_id": "0x010308",
+          "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
           "level": 38,
-          "exp": 540,
-          "is_boss": false
+          "exp": 155
         },
         {
-          "enemy_id": "0x010308",
+          "comment": "Vigilant Skeleton Knight",
+          "enemy_id": "0x010301",
+          "named_enemy_params_id": 53,
           "level": 38,
-          "exp": 540,
-          "is_boss": false
+          "exp": 155
         },
         {
+          "comment": "Vigilant Skeleton Mage",
           "enemy_id": "0x010308",
+          "named_enemy_params_id": 53,
           "level": 38,
-          "exp": 540,
-          "is_boss": false
+          "exp": 147
+        },
+        {
+          "comment": "Vigilant Skeleton Mage",
+          "enemy_id": "0x010308",
+          "named_enemy_params_id": 53,
+          "level": 38,
+          "exp": 147
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Angules Horn",
           "item_id": 7756,
           "num": 1
         },
         {
+          "comment": "Strong Gala Extract",
           "item_id": 9363,
           "num": 3
         },
         {
+          "comment": "Rare Meat Paté",
           "item_id": 9420,
           "num": 1
         }
@@ -45,19 +48,15 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 271
+        "group_id": 269
       },
       "enemies": [
         {
-          "enemy_id": "0x015707",
+          "comment": "Bounty Angules",
+          "enemy_id": "0x015708",
+          "named_enemy_params_id": 458,
           "level": 45,
-          "exp": 13000,
-          "is_boss": true
-        },
-        {
-          "enemy_id": "0x015500",
-          "level": 45,
-          "exp": 13000,
+          "exp": 7980,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_1.json
@@ -1,0 +1,120 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Blue-Scaled Wicked Dragon (Twelve Calamities)",
+  "quest_id": 20025008,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BetlandPlains",
+  "news_image": 44,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3990
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 360
+    },
+    {
+      "type": "exp",
+      "amount": 5440
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Bluish Gray Dragonscale",
+          "item_id": 7932,
+          "num": 1
+        },
+        {
+          "comment": "Silver Bristle",
+          "item_id": 7782,
+          "num": 2
+        },
+        {
+          "comment": "Alkahest",
+          "item_id": 7833,
+          "num": 3
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Dragonsbane",
+          "item_id": 9235,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Drowning",
+          "item_id": 9246,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 269
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Deep Lake Lindwurm",
+          "enemy_id": "0x015707",
+          "named_enemy_params_id": 516,
+          "level": 55,
+          "exp": 8480,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Dangerous Silver Roar",
+          "enemy_id": "0x015505",
+          "named_enemy_params_id": 46,
+          "level": 55,
+          "exp": 4085,
+          "is_boss": true,
+          "index": 4
+        },
+        {
+          "comment": "Dangerous Silver Roar",
+          "enemy_id": "0x015505",
+          "named_enemy_params_id": 46,
+          "level": 55,
+          "exp": 4085,
+          "is_boss": true,
+          "index": 5
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_2.json
@@ -1,0 +1,104 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Blue-Scaled Wicked Dragon (Nine Calamities)",
+  "quest_id": 20025008,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "BetlandPlains",
+  "news_image": 44,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3960
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 490
+    },
+    {
+      "type": "exp",
+      "amount": 6930
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Intelligence+",
+          "item_id": 11741,
+          "num": 1
+        },
+        {
+          "comment": "Spectral Dragon Claw",
+          "item_id": 7802,
+          "num": 1
+        },
+        {
+          "comment": "Spectral Dragonscale",
+          "item_id": 7922,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 269
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Deep Mist Wyrm",
+          "enemy_id": "0x015711",
+          "named_enemy_params_id": 592,
+          "level": 60,
+          "exp": 9860,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Deep Newt (Blue Newt)",
+          "enemy_id": "0x010460",
+          "named_enemy_params_id": 593,
+          "level": 60,
+          "exp": 257,
+          "index": 2
+        },
+        {
+          "comment": "Deep Newt (Blue Newt)",
+          "enemy_id": "0x010460",
+          "named_enemy_params_id": 593,
+          "level": 60,
+          "exp": 257,
+          "index": 3
+        },
+        {
+          "comment": "Deep Newt (Blue Newt)",
+          "enemy_id": "0x010460",
+          "named_enemy_params_id": 593,
+          "level": 60,
+          "exp": 257,
+          "index": 5
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "DiscoverEnemy",
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009.json
@@ -27,24 +27,19 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Cathedral Bottoms",
           "item_id": 9719,
           "num": 1
         },
         {
+          "comment": "Five-Herb Salad",
           "item_id": 9414,
           "num": 2
         },
         {
+          "comment": "Enhanced Lumber Knife",
           "item_id": 9402,
           "num": 3
-        },
-        {
-          "item_id": 968,
-          "num": 1
-        },
-        {
-          "item_id": 9402,
-          "num": 1
         }
       ]
     }
@@ -58,11 +53,12 @@
       "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015303",
+          "comment": "Brutal Griffin",
+          "enemy_id": "0x015300",
           "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
+          "named_enemy_params_id": 54,
           "level": 36,
-          "exp": 6040,
+          "exp": 4200,
           "is_boss": true,
           "index": 6
         }
@@ -72,6 +68,8 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
+      "spawn_time_start": "18 * 3600000 + 0 * 60000",
+      "spawn_time_end": "6 * 3600000 + 59 * 60000",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009_1.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Whirling Hawk on a Dark Night",
+  "comment": "A Whirling Hawk on a Dark Night (II)",
   "quest_id": 20025009,
   "base_level": 57,
   "minimum_item_rank": 0,
@@ -13,7 +13,7 @@
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1180
+      "amount": 1880
     },
     {
       "type": "wallet",
@@ -28,20 +28,19 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Griffin Glossy Plume",
           "item_id": 9439,
           "num": 1
         },
         {
+          "comment": "Ambrosial Beast-Steak",
           "item_id": 7727,
           "num": 1
         },
         {
+          "comment": "Griffin Beak",
           "item_id": 7758,
           "num": 1
-        },
-        {
-          "item_id": 41,
-          "num": 3
         }
       ]
     }
@@ -53,13 +52,14 @@
         "group_id": 242
       },
         "placement_type": "manual",
-      "enemies": [
+        "enemies": [
         {
-          "enemy_id": "0x015303",
+          "comment": "Dangerous Griffin",
+          "enemy_id": "0x015300",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
+          "named_enemy_params_id": 56,
           "level": 57,
-          "exp": 23700,
+          "exp": 5775,
           "is_boss": true,
           "index": 6
         }
@@ -69,6 +69,8 @@
   "blocks": [
     {
       "type": "DiscoverEnemy",
+      "spawn_time_start": "18 * 3600000 + 0 * 60000",
+      "spawn_time_end": "6 * 3600000 + 59 * 60000",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002.json
@@ -67,6 +67,7 @@
         "id": 1,
         "group_id": 185
       },
+      "starting_index": 2,
       "enemies": [
         {
           "comment": "Vigilant Griffin",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_1.json
@@ -51,6 +51,7 @@
         "id": 1,
         "group_id": 185
       },
+      "starting_index": 2,
       "enemies": [
         {
           "comment": "Brutal Chimera",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_2.json
@@ -51,6 +51,7 @@
         "id": 1,
         "group_id": 185
       },
+      "starting_index": 2,
       "enemies": [
         {
           "comment": "Dangerous Griffin",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040002_3.json
@@ -51,6 +51,7 @@
         "id": 1,
         "group_id": 185
       },
+      "starting_index": 2,
       "enemies": [
         {
           "comment": "Bounty Golem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004.json
@@ -61,7 +61,7 @@
         "id": 152,
         "group_id": 5
       },
-      "starting_index": 7,
+      "starting_index": 4,
       "enemies": [
         {
           "comment": "Vigilant Armored Cyclops",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_1.json
@@ -51,7 +51,7 @@
         "id": 152,
         "group_id": 5
       },
-      "starting_index": 7,
+      "starting_index": 4,
       "enemies": [
         {
           "comment": "Brutal Colossus",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040004_2.json
@@ -51,7 +51,7 @@
         "id": 152,
         "group_id": 5
       },
-      "starting_index": 7,
+      "starting_index": 4,
       "enemies": [
         {
           "comment": "Bounty Cyclops",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005.json
@@ -39,292 +39,331 @@
       ]
     }
   ],
-  "blocks": [
+  "enemy_groups": [
     {
-      "type": "NewNpcTalkAndOrder",
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1048,
-          "comment": "Spawns Nelson NPC"
-        }
-      ],
       "stage_id": {
         "id": 104,
-        "group_id": 13,
-        "layer_no": 1
+        "group_id": 5
       },
-      "npc_id": "Nelson",
-      "message_id": 11095
-    },
-    {
-      "type": "CollectItem",
-      "announce_type": "Accept",
-      "result_commands": [
+      "enemies": [
         {
-          "comment": "Idle dialogue",
-          "type": "QstTalkChg",
-          "Param1": 1608,
-          "Param2": 11101
+          "comment": "Vigilant Ogre",
+          "enemy_id": "0x015500",
+          "named_enemy_params_id": 53,
+          "level": 25,
+          "exp": 2000,
+          "is_boss": true,
+          "is_required": false
         }
-      ],
-      "stage_id": {
-        "id": 104,
-        "group_id": 2,
-        "layer_no": 1
-      },
-      "flags": [
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1166,
-          "comment": "Spawns Glowing Item"
+          "type": "NewNpcTalkAndOrder",
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1048,
+              "comment": "Spawns Nelson NPC"
+            }
+          ],
+          "stage_id": {
+            "id": 104,
+            "group_id": 13,
+            "layer_no": 1
+          },
+          "npc_id": "Nelson",
+          "message_id": 11431
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1167,
-          "comment": "Spawns Glowing Item"
+          "type": "CollectItem",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 1608,
+              "Param2": 11101
+            },
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 0
+            }
+          ],
+          "stage_id": {
+            "id": 104,
+            "group_id": 2,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1166,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1167,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1168,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1169,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1170,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1832,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1833,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1834,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1835,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1836,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1837,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1838,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1168,
-          "comment": "Spawns Glowing Item"
+          "type": "CollectItem",
+          "announce_type": "Update",
+          "stage_id": {
+            "id": 104,
+            "group_id": 3,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1166,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1167,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1168,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1169,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1170,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1832,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1833,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1834,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1835,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1836,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1837,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1838,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1169,
-          "comment": "Spawns Glowing Item"
+          "type": "CollectItem",
+          "announce_type": "Update",
+          "stage_id": {
+            "id": 104,
+            "group_id": 4,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1166,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1167,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1168,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1169,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1170,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1832,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1833,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1834,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1835,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1836,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1837,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1838,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1170,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1832,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1833,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1834,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1835,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1836,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1837,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1838,
-          "comment": "Spawns Glowing Item"
+          "type": "NewTalkToNpc",
+          "stage_id": {
+            "id": 104,
+            "group_id": 13,
+            "layer_no": 1
+          },
+          "announce_type": "Update",
+          "npc_id": "Nelson",
+          "message_id": 11098
         }
       ]
     },
     {
-      "type": "CollectItem",
-      "announce_type": "Update",
-      "stage_id": {
-        "id": 104,
-        "group_id": 3,
-        "layer_no": 1
-      },
-      "flags": [
+      "blocks": [
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1166,
-          "comment": "Spawns Glowing Item"
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 0 } ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1167,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1168,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1169,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1170,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1832,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1833,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1834,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1835,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1836,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1837,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1838,
-          "comment": "Spawns Glowing Item"
+          "type": "SpawnGroup",
+          "groups": [0]
         }
       ]
-    },
-    {
-      "type": "CollectItem",
-      "announce_type": "Update",
-      "stage_id": {
-        "id": 104,
-        "group_id": 4,
-        "layer_no": 1
-      },
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1166,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1167,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1168,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1169,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1170,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1832,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1833,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1834,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1835,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1836,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1837,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1838,
-          "comment": "Spawns Glowing Item"
-        }
-      ]
-    },
-    {
-      "type": "NewTalkToNpc",
-      "stage_id": {
-        "id": 104,
-        "group_id": 13,
-        "layer_no": 1
-      },
-      "announce_type": "Update",
-      "npc_id": "Nelson",
-      "message_id": 11098
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005_1.json
@@ -45,292 +45,378 @@
       ]
     }
   ],
-  "blocks": [
+  "enemy_groups": [
     {
-      "type": "NewNpcTalkAndOrder",
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1048,
-          "comment": "Spawns Nelson NPC"
-        }
-      ],
       "stage_id": {
         "id": 104,
-        "group_id": 13,
-        "layer_no": 1
+        "group_id": 5
       },
-      "npc_id": "Nelson",
-      "message_id": 11095
-    },
-    {
-      "type": "CollectItem",
-      "announce_type": "Accept",
-      "result_commands": [
+      "enemies": [
         {
-          "comment": "Idle dialogue",
-          "type": "QstTalkChg",
-          "Param1": 1608,
-          "Param2": 11101
+          "comment": "Vigilant Shadow Goblin Slinger",
+          "enemy_id": "0x011132",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
+        },
+        {
+          "comment": "Vigilant Shadow Goblin Slinger",
+          "enemy_id": "0x011132",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
+        },
+        {
+          "comment": "Vigilant Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
+        },
+        {
+          "comment": "Vigilant Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
+        },
+        {
+          "comment": "Vigilant Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
+        },
+        {
+          "comment": "Vigilant Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
+        },
+        {
+          "comment": "Vigilant Shadow Goblin",
+          "enemy_id": "0x011130",
+          "named_enemy_params_id": 53,
+          "level": 45,
+          "exp": 175,
+          "is_required": false
         }
-      ],
-      "stage_id": {
-        "id": 104,
-        "group_id": 2,
-        "layer_no": 1
-      },
-      "flags": [
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1166,
-          "comment": "Spawns Glowing Item"
+          "type": "NewNpcTalkAndOrder",
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1048,
+              "comment": "Spawns Nelson NPC"
+            }
+          ],
+          "stage_id": {
+            "id": 104,
+            "group_id": 13,
+            "layer_no": 1
+          },
+          "npc_id": "Nelson",
+          "message_id": 11431
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1167,
-          "comment": "Spawns Glowing Item"
+          "type": "CollectItem",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 1608,
+              "Param2": 11101
+            },
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 0
+            }
+          ],
+          "stage_id": {
+            "id": 104,
+            "group_id": 2,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1166,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1167,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1168,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1169,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1170,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1832,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1833,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1834,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1835,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1836,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1837,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1838,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1168,
-          "comment": "Spawns Glowing Item"
+          "type": "CollectItem",
+          "announce_type": "Update",
+          "stage_id": {
+            "id": 104,
+            "group_id": 3,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1166,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1167,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1168,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1169,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1170,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1832,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1833,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1834,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1835,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1836,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1837,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1838,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1169,
-          "comment": "Spawns Glowing Item"
+          "type": "CollectItem",
+          "announce_type": "Update",
+          "stage_id": {
+            "id": 104,
+            "group_id": 4,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1166,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1167,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1168,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1169,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1170,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1832,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1833,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1834,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1835,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1836,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1837,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1838,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1170,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1832,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1833,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1834,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1835,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1836,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1837,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1838,
-          "comment": "Spawns Glowing Item"
+          "type": "NewTalkToNpc",
+          "stage_id": {
+            "id": 104,
+            "group_id": 13,
+            "layer_no": 1
+          },
+          "announce_type": "Update",
+          "npc_id": "Nelson",
+          "message_id": 11098
         }
       ]
     },
     {
-      "type": "CollectItem",
-      "announce_type": "Update",
-      "stage_id": {
-        "id": 104,
-        "group_id": 3,
-        "layer_no": 1
-      },
-      "flags": [
+      "blocks": [
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1166,
-          "comment": "Spawns Glowing Item"
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 0 } ]
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1167,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1168,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1169,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1170,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1832,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1833,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1834,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1835,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1836,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1837,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1838,
-          "comment": "Spawns Glowing Item"
+          "type": "SpawnGroup",
+          "groups": [0]
         }
       ]
-    },
-    {
-      "type": "CollectItem",
-      "announce_type": "Update",
-      "stage_id": {
-        "id": 104,
-        "group_id": 4,
-        "layer_no": 1
-      },
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1166,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1167,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1168,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1169,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1170,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1832,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1833,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1834,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1835,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1836,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1837,
-          "comment": "Spawns Glowing Item"
-        },
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 1838,
-          "comment": "Spawns Glowing Item"
-        }
-      ]
-    },
-    {
-      "type": "NewTalkToNpc",
-      "stage_id": {
-        "id": 104,
-        "group_id": 13,
-        "layer_no": 1
-      },
-      "announce_type": "Update",
-      "npc_id": "Nelson",
-      "message_id": 11098
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006.json
@@ -52,33 +52,6 @@
       },
       "enemies": [
         {
-          "comment": "Vigilant Rogue Fighter",
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 53,
-          "level": 26,
-          "exp": 118,
-          "is_boss": false,
-          "hm_present_no": 45
-        },
-        {
-          "comment": "Vigilant Rogue Fighter",
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 53,
-          "level": 26,
-          "exp": 118,
-          "is_boss": false,
-          "hm_present_no": 45
-        },
-        {
-          "comment": "Vigilant Rogue Fighter",
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 53,
-          "level": 26,
-          "exp": 118,
-          "is_boss": false,
-          "hm_present_no": 45
-        },
-        {
           "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
           "named_enemy_params_id": 53,
@@ -97,6 +70,33 @@
           "exp": 118,
           "is_boss": false,
           "hm_present_no": 46
+        },
+        {
+          "comment": "Vigilant Rogue Fighter",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
+          "is_boss": false,
+          "hm_present_no": 45
+        },
+        {
+          "comment": "Vigilant Rogue Fighter",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
+          "is_boss": false,
+          "hm_present_no": 45
+        },
+        {
+          "comment": "Vigilant Rogue Fighter",
+          "enemy_id": "0x011000",
+          "named_enemy_params_id": 53,
+          "level": 26,
+          "exp": 118,
+          "is_boss": false,
+          "hm_present_no": 45
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_1.json
@@ -53,6 +53,28 @@
       },
       "enemies": [
         {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 47,
+          "repop_count": 2,
+          "repop_wait_second": 5
+        },
+        {
+          "comment": "Vigilant Rogue Hunter",
+          "enemy_id": "0x011002",
+          "named_enemy_params_id": 53,
+          "level": 30,
+          "exp": 134,
+          "is_boss": false,
+          "hm_present_no": 47,
+          "repop_count": 2,
+          "repop_wait_second": 5
+        },
+        {
           "comment": "Vigilant Rogue Defender",
           "enemy_id": "0x011004",
           "named_enemy_params_id": 53,
@@ -79,28 +101,6 @@
           "is_boss": false,
           "hm_present_no": 49,
           "repop_count": 1,
-          "repop_wait_second": 5
-        },
-        {
-          "comment": "Vigilant Rogue Hunter",
-          "enemy_id": "0x011002",
-          "named_enemy_params_id": 53,
-          "level": 30,
-          "exp": 134,
-          "is_boss": false,
-          "hm_present_no": 47,
-          "repop_count": 2,
-          "repop_wait_second": 5
-        },
-        {
-          "comment": "Vigilant Rogue Hunter",
-          "enemy_id": "0x011002",
-          "named_enemy_params_id": 53,
-          "level": 30,
-          "exp": 134,
-          "is_boss": false,
-          "hm_present_no": 47,
-          "repop_count": 2,
           "repop_wait_second": 5
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040006_2.json
@@ -51,6 +51,7 @@
         "id": 138,
         "group_id": 1
       },
+      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Dangerous Chimera",
@@ -58,35 +59,40 @@
           "named_enemy_params_id": 56,
           "level": 57,
           "exp": 4620,
-          "is_boss": true
+          "is_boss": true,
+          "index": 0
         },
         {
           "comment": "Brutal Lapis Eye",
           "enemy_id": "0x015412",
           "named_enemy_params_id": 54,
           "level": 56,
-          "exp": 388
+          "exp": 388,
+          "index": 3
         },
         {
           "comment": "Brutal Lapis Eye",
           "enemy_id": "0x015412",
           "named_enemy_params_id": 54,
           "level": 56,
-          "exp": 388
+          "exp": 388,
+          "index": 4
         },
         {
           "comment": "Brutal Lapis Eye",
           "enemy_id": "0x015412",
           "named_enemy_params_id": 54,
           "level": 56,
-          "exp": 388
+          "exp": 388,
+          "index": 5
         },
         {
           "comment": "Brutal Lapis Eye",
           "enemy_id": "0x015412",
           "named_enemy_params_id": 54,
           "level": 56,
-          "exp": 388
+          "exp": 388,
+          "index": 6
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009.json
@@ -50,67 +50,67 @@
         "id": 102,
         "group_id": 3
       },
-      "starting_index": 6,
+      "placement_type": "manual",
       "enemies": [
         {
-          "comment": "Vigilant Rogue Seeker",
-          "enemy_id": "0x011001",
+          "comment": "Vigilant Rogue Defender",
+          "enemy_id": "0x011004",
+          "hm_present_no": 49,
           "named_enemy_params_id": 53,
           "start_think_table_no": 1,
           "level": 34,
           "exp": 148,
-          "is_boss": false,
-          "hm_present_no": 46
-        },
-        {
-          "comment": "Vigilant Rogue Seeker",
-          "enemy_id": "0x011001",
-          "named_enemy_params_id": 53,
-          "start_think_table_no": 1,
-          "level": 34,
-          "exp": 148,
-          "is_boss": false,
-          "hm_present_no": 46
+          "index": 5
         },
         {
           "comment": "Vigilant Rogue Defender",
           "enemy_id": "0x011004",
+          "hm_present_no": 49,
           "named_enemy_params_id": 53,
           "start_think_table_no": 1,
           "level": 34,
           "exp": 148,
-          "is_boss": false,
-          "hm_present_no": 49
+          "index": 6
         },
         {
           "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
+          "hm_present_no": 46,
           "named_enemy_params_id": 53,
           "start_think_table_no": 1,
           "level": 34,
           "exp": 148,
-          "is_boss": false,
-          "hm_present_no": 46
+          "index": 8
         },
         {
           "comment": "Vigilant Rogue Seeker",
           "enemy_id": "0x011001",
+          "hm_present_no": 46,
           "named_enemy_params_id": 53,
           "start_think_table_no": 1,
           "level": 34,
           "exp": 148,
-          "is_boss": false,
-          "hm_present_no": 46
+          "index": 9
         },
         {
-          "comment": "Vigilant Rogue Defender",
-          "enemy_id": "0x011004",
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "hm_present_no": 46,
           "named_enemy_params_id": 53,
           "start_think_table_no": 1,
           "level": 34,
           "exp": 148,
-          "is_boss": false,
-          "hm_present_no": 49
+          "index": 10
+        },
+        {
+          "comment": "Vigilant Rogue Seeker",
+          "enemy_id": "0x011001",
+          "hm_present_no": 46,
+          "named_enemy_params_id": 53,
+          "start_think_table_no": 1,
+          "level": 34,
+          "exp": 148,
+          "index": 11
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009_1.json
@@ -51,67 +51,67 @@
         "id": 102,
         "group_id": 3
       },
-      "starting_index": 6,
+      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Dangerous Rogue Healer",
           "enemy_id": "0x011003",
+          "hm_present_no": 48,
           "named_enemy_params_id": 56,
           "start_think_table_no": 1,
           "level": 46,
           "exp": 194,
-          "is_boss": false,
-          "hm_present_no": 48
-        },
-        {
-          "comment": "Dangerous Rogue Warrior",
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 56,
-          "start_think_table_no": 1,
-          "level": 46,
-          "exp": 194,
-          "is_boss": false,
-          "hm_present_no": 45
-        },
-        {
-          "comment": "Dangerous Rogue Warrior",
-          "enemy_id": "0x011000",
-          "named_enemy_params_id": 56,
-          "start_think_table_no": 1,
-          "level": 46,
-          "exp": 194,
-          "is_boss": false,
-          "hm_present_no": 45
+          "index": 5
         },
         {
           "comment": "Dangerous Rogue Healer",
           "enemy_id": "0x011003",
+          "hm_present_no": 48,
           "named_enemy_params_id": 56,
           "start_think_table_no": 1,
           "level": 46,
           "exp": 194,
-          "is_boss": false,
-          "hm_present_no": 48
+          "index": 6
         },
         {
           "comment": "Dangerous Rogue Warrior",
           "enemy_id": "0x011000",
+          "hm_present_no": 45,
           "named_enemy_params_id": 56,
           "start_think_table_no": 1,
           "level": 46,
           "exp": 194,
-          "is_boss": false,
-          "hm_present_no": 45
+          "index": 8
         },
         {
           "comment": "Dangerous Rogue Warrior",
           "enemy_id": "0x011000",
+          "hm_present_no": 45,
           "named_enemy_params_id": 56,
           "start_think_table_no": 1,
           "level": 46,
           "exp": 194,
-          "is_boss": false,
-          "hm_present_no": 45
+          "index": 9
+        },
+        {
+          "comment": "Dangerous Rogue Warrior",
+          "enemy_id": "0x011000",
+          "hm_present_no": 45,
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "index": 10
+        },
+        {
+          "comment": "Dangerous Rogue Warrior",
+          "enemy_id": "0x011000",
+          "hm_present_no": 45,
+          "named_enemy_params_id": 56,
+          "start_think_table_no": 1,
+          "level": 46,
+          "exp": 194,
+          "index": 11
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000.json
@@ -48,7 +48,7 @@
     {
       "stage_id": {
         "id": 72,
-        "group_id": 14
+        "group_id": 21
       },
       "enemies": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_1.json
@@ -49,7 +49,7 @@
     {
       "stage_id": {
         "id": 72,
-        "group_id": 14
+        "group_id": 21
       },
       "enemies": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_2.json
@@ -49,7 +49,7 @@
     {
       "stage_id": {
         "id": 72,
-        "group_id": 14
+        "group_id": 21
       },
       "enemies": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001.json
@@ -95,7 +95,7 @@
           "level": 27,
           "exp": 128,
           "is_boss": false,
-          "index": 11
+          "index": 12
         },
         {
           "comment": "Vigilant Skeleton Sorcerer",
@@ -104,7 +104,7 @@
           "level": 27,
           "exp": 128,
           "is_boss": false,
-          "index": 11
+          "index": 13
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003.json
@@ -50,6 +50,7 @@
         "id": 101,
         "group_id": 5
       },
+      "starting_index": 9,
       "enemies": [
         {
           "comment": "Vigilant Chimera",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_1.json
@@ -51,6 +51,7 @@
         "id": 101,
         "group_id": 5
       },
+      "starting_index": 9,
       "enemies": [
         {
           "comment": "Brutal Ogre",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004.json
@@ -50,6 +50,7 @@
         "id": 1,
         "group_id": 192
       },
+      "starting_index": 3,
       "enemies": [
         {
           "comment": "Vigilant Chimera",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004_1.json
@@ -51,6 +51,7 @@
         "id": 1,
         "group_id": 192
       },
+      "starting_index": 3,
       "enemies": [
         {
           "comment": "Brutal Colossus",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005.json
@@ -45,7 +45,6 @@
         "id": 96,
         "group_id": 2
       },
-      "starting_index": 5,
       "enemies": [
         {
           "comment": "Vigilant Rock Saurian",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005_1.json
@@ -51,7 +51,6 @@
         "id": 96,
         "group_id": 2
       },
-      "starting_index": 5,
       "enemies": [
         {
           "comment": "Brutal Rock Saurian",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045006.json
@@ -8,6 +8,10 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 546,
+  "order_conditions": [
+    {"type": "MinimumLevel", "Param1": 55},
+    {"type": "MainQuestCompleted", "Param1": 30}
+  ],
   "rewards": [
     {
       "type": "exp",
@@ -61,19 +65,19 @@
           "exp": 1660
         },
         {
-          "comment": "Death Calling Dark Knight (Death Knight)",
-          "enemy_id": "0x010310",
-          "named_enemy_params_id": 639,
-          "level": 58,
-          "exp": 1660
-        },
-        {
           "comment": "Demolition Fang (Behemoth)",
           "enemy_id": "0x015709",
           "named_enemy_params_id": 638,
           "level": 58,
           "exp": 9296,
           "is_boss": true
+        },
+        {
+          "comment": "Death Calling Dark Knight (Death Knight)",
+          "enemy_id": "0x010310",
+          "named_enemy_params_id": 639,
+          "level": 58,
+          "exp": 1660
         }
       ]
     },
@@ -86,20 +90,20 @@
       "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Death Courting Demon Princess (Empress Ghost)",
+          "enemy_id": "0x015605",
+          "named_enemy_params_id": 641,
+          "level": 58,
+          "exp": 4249,
+          "index": 3
+        },
+        {
           "comment": "Calamity Caller (Nightmare)",
           "enemy_id": "0x015305",
           "named_enemy_params_id": 640,
           "level": 58,
           "exp": 8831,
           "is_boss": true,
-          "index": 3
-        },
-        {
-          "comment": "Death Courting Demon Princess (Empress Ghost)",
-          "enemy_id": "0x015605",
-          "named_enemy_params_id": 641,
-          "level": 58,
-          "exp": 4249,
           "index": 4
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060000.json
@@ -61,11 +61,19 @@
         "layer_no": 1
       },
       "npc_id": "Hunter0",
-      "message_id": 11372
+      "message_id": 11204
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 541,
+          "Param2": 11210
+        }
+      ],
       "stage_id": {
         "id": 110,
         "group_id": 2,
@@ -213,11 +221,19 @@
       },
       "announce_type": "Update",
       "npc_id": "Hunter0",
-      "message_id": 11842
+      "message_id": 13340
     },
     {
       "type": "CollectItem",
       "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 541,
+          "Param2": 11210
+        }
+      ],
       "stage_id": {
         "id": 171,
         "group_id": 1,
@@ -271,7 +287,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Hunter0",
-      "message_id": 11842
+      "message_id": 11207
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060001_1.json
@@ -1,45 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Inias Monster",
+  "comment": "The Inias Monster (II)",
   "quest_id": 20060001,
-  "base_level": 36,
+  "base_level": 43,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 124,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "exp",
-      "amount": 1660
+      "amount": 1980
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1180
+      "amount": 1410
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 230
+      "amount": 280
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Crest of Electrocution",
+          "comment": "Bluish Gray Dragonscale",
+          "item_id": 7932,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Electroction",
           "item_id": 9262,
           "num": 1
         },
         {
-          "comment": "Superior Quality Gala Extract",
-          "item_id": 9362,
-          "num": 3
-        },
-        {
-          "comment": "Special Mushroom Dip",
-          "item_id": 9419,
-          "num": 2
+          "comment": "Demon's Talisman",
+          "item_id": 9389,
+          "num": 1
         }
       ]
     }
@@ -55,8 +56,8 @@
           "comment": "Brutal Lindwurm",
           "enemy_id": "0x015707",
           "named_enemy_params_id": 54,
-          "level": 36,
-          "exp": 6466,
+          "level": 43,
+          "exp": 7208,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060001_2.json
@@ -1,45 +1,46 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Inias Monster",
+  "comment": "The Inias Monster (Bounty)",
   "quest_id": 20060001,
-  "base_level": 36,
+  "base_level": 43,
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 124,
+  "variant_index": 2,
   "rewards": [
     {
       "type": "exp",
-      "amount": 1660
+      "amount": 3970
     },
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 1180
+      "amount": 2830
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 230
+      "amount": 280
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Crest of Electrocution",
-          "item_id": 9262,
-          "num": 1
-        },
-        {
-          "comment": "Superior Quality Gala Extract",
-          "item_id": 9362,
+          "comment": "Superior Healing Elixir",
+          "item_id": 7553,
           "num": 3
         },
         {
-          "comment": "Special Mushroom Dip",
-          "item_id": 9419,
-          "num": 2
+          "comment": "Enhanced Lockpick",
+          "item_id": 9403,
+          "num": 3
+        },
+        {
+          "comment": "Conqueror's Talisman",
+          "item_id": 9387,
+          "num": 1
         }
       ]
     }
@@ -52,11 +53,11 @@
       },
       "enemies": [
         {
-          "comment": "Brutal Lindwurm",
+          "comment": "Bounty Lindwurm",
           "enemy_id": "0x015707",
-          "named_enemy_params_id": 54,
-          "level": 36,
-          "exp": 6466,
+          "named_enemy_params_id": 512,
+          "level": 43,
+          "exp": 7208,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Protective Cloth",
           "item_id": 7940,
           "num": 1
         },
         {
+          "comment": "Angel's Talisman",
           "item_id": 9388,
           "num": 1
         },
         {
+          "comment": "Witch's Brew",
           "item_id": 9421,
           "num": 1
         }
@@ -58,11 +61,19 @@
         "layer_no": 1
       },
       "npc_id": "Soldier0",
-      "message_id": 11372
+      "message_id": 11220
     },
     {
       "type": "CollectItem",
       "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 536,
+          "Param2": 11226
+        }
+      ],
       "stage_id": {
         "id": 112,
         "group_id": 1,
@@ -282,7 +293,7 @@
       },
       "announce_type": "Update",
       "npc_id": "Soldier0",
-      "message_id": 11842
+      "message_id": 11223
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002_1.json
@@ -1,0 +1,349 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Grieving Underling (II)",
+  "quest_id": 20060002,
+  "base_level": 46,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeGrove",
+  "news_image": 566,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 1660
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1260
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 220
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mithril Ore",
+          "item_id": 7862,
+          "num": 3
+        },
+        {
+          "comment": "Healing Remedy",
+          "item_id": 7554,
+          "num": 3
+        },
+        {
+          "comment": "Strong Gala Extract",
+          "item_id": 9363,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 112,
+        "group_id": 2
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Brutal Mole Troll",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 54,
+          "level": 46,
+          "exp": 4260,
+          "is_boss": true,
+          "is_required": false
+        },
+        {
+          "comment": "Brutal Mole Troll",
+          "enemy_id": "0x015041",
+          "named_enemy_params_id": 54,
+          "level": 46,
+          "exp": 4260,
+          "is_boss": true,
+          "is_required": false
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NewNpcTalkAndOrder",
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1063,
+              "comment": "Spawns Soldier0 NPC"
+            }
+          ],
+          "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "npc_id": "Soldier0",
+          "message_id": 11220
+        },
+        {
+          "type": "CollectItem",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 536,
+              "Param2": 11226
+            },
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 0
+            }
+          ],
+          "stage_id": {
+            "id": 112,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1195,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1196,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1197,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1198,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1199,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1200,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1805,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1806,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1807,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1808,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
+        },
+        {
+          "type": "CollectItem",
+          "announce_type": "Update",
+          "stage_id": {
+            "id": 112,
+            "group_id": 2,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1195,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1196,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1197,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1198,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1199,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1200,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1805,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1806,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1807,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1808,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
+        },
+        {
+          "type": "CollectItem",
+          "announce_type": "Update",
+          "stage_id": {
+            "id": 112,
+            "group_id": 3,
+            "layer_no": 1
+          },
+          "flags": [
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1195,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1196,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1197,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1198,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1199,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1200,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1805,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1806,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1807,
+              "comment": "Spawns Glowing Item"
+            },
+            {
+              "type": "QstLayout",
+              "action": "Set",
+              "value": 1808,
+              "comment": "Spawns Glowing Item"
+            }
+          ]
+        },
+        {
+          "type": "NewTalkToNpc",
+          "stage_id": {
+            "id": 1,
+            "group_id": 1,
+            "layer_no": 1
+          },
+          "announce_type": "Update",
+          "npc_id": "Soldier0",
+          "message_id": 11223
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [ { "type": "MyQstFlagOn", "Param1": 0 } ]
+        },
+        {
+          "type": "SpawnGroup",
+          "groups": [0]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003.json
@@ -63,13 +63,11 @@
           "index": 3
         },
         {
-          "comment": "Vigilant Sling Redcap",
-          "enemy_id": "0x011112",
+          "comment": "Vigilant Redcap Fighter",
+          "enemy_id": "0x011111",
           "named_enemy_params_id": 53,
           "level": 34,
           "exp": 141,
-          "repop_count": 1,
-          "repop_wait_time": 10,
           "index": 4
         },
         {
@@ -78,11 +76,13 @@
           "named_enemy_params_id": 53,
           "level": 34,
           "exp": 141,
+          "repop_count": 1,
+          "repop_wait_time": 10,
           "index": 5
         },
         {
-          "comment": "Vigilant Redcap Fighter",
-          "enemy_id": "0x011111",
+          "comment": "Vigilant Sling Redcap",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 53,
           "level": 34,
           "exp": 141,
@@ -109,7 +109,7 @@
         {
           "comment": "Idle dialogue",
           "type": "QstTalkChg",
-          "Param1": 522,
+          "Param1": 4503,
           "Param2": 13303
         }
       ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003_1.json
@@ -64,8 +64,8 @@
           "index": 3
         },
         {
-          "comment": "Brutal Sling Redcap",
-          "enemy_id": "0x011112",
+          "comment": "Brutal Redcap Fighter",
+          "enemy_id": "0x011111",
           "named_enemy_params_id": 54,
           "level": 41,
           "exp": 166,
@@ -84,8 +84,8 @@
           "index": 5
         },
         {
-          "comment": "Brutal Redcap Fighter",
-          "enemy_id": "0x011111",
+          "comment": "Brutal Sling Redcap",
+          "enemy_id": "0x011112",
           "named_enemy_params_id": 54,
           "level": 41,
           "exp": 166,
@@ -114,7 +114,7 @@
         {
           "comment": "Idle dialogue",
           "type": "QstTalkChg",
-          "Param1": 522,
+          "Param1": 4503,
           "Param2": 13303
         }
       ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060003_2.json
@@ -58,19 +58,17 @@
           "enemy_id": "0x011160",
           "named_enemy_params_id": 54,
           "level": 46,
-          "exp": 472,
+          "exp": 236,
           "repop_count": 1,
           "repop_wait_time": 10,
           "index": 3
         },
         {
-          "comment": "Brutal Shadow Sling Goblin",
-          "enemy_id": "0x011132",
+          "comment": "Brutal Shadow Goblin Leader",
+          "enemy_id": "0x011160",
           "named_enemy_params_id": 54,
           "level": 46,
-          "exp": 390,
-          "repop_count": 2,
-          "repop_wait_time": 10,
+          "exp": 236,
           "index": 4
         },
         {
@@ -78,17 +76,19 @@
           "enemy_id": "0x011132",
           "named_enemy_params_id": 54,
           "level": 46,
-          "exp": 390,
-          "repop_count": 3,
+          "exp": 195,
+          "repop_count": 1,
           "repop_wait_time": 10,
           "index": 5
         },
         {
-          "comment": "Brutal Shadow Goblin Leader",
-          "enemy_id": "0x011160",
+          "comment": "Brutal Shadow Sling Goblin",
+          "enemy_id": "0x011132",
           "named_enemy_params_id": 54,
           "level": 46,
-          "exp": 472,
+          "exp": 195,
+          "repop_count": 2,
+          "repop_wait_time": 10,
           "index": 9
         }
       ]
@@ -112,7 +112,7 @@
         {
           "comment": "Idle dialogue",
           "type": "QstTalkChg",
-          "Param1": 522,
+          "Param1": 4503,
           "Param2": 13303
         }
       ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000_1.json
@@ -1,44 +1,45 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "A Faint Ill Omen",
+  "comment": "A Faint Ill Omen (II)",
   "quest_id": 20065000,
-  "base_level": 36,
+  "base_level": 40,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "MysreeGrove",
   "news_image": 128,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 990
+      "amount": 1320
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 150
+      "amount": 200
     },
     {
       "type": "exp",
-      "amount": 990
+      "amount": 1540
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Noir Gambeson",
-          "item_id": 8608,
-          "num": 1
+          "comment": "Gold Ingot",
+          "item_id": 7877,
+          "num": 2
         },
         {
-          "comment": "Demon's Talisman",
-          "item_id": 9389,
-          "num": 1
+          "comment": "Mithril Ingot",
+          "item_id": 7880,
+          "num": 3
         },
         {
-          "comment": "Throwing Knife",
-          "item_id": 9398,
+          "comment": "Forest Dweller's Old Key",
+          "item_id": 9066,
           "num": 3
         }
       ]
@@ -53,21 +54,21 @@
       "placement_type": "manual",
       "enemies": [
         {
-          "comment": "Vigilant Mist Priest",
-          "enemy_id": "0x011032",
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
           "named_enemy_params_id": 53,
-          "hm_present_no": 70,
-          "level": 36,
-          "exp": 188,
+          "hm_present_no": 69,
+          "level": 40,
+          "exp": 196,
           "index": 0
         },
         {
-          "comment": "Vigilant Mist Priest",
-          "enemy_id": "0x011032",
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
           "named_enemy_params_id": 53,
-          "hm_present_no": 70,
-          "level": 36,
-          "exp": 188,
+          "hm_present_no": 69,
+          "level": 40,
+          "exp": 196,
           "index": 3
         }
       ]
@@ -84,40 +85,40 @@
           "enemy_id": "0x011032",
           "named_enemy_params_id": 53,
           "hm_present_no": 70,
-          "level": 36,
-          "exp": 188
+          "level": 40,
+          "exp": 196
         },
         {
           "comment": "Vigilant Mist Priest",
           "enemy_id": "0x011032",
           "named_enemy_params_id": 53,
           "hm_present_no": 70,
-          "level": 36,
-          "exp": 188
+          "level": 40,
+          "exp": 196
         },
         {
-          "comment": "Vigilant Mist Sorcerer",
-          "enemy_id": "0x011033",
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
           "named_enemy_params_id": 53,
-          "hm_present_no": 71,
-          "level": 36,
-          "exp": 188
+          "hm_present_no": 69,
+          "level": 40,
+          "exp": 196
         },
         {
-          "comment": "Vigilant Mist Sorcerer",
-          "enemy_id": "0x011033",
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
           "named_enemy_params_id": 53,
-          "hm_present_no": 71,
-          "level": 36,
-          "exp": 188
+          "hm_present_no": 69,
+          "level": 40,
+          "exp": 196
         },
         {
-          "comment": "Vigilant Mist Sorcerer",
-          "enemy_id": "0x011033",
+          "comment": "Vigilant Mist Hunter",
+          "enemy_id": "0x011031",
           "named_enemy_params_id": 53,
-          "hm_present_no": 71,
-          "level": 36,
-          "exp": 188
+          "hm_present_no": 69,
+          "level": 40,
+          "exp": 196
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "Ruby",
           "item_id": 7900,
           "num": 2
         },
         {
+          "comment": "Sprite's Talisman",
           "item_id": 9390,
           "num": 1
         },
         {
+          "comment": "Three-Herb Salad",
           "item_id": 9410,
           "num": 2
         }
@@ -45,13 +48,16 @@
     {
       "stage_id": {
         "id": 112,
-        "group_id": 4
+        "group_id": 1
       },
+      "starting_index": 2,
       "enemies": [
         {
+          "comment": "Brutal Ent",
           "enemy_id": "0x015031",
+          "named_enemy_params_id": 54,
           "level": 40,
-          "exp": 12000,
+          "exp": 3380,
           "is_boss": true
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_1.json
@@ -1,0 +1,117 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Guardian of Green Leaves (II)",
+  "quest_id": 20065001,
+  "base_level": 41,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MysreeGrove",
+  "news_image": 567,
+  "variant_index": 1,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1350
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 210
+    },
+    {
+      "type": "exp",
+      "amount": 1890
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Rosewood",
+          "item_id": 7900,
+          "num": 3
+        },
+        {
+          "comment": "Harvest Salad",
+          "item_id": 9390,
+          "num": 1
+        },
+        {
+          "comment": "Throwblast",
+          "item_id": 9410,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 112,
+        "group_id": 1
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Brutal Ent",
+          "enemy_id": "0x015031",
+          "named_enemy_params_id": 54,
+          "level": 41,
+          "exp": 3432,
+          "is_boss": true
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 112,
+        "group_id": 3
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "SpawnGroup",
+      "groups": [ 0 , 1 ],
+      "check_commands": [{"type": "IsEnemyFound", "Param1": 527, "Param2": 1, "Param3": 2}]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 , 1 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_2.json
@@ -1,0 +1,119 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "The Guardian of Green Leaves (III)",
+  "quest_id": 20065001,
+  "base_level": 55,
+  "minimum_item_rank": 0,
+  "discoverable": false,
+  "area_id": "MysreeGrove",
+  "news_image": 567,
+  "variant_index": 2,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 1810
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "exp",
+      "amount": 2110
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Writhing Live Bark",
+          "item_id": 7900,
+          "num": 1
+        },
+        {
+          "comment": "Ent Seed",
+          "item_id": 9390,
+          "num": 2
+        },
+        {
+          "comment": "Ent Branch",
+          "item_id": 9410,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 112,
+        "group_id": 1
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Dangerous Ent",
+          "enemy_id": "0x015031",
+          "named_enemy_params_id": 56,
+          "level": 55,
+          "exp": 4160,
+          "is_boss": true
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 112,
+        "group_id": 3
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 149,
+          "repop_count": 1,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 149
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 149
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "named_enemy_params_id": 53,
+          "level": 55,
+          "exp": 149
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "SpawnGroup",
+      "groups": [ 0 , 1 ],
+      "check_commands": [{"type": "IsEnemyFound", "Param1": 527, "Param2": 1, "Param3": 2}]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 , 1 ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065002_1.json
@@ -1,44 +1,45 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Unbidden Guest",
+  "comment": "The Unbidden Guest (II)",
   "quest_id": 20065002,
-  "base_level": 35,
+  "base_level": 55,
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "MysreeGrove",
   "news_image": 564,
+  "variant_index": 1,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 960
+      "amount": 1510
     },
     {
       "type": "wallet",
       "wallet_type": "RiftPoints",
-      "amount": 150
+      "amount": 240
     },
     {
       "type": "exp",
-      "amount": 1150
+      "amount": 1510
     },
     {
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Soldier Arms",
-          "item_id": 711,
+          "comment": "Sand of Reminiscence",
+          "item_id": 9441,
           "num": 1
         },
         {
-          "comment": "Refreshing Remedy",
-          "item_id": 9375,
-          "num": 3
+          "comment": "Demonic Gem",
+          "item_id": 7911,
+          "num": 1
         },
         {
-          "comment": "Three-Herb Salad",
-          "item_id": 9410,
+          "comment": "Cracked Black Horn",
+          "item_id": 7753,
           "num": 2
         }
       ]
@@ -53,36 +54,36 @@
       "starting_index": 5,
       "enemies": [
         {
-          "comment": "Vigilant Giant Sulfur Saurian",
-          "enemy_id": "0x010411",
-          "named_enemy_params_id": 53,
-          "level": 35,
-          "exp": 201,
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
           "repop_count": 1,
           "repop_wait_second": 10
         },
         {
-          "comment": "Vigilant Giant Sulfur Saurian",
-          "enemy_id": "0x010411",
-          "named_enemy_params_id": 53,
-          "level": 35,
-          "exp": 201,
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
           "repop_count": 1,
           "repop_wait_second": 10
         },
         {
-          "comment": "Vigilant Giant Sulfur Saurian",
-          "enemy_id": "0x010411",
-          "named_enemy_params_id": 53,
-          "level": 35,
-          "exp": 201
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_second": 10
         },
         {
-          "comment": "Vigilant Giant Sulfur Saurian",
-          "enemy_id": "0x010411",
-          "named_enemy_params_id": 53,
-          "level": 35,
-          "exp": 201
+          "comment": "Shadow Goblin",
+          "enemy_id": "0x011130",
+          "level": 55,
+          "exp": 223,
+          "repop_count": 1,
+          "repop_wait_second": 10
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065003.json
@@ -27,14 +27,17 @@
       "type": "select",
       "loot_pool": [
         {
+          "comment": "White Shining Sand",
           "item_id": 7851,
           "num": 3
         },
         {
+          "comment": "Special Mushroom Dip",
           "item_id": 9419,
           "num": 1
         },
         {
+          "comment": "Enhanced Pickaxe",
           "item_id": 9401,
           "num": 3
         }
@@ -45,21 +48,19 @@
     {
       "stage_id": {
         "id": 1,
-        "group_id": 148
+        "group_id": 149
       },
-      "placement_type": "manual",
+      "starting_index": 3,
       "enemies": [
         {
-          "comment": "Silv roar",
+          "comment": "Brutal Silver Roar",
           "enemy_id": "0x015505",
           "start_think_tbl_no": 1,
-		      "named_enemy_params_id": 56,
+          "named_enemy_params_id": 54,
           "level": 41,
-          "exp": 6590,
-          "is_boss": true,
-          "is_manual_set": false,
-          "index": 4
-        } 
+          "exp": 3287,
+          "is_boss": true
+        }
       ]
     }
   ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065004.json
@@ -8,6 +8,10 @@
   "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 567,
+  "order_conditions": [
+    {"type": "MinimumLevel", "Param1": 55},
+    {"type": "MainQuestCompleted", "Param1": 30}
+  ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080000.json
@@ -43,113 +43,192 @@
             ]
         }
     ],
-    "blocks": [
+    "enemy_groups": [
         {
-            "type": "NewNpcTalkAndOrder",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1069, "comment": "Spawns Peddler NPC"}
-            ],
-            "stage_id": {
-                "id": 54,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "npc_id": "Peddler",
-            "message_id": 8682
-        },
-        {
-            "type": "CollectItem",
-            "announce_type": "Accept",
             "stage_id": {
                 "id": 32,
-                "group_id": 1,
-                "layer_no": 1
+                "group_id": 0
             },
-            "result_commands": [
+            "starting_index": 9,
+            "enemies": [
                 {
-                    "comment": "Idle dialogue",
-                    "type": "QstTalkChg",
-                    "Param1": 509,
-                    "Param2": 8688
+                    "comment": "Vigilant Mist Fighter",
+                    "enemy_id": "0x011030",
+                    "named_enemy_params_id": 53,
+                    "level": 46,
+                    "exp": 223,
+                    "hm_present_no": 68
+                },
+                {
+                    "comment": "Vigilant Mist Sorcerer",
+                    "enemy_id": "0x011033",
+                    "named_enemy_params_id": 53,
+                    "level": 46,
+                    "exp": 223,
+                    "hm_present_no": 71
+                },
+                {
+                    "comment": "Vigilant Mist Fighter",
+                    "enemy_id": "0x011030",
+                    "named_enemy_params_id": 53,
+                    "level": 46,
+                    "exp": 223,
+                    "hm_present_no": 68
+                },
+                {
+                    "comment": "Vigilant Mist Sorcerer",
+                    "enemy_id": "0x011033",
+                    "named_enemy_params_id": 53,
+                    "level": 46,
+                    "exp": 223,
+                    "hm_present_no": 71
+                },
+                {
+                    "comment": "Vigilant Mist Sorcerer",
+                    "enemy_id": "0x011033",
+                    "named_enemy_params_id": 53,
+                    "level": 46,
+                    "exp": 223,
+                    "hm_present_no": 71
+                },
+                {
+                    "comment": "Vigilant Mist Sorcerer",
+                    "enemy_id": "0x011033",
+                    "named_enemy_params_id": 53,
+                    "level": 46,
+                    "exp": 223,
+                    "hm_present_no": 71
                 }
-            ],
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1755, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1756, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1757, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1758, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1759, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1760, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1761, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1762, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1763, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1764, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2452, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2453, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2454, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2455, "comment": "Spawns Glowing Item"}
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "NewNpcTalkAndOrder",
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1069, "comment": "Spawns Peddler NPC"}
+                    ],
+                    "stage_id": {
+                        "id": 54,
+                        "group_id": 1,
+                        "layer_no": 1
+                    },
+                    "npc_id": "Peddler",
+                    "message_id": 8682
+                },
+                {
+                    "type": "CollectItem",
+                    "announce_type": "Accept",
+                    "stage_id": {
+                        "id": 32,
+                        "group_id": 1,
+                        "layer_no": 1
+                    },
+                    "result_commands": [
+                        {
+                            "comment": "Idle dialogue",
+                            "type": "QstTalkChg",
+                            "Param1": 509,
+                            "Param2": 8688
+                        },
+                        {
+                            "type": "MyQstFlagOn",
+                            "Param1": 0
+                        }
+                    ],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1755, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1756, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1757, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1758, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1759, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1760, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1761, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1762, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1763, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1764, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2452, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2453, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2454, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2455, "comment": "Spawns Glowing Item"}
+                    ]
+                },
+                {
+                    "type": "CollectItem",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 32,
+                        "group_id": 2,
+                        "layer_no": 1
+                    },
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1755, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1756, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1757, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1758, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1759, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1760, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1761, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1762, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1763, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1764, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2452, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2453, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2454, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2455, "comment": "Spawns Glowing Item"}
+                    ]
+                },
+                {
+                    "type": "CollectItem",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 32,
+                        "group_id": 3,
+                        "layer_no": 1
+                    },
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1755, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1756, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1757, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1758, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1759, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1760, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1761, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1762, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1763, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 1764, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2452, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2453, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2454, "comment": "Spawns Glowing Item"},
+                        {"type": "QstLayout", "action": "Set", "value": 2455, "comment": "Spawns Glowing Item"}
+                    ]
+                },
+                {
+                    "type": "NewTalkToNpc",
+                    "stage_id": {
+                        "id": 54,
+                        "group_id": 1,
+                        "layer_no": 1
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Peddler",
+                    "message_id": 8685
+                }
             ]
         },
         {
-            "type": "CollectItem",
-            "announce_type": "Update",
-            "stage_id": {
-                "id": 32,
-                "group_id": 2,
-                "layer_no": 1
-            },
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1755, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1756, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1757, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1758, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1759, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1760, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1761, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1762, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1763, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1764, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2452, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2453, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2454, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2455, "comment": "Spawns Glowing Item"}
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [ { "type": "MyQstFlagOn", "Param1": 0 } ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
             ]
-        },
-        {
-            "type": "CollectItem",
-            "announce_type": "Update",
-            "stage_id": {
-                "id": 32,
-                "group_id": 3,
-                "layer_no": 1
-            },
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1755, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1756, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1757, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1758, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1759, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1760, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1761, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1762, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1763, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 1764, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2452, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2453, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2454, "comment": "Spawns Glowing Item"},
-                {"type": "QstLayout", "action": "Set", "value": 2455, "comment": "Spawns Glowing Item"}
-            ]
-        },
-        {
-            "type": "NewTalkToNpc",
-            "stage_id": {
-                "id": 54,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Peddler",
-            "message_id": 8685
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080001.json
@@ -52,6 +52,16 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Brutal Empress Ghost",
+                    "enemy_id": "0x015605",
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 2,
+                    "level": 48,
+                    "exp": 3738,
+                    "is_boss": true,
+                    "index": 2
+                },
+                {
                     "comment": "Skeleton Warrior",
                     "enemy_id": "0x010302",
                     "start_think_tbl_no": 8,
@@ -80,16 +90,6 @@
                     "is_required": false,
                     "is_manual_set": true,
                     "index": 10
-                },
-                {
-                    "comment": "Brutal Empress Ghost",
-                    "enemy_id": "0x015605",
-                    "named_enemy_params_id": 54,
-                    "start_think_tbl_no": 2,
-                    "level": 48,
-                    "exp": 3738,
-                    "is_boss": true,
-                    "index": 2
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080001_1.json
@@ -53,6 +53,15 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Dangerous Empress Ghost",
+                    "enemy_id": "0x015605",
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 3840,
+                    "is_boss": true,
+                    "index": 2
+                },
+                {
                     "comment": "Brutal Ghost Mail",
                     "enemy_id": "0x010311",
                     "named_enemy_params_id": 54,
@@ -75,15 +84,6 @@
                     "level": 50,
                     "exp": 600,
                     "index": 10
-                },
-                {
-                    "comment": "Dangerous Empress Ghost",
-                    "enemy_id": "0x015605",
-                    "named_enemy_params_id": 56,
-                    "level": 50,
-                    "exp": 3840,
-                    "is_boss": true,
-                    "index": 2
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080002_1.json
@@ -60,20 +60,11 @@
                     "exp": 1500
                 },
                 {
-                    "comment": "Brutal Living Armor",
-                    "enemy_id": "0x010306",
-                    "named_enemy_params_id": 54,
-                    "level": 50,
-                    "exp": 1500
-                },
-                {
                     "comment": "Vigilant Frost Corpse Torturer",
                     "enemy_id": "0x010512",
                     "named_enemy_params_id": 53,
                     "level": 50,
-                    "exp": 254,
-                    "repop_count": 1,
-                    "repop_wait_second": 10
+                    "exp": 254
                 },
                 {
                     "comment": "Vigilant Frost Corpse Torturer",
@@ -81,6 +72,20 @@
                     "named_enemy_params_id": 53,
                     "level": 50,
                     "exp": 254
+                },
+                {
+                    "comment": "Vigilant Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "named_enemy_params_id": 53,
+                    "level": 50,
+                    "exp": 254
+                },
+                {
+                    "comment": "Brutal Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 54,
+                    "level": 50,
+                    "exp": 1500
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080003.json
@@ -157,7 +157,40 @@
             },
             "placement_type": "manual",
             "enemies": [
-               {
+                {
+                    "comment": "Brutal Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 279,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 6
+                },
+                {
+                    "comment": "Brutal Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 279,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 7
+                },
+                {
+                    "comment": "Brutal Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 279,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 8
+                },
+                {
                     "comment": "Dangerous White Chimera",
                     "enemy_id": "0x015202",
                     "start_think_tbl_no": 1,
@@ -165,39 +198,6 @@
                     "level": 57,
                     "is_boss": true,
                     "exp": 5937,
-                    "index": 0
-                },
-                {
-                    "comment": "Brutal Shadow Wolf",
-                    "enemy_id": "0x010206",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 54,
-                    "level": 56,
-                    "exp": 279,
-                    "repop_count": 1,
-                    "repop_wait_second": 10,
-                    "index": 1
-                },
-                {
-                    "comment": "Brutal Shadow Wolf",
-                    "enemy_id": "0x010206",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 54,
-                    "level": 56,
-                    "exp": 279,
-                    "repop_count": 1,
-                    "repop_wait_second": 10,
-                    "index": 9
-                },
-                {
-                    "comment": "Brutal Shadow Wolf",
-                    "enemy_id": "0x010206",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 54,
-                    "level": 56,
-                    "exp": 279,
-                    "repop_count": 1,
-                    "repop_wait_second": 10,
                     "index": 10
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
@@ -60,44 +60,8 @@
                 "id": 169,
                 "group_id": 1
             },
-            "placement_type": "manual",
+            "starting_index": 6,
             "enemies": [
-                {
-                    "comment": "Vigilant Banded Hunter",
-                    "enemy_id": "0x011012",
-                    "named_enemy_params_id": 53,
-                    "hm_present_no": 54,
-                    "level": 46,
-                    "exp": 231,
-                    "index": 5
-                },
-                {
-                    "comment": "Vigilant Banded Hunter",
-                    "enemy_id": "0x011012",
-                    "named_enemy_params_id": 53,
-                    "hm_present_no": 54,
-                    "level": 46,
-                    "exp": 231,
-                    "index": 6
-                },
-                {
-                    "comment": "Vigilant Banded Hunter",
-                    "enemy_id": "0x011012",
-                    "named_enemy_params_id": 53,
-                    "hm_present_no": 54,
-                    "level": 46,
-                    "exp": 231,
-                    "index": 7
-                },
-                {
-                    "comment": "Vigilant Banded Hunter",
-                    "enemy_id": "0x011012",
-                    "named_enemy_params_id": 53,
-                    "hm_present_no": 54,
-                    "level": 46,
-                    "exp": 231,
-                    "index": 8
-                },
                 {
                     "comment": "Vigilant Banded Fighter",
                     "enemy_id": "0x011010",
@@ -105,9 +69,50 @@
                     "hm_present_no": 52,
                     "level": 46,
                     "exp": 231,
-                    "repop_count": 2,
-                    "repop_wait_second": 10,
-                    "index": 11
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Vigilant Banded Hunter",
+                    "enemy_id": "0x011012",
+                    "named_enemy_params_id": 53,
+                    "hm_present_no": 54,
+                    "level": 46,
+                    "exp": 231,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Vigilant Banded Hunter",
+                    "enemy_id": "0x011012",
+                    "named_enemy_params_id": 53,
+                    "hm_present_no": 54,
+                    "level": 46,
+                    "exp": 231
+                },
+                {
+                    "comment": "Vigilant Banded Hunter",
+                    "enemy_id": "0x011012",
+                    "named_enemy_params_id": 53,
+                    "hm_present_no": 54,
+                    "level": 46,
+                    "exp": 231
+                },
+                {
+                    "comment": "Vigilant Banded Fighter",
+                    "enemy_id": "0x011010",
+                    "named_enemy_params_id": 53,
+                    "hm_present_no": 52,
+                    "level": 46,
+                    "exp": 231
+                },
+                {
+                    "comment": "Vigilant Banded Hunter",
+                    "enemy_id": "0x011012",
+                    "named_enemy_params_id": 53,
+                    "hm_present_no": 54,
+                    "level": 46,
+                    "exp": 231
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_1.json
@@ -50,44 +50,8 @@
                 "id": 169,
                 "group_id": 1
             },
-            "placement_type": "manual",
+            "starting_index": 6,
             "enemies": [
-                {
-                    "comment": "Brutal Banded Mage",
-                    "enemy_id": "0x011015",
-                    "named_enemy_params_id": 54,
-                    "hm_present_no": 57,
-                    "level": 47,
-                    "exp": 234,
-                    "index": 5
-                },
-                {
-                    "comment": "Brutal Banded Mage",
-                    "enemy_id": "0x011015",
-                    "named_enemy_params_id": 54,
-                    "hm_present_no": 57,
-                    "level": 47,
-                    "exp": 234,
-                    "index": 6
-                },
-                {
-                    "comment": "Brutal Banded Mage",
-                    "enemy_id": "0x011015",
-                    "named_enemy_params_id": 54,
-                    "hm_present_no": 57,
-                    "level": 47,
-                    "exp": 234,
-                    "index": 7
-                },
-                {
-                    "comment": "Brutal Banded Mage",
-                    "enemy_id": "0x011015",
-                    "named_enemy_params_id": 54,
-                    "hm_present_no": 57,
-                    "level": 47,
-                    "exp": 234,
-                    "index": 8
-                },
                 {
                     "comment": "Brutal Banded Hunter",
                     "enemy_id": "0x011012",
@@ -95,9 +59,50 @@
                     "hm_present_no": 54,
                     "level": 47,
                     "exp": 234,
-                    "index": 11,
-                    "repop_count": 2,
+                    "repop_count": 1,
                     "repop_wait_second": 10
+                },
+                {
+                    "comment": "Brutal Banded Mage",
+                    "enemy_id": "0x011015",
+                    "named_enemy_params_id": 54,
+                    "hm_present_no": 57,
+                    "level": 47,
+                    "exp": 234,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Brutal Banded Mage",
+                    "enemy_id": "0x011015",
+                    "named_enemy_params_id": 54,
+                    "hm_present_no": 57,
+                    "level": 47,
+                    "exp": 234
+                },
+                {
+                    "comment": "Brutal Banded Mage",
+                    "enemy_id": "0x011015",
+                    "named_enemy_params_id": 54,
+                    "hm_present_no": 57,
+                    "level": 47,
+                    "exp": 234
+                },
+                {
+                    "comment": "Brutal Banded Hunter",
+                    "enemy_id": "0x011012",
+                    "named_enemy_params_id": 54,
+                    "hm_present_no": 54,
+                    "level": 47,
+                    "exp": 234
+                },
+                {
+                    "comment": "Brutal Banded Mage",
+                    "enemy_id": "0x011015",
+                    "named_enemy_params_id": 54,
+                    "hm_present_no": 57,
+                    "level": 47,
+                    "exp": 234
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_2.json
@@ -50,49 +50,53 @@
                 "id": 169,
                 "group_id": 1
             },
-            "placement_type": "manual",
+            "starting_index": 6,
             "enemies": [
-                {
-                    "comment": "Vigilant Shadow Goblin Fighter",
-                    "enemy_id": "0x011131",
-                    "named_enemy_params_id": 53,
-                    "level": 48,
-                    "exp": 195,
-                    "index": 5
-                },
-                {
-                    "comment": "Vigilant Shadow Goblin Fighter",
-                    "enemy_id": "0x011131",
-                    "named_enemy_params_id": 53,
-                    "level": 48,
-                    "exp": 195,
-                    "index": 6
-                },
-                {
-                    "comment": "Vigilant Shadow Goblin Fighter",
-                    "enemy_id": "0x011131",
-                    "named_enemy_params_id": 53,
-                    "level": 48,
-                    "exp": 195,
-                    "index": 7
-                },
-                {
-                    "comment": "Vigilant Shadow Goblin Fighter",
-                    "enemy_id": "0x011131",
-                    "named_enemy_params_id": 53,
-                    "level": 48,
-                    "exp": 195,
-                    "index": 8
-                },
                 {
                     "comment": "Vigilant Shadow Goblin",
                     "enemy_id": "0x011130",
                     "named_enemy_params_id": 53,
                     "level": 48,
                     "exp": 183,
-                    "repop_count": 2,
-                    "repop_wait_second": 5,
-                    "index": 11
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 195,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 195
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 195
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin",
+                    "enemy_id": "0x011130",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 183
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 195
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080007_2.json
@@ -7,7 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
-    "variant_index": 3,
+    "variant_index": 2,
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085000_1.json
@@ -61,8 +61,35 @@
                 "id": 149,
                 "group_id": 2
             },
-            "starting_index": 7,
+            "starting_index": 8,
             "enemies": [
+                {
+                    "comment": "Dangerous Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 56,
+                    "start_think_tbl_no": 0,
+                    "level": 55,
+                    "exp": 1120,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Dangerous Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 56,
+                    "start_think_tbl_no": 0,
+                    "level": 55,
+                    "exp": 1120,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Dangerous Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 56,
+                    "start_think_tbl_no": 0,
+                    "level": 55,
+                    "exp": 1120,
+                    "is_boss": false
+                },
                 {
                     "comment": "Legendary Empress Ghost",
                     "enemy_id": "0x015605",
@@ -71,33 +98,6 @@
                     "level": 55,
                     "exp": 4095,
                     "is_boss": true
-                },
-                {
-                    "comment": "Dangerous Living Armor",
-                    "enemy_id": "0x010306",
-                    "named_enemy_params_id": 56,
-                    "start_think_tbl_no": 0,
-                    "level": 55,
-                    "exp": 1120,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Dangerous Living Armor",
-                    "enemy_id": "0x010306",
-                    "named_enemy_params_id": 56,
-                    "start_think_tbl_no": 0,
-                    "level": 55,
-                    "exp": 1120,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Dangerous Living Armor",
-                    "enemy_id": "0x010306",
-                    "named_enemy_params_id": 56,
-                    "start_think_tbl_no": 0,
-                    "level": 55,
-                    "exp": 1120,
-                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001.json
@@ -6,7 +6,7 @@
     "base_level": 46,
     "minimum_item_rank": 0,
     "discoverable": false,
-  "area_id": "EasternZandora",	
+    "area_id": "EasternZandora",
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Pigeon Blood",
                     "item_id": 7910,
                     "num": 1
                 },
                 {
+                    "comment": "Healing Elixir",
                     "item_id": 7554,
                     "num": 3
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 3
                 }
@@ -48,34 +51,54 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x015801",
-                    "level": 47,
-                    "exp": 1300,
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 269,
+                    "is_boss": false,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 269,
                     "is_boss": false
-        },
-        {
-                    "enemy_id": "0x015801",
-                    "level": 47,
-                    "exp": 1300,
+                },
+                {
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 269,
                     "is_boss": false
-        },
-        {
-                    "enemy_id": "0x015801",
-                    "level": 47,
-                    "exp": 1300,
+                },
+                {
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 269,
                     "is_boss": false
-        },
-        {
-                    "enemy_id": "0x015801",
-                    "level": 47,
-                    "exp": 1300,
+                },
+                {
+                    "comment": "Brutal Captain Orc",
+                    "enemy_id": "0x015820",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 573,
                     "is_boss": false
-        },
-        {
-                    "enemy_id": "0x015801",
-                    "level": 47,
-                    "exp": 1300,
-                    "is_boss": false							
+                },
+                {
+                    "comment": "Brutal Captain Orc",
+                    "enemy_id": "0x015820",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 573,
+                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001_1.json
@@ -1,9 +1,9 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "An Ancient Perseverance (II)",
-    "quest_id": 20085009,
-    "base_level": 49,
+    "comment": "The Mighty Brutes (II)",
+    "quest_id": 20085001,
+    "base_level": 47,
     "minimum_item_rank": 0,
     "discoverable": false,
     "area_id": "EasternZandora",
@@ -12,28 +12,28 @@
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1340
+            "amount": 1030
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 210
+            "amount": 200
         },
         {
             "type": "exp",
-            "amount": 1610
+            "amount": 1290
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Cursed Skull",
-                    "item_id": 7772,
+                    "comment": "Pigeon Blood",
+                    "item_id": 7910,
                     "num": 1
                 },
                 {
-                    "comment": "Bone Meal",
-                    "item_id": 7850,
+                    "comment": "Orc's War Tusk",
+                    "item_id": 7761,
                     "num": 3
                 },
                 {
@@ -47,58 +47,59 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 65,
-                "group_id": 0
+                "id": 1,
+                "group_id": 452
             },
-            "placement_type": "manual",
             "enemies": [
                 {
-                    "comment": "Brutal Skeleton Warrior",
-                    "enemy_id": "0x010302",
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
                     "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 232,
-                    "index": 0
+                    "level": 47,
+                    "exp": 273,
+                    "is_boss": false,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Skeleton Warrior",
-                    "enemy_id": "0x010302",
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
                     "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 232,
-                    "index": 3
+                    "level": 47,
+                    "exp": 273,
+                    "is_boss": false
                 },
                 {
-                    "comment": "Brutal Skull Lord",
-                    "enemy_id": "0x010313",
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
                     "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 1148,
-                    "index": 6
+                    "level": 47,
+                    "exp": 273,
+                    "is_boss": false
                 },
                 {
-                    "comment": "Brutal Skeleton Warrior",
-                    "enemy_id": "0x010302",
+                    "comment": "Brutal Orc Trooper",
+                    "enemy_id": "0x015812",
                     "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 232,
-                    "index": 7
+                    "level": 47,
+                    "exp": 273,
+                    "is_boss": false
                 },
                 {
-                    "comment": "Brutal Skeleton Warrior",
-                    "enemy_id": "0x010302",
+                    "comment": "Brutal Orc General",
+                    "enemy_id": "0x015830",
                     "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 232,
-                    "index": 8
+                    "level": 47,
+                    "exp": 1337,
+                    "is_boss": false
                 },
                 {
-                    "comment": "Brutal Skull Lord",
-                    "enemy_id": "0x010313",
+                    "comment": "Brutal Orc General",
+                    "enemy_id": "0x015830",
                     "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 1148,
-                    "index": 9
+                    "level": 47,
+                    "exp": 1337,
+                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085002_1.json
@@ -50,6 +50,7 @@
                 "id": 1,
                 "group_id": 449
             },
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Brutal Ghost Mail",
@@ -58,16 +59,8 @@
                     "start_think_tbl_no": 1,
                     "level": 47,
                     "exp": 576,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Brutal Ghost Mail",
-                    "enemy_id": "0x010311",
-                    "named_enemy_params_id": 54,
-                    "start_think_tbl_no": 1,
-                    "level": 47,
-                    "exp": 576,
-                    "is_boss": false
+                    "is_boss": false,
+                    "index": 0
                 },
                 {
                     "comment": "Vigilant Skeleton Warrior",
@@ -78,7 +71,18 @@
                     "exp": 224,
                     "is_boss": false,
                     "repop_count": 1,
-                    "repop_wait_second": 10
+                    "repop_wait_second": 10,
+                    "index": 1
+                },
+                {
+                    "comment": "Brutal Ghost Mail",
+                    "enemy_id": "0x010311",
+                    "named_enemy_params_id": 54,
+                    "start_think_tbl_no": 1,
+                    "level": 47,
+                    "exp": 576,
+                    "is_boss": false,
+                    "index": 8
                 }
             ]
         }
@@ -101,7 +105,7 @@
                 {
                     "comment": "Idle dialogue",
                     "type": "QstTalkChg",
-                    "Param1": 541,
+                    "Param1": 1814,
                     "Param2": 16041
                 }
             ],

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003.json
@@ -49,8 +49,15 @@
                 "id": 1,
                 "group_id": 468
             },
-            "starting_index": 8,
+            "starting_index": 5,
             "enemies": [
+                {
+                    "comment": "Brutal Orc Captain",
+                    "enemy_id": "0x015820",
+                    "named_enemy_params_id": 54,
+                    "level": 46,
+                    "exp": 564
+                },
                 {
                     "comment": "Brutal Grimwarg",
                     "enemy_id": "0x010205",
@@ -87,13 +94,6 @@
                     "named_enemy_params_id": 54,
                     "level": 46,
                     "exp": 234
-                },
-                {
-                    "comment": "Brutal Orc Captain",
-                    "enemy_id": "0x015820",
-                    "named_enemy_params_id": 54,
-                    "level": 46,
-                    "exp": 564
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_1.json
@@ -50,43 +50,8 @@
                 "id": 1,
                 "group_id": 468
             },
-            "starting_index": 8,
+            "starting_index": 5,
             "enemies": [
-                {
-                    "comment": "Brutal Orc Blitzer",
-                    "enemy_id": "0x015811",
-                    "named_enemy_params_id": 54,
-                    "level": 47,
-                    "exp": 273
-                },
-                {
-                    "comment": "Brutal Orc Blitzer",
-                    "enemy_id": "0x015811",
-                    "named_enemy_params_id": 54,
-                    "level": 47,
-                    "exp": 273
-                },
-                {
-                    "comment": "Brutal Orc Blitzer",
-                    "enemy_id": "0x015811",
-                    "named_enemy_params_id": 54,
-                    "level": 47,
-                    "exp": 273
-                },
-                {
-                    "comment": "Brutal Orc Blitzer",
-                    "enemy_id": "0x015811",
-                    "named_enemy_params_id": 54,
-                    "level": 47,
-                    "exp": 273
-                },
-                {
-                    "comment": "Brutal Orc Blitzer",
-                    "enemy_id": "0x015811",
-                    "named_enemy_params_id": 54,
-                    "level": 47,
-                    "exp": 273
-                },
                 {
                     "comment": "Brutal Orc Captain",
                     "enemy_id": "0x015820",
@@ -95,6 +60,41 @@
                     "exp": 573,
                     "repop_count": 1,
                     "repop_wait_second": 10
+                },
+                {
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 54,
+                    "level": 47,
+                    "exp": 273
+                },
+                {
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 54,
+                    "level": 47,
+                    "exp": 273
+                },
+                {
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 54,
+                    "level": 47,
+                    "exp": 273
+                },
+                {
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 54,
+                    "level": 47,
+                    "exp": 273
+                },
+                {
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 54,
+                    "level": 47,
+                    "exp": 273
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_2.json
@@ -50,9 +50,18 @@
                 "id": 1,
                 "group_id": 468
             },
-            "starting_index": 8,
+            "starting_index": 5,
             "enemies": [
                 {
+                    "comment": "Dangerous Orc General",
+                    "enemy_id": "0x015830",
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 1505,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
                     "comment": "Dangerous Orc Battler",
                     "enemy_id": "0x015810",
                     "named_enemy_params_id": 56,
@@ -85,18 +94,11 @@
                     "exp": 352
                 },
                 {
-                    "comment": "Dangerous Orc General",
-                    "enemy_id": "0x015830",
+                    "comment": "Dangerous Orc Battler",
+                    "enemy_id": "0x015810",
                     "named_enemy_params_id": 56,
                     "level": 55,
-                    "exp": 1505
-                },
-                {
-                    "comment": "Dangerous Orc General",
-                    "enemy_id": "0x015830",
-                    "named_enemy_params_id": 56,
-                    "level": 55,
-                    "exp": 1505
+                    "exp": 352
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_1.json
@@ -61,6 +61,7 @@
                 "id": 1,
                 "group_id": 447
             },
+            "starting_index": 1,
             "enemies": [
                 {
                     "comment": "Brutal Geo Golem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_2.json
@@ -61,6 +61,7 @@
                 "id": 1,
                 "group_id": 447
             },
+            "starting_index": 1,
             "enemies": [
                 {
                     "comment": "Dangerous Geo Golem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005.json
@@ -49,7 +49,6 @@
                 "id": 1,
                 "group_id": 459
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Brutal Cockatrice",
@@ -58,8 +57,7 @@
                     "start_think_tbl_no": 1,
                     "level": 47,
                     "exp": 5218,
-                    "is_boss": true,
-                    "index": 6
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005.json
@@ -76,6 +76,8 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "spawn_time_start": "18 * 3600000 + 0 * 60000",
+            "spawn_time_end": "6 * 3600000 + 59 * 60000",
             "result_commands": [
                 {
                     "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_1.json
@@ -61,7 +61,6 @@
                 "id": 1,
                 "group_id": 459
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Brutal Black Griffin",
@@ -70,8 +69,7 @@
                     "named_enemy_params_id": 54,
                     "level": 49,
                     "exp": 5343,
-                    "is_boss": true,
-                    "index": 6
+                    "is_boss": true
                 }
             ]
         }
@@ -90,6 +88,8 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "spawn_time_start": "18 * 3600000 + 0 * 60000",
+            "spawn_time_end": "6 * 3600000 + 59 * 60000",
             "result_commands": [
                 {
                     "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_2.json
@@ -50,7 +50,6 @@
                 "id": 1,
                 "group_id": 459
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Dangerous Black Griffin",
@@ -59,8 +58,7 @@
                     "named_enemy_params_id": 56,
                     "level": 57,
                     "exp": 5959,
-                    "is_boss": true,
-                    "index": 6
+                    "is_boss": true
                 }
             ]
         }
@@ -79,6 +77,8 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "spawn_time_start": "18 * 3600000 + 0 * 60000",
+            "spawn_time_end": "6 * 3600000 + 59 * 60000",
             "result_commands": [
                 {
                     "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_3.json
@@ -50,7 +50,6 @@
                 "id": 1,
                 "group_id": 459
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Brutal Nightmare",
@@ -59,8 +58,7 @@
                     "start_think_tbl_no": 1,
                     "level": 58,
                     "exp": 8831,
-                    "is_boss": true,
-                    "index": 6
+                    "is_boss": true
                 }
             ]
         }
@@ -79,6 +77,8 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "spawn_time_start": "18 * 3600000 + 0 * 60000",
+            "spawn_time_end": "6 * 3600000 + 59 * 60000",
             "result_commands": [
                 {
                     "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_4.json
@@ -50,7 +50,6 @@
                 "id": 1,
                 "group_id": 459
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Glossy Black Griffin (Black Griffin)",
@@ -59,8 +58,7 @@
                     "start_think_tbl_no": 1,
                     "level": 57,
                     "exp": 5959,
-                    "is_boss": true,
-                    "index": 6
+                    "is_boss": true
                 }
             ]
         }
@@ -79,6 +77,8 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "spawn_time_start": "18 * 3600000 + 0 * 60000",
+            "spawn_time_end": "6 * 3600000 + 59 * 60000",
             "result_commands": [
                 {
                     "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006.json
@@ -59,9 +59,8 @@
         {
             "stage_id": {
                 "id": 1,
-                "group_id": 446
+                "group_id": 460
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Brutal Behemoth",
@@ -70,8 +69,7 @@
                     "start_think_tbl_no": 1,
                     "level": 55,
                     "exp": 8960,
-                    "is_boss": true,
-                    "index": 1
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_1.json
@@ -60,9 +60,8 @@
         {
             "stage_id": {
                 "id": 1,
-                "group_id": 446
+                "group_id": 460
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Dangerous Drake",
@@ -71,8 +70,7 @@
                     "start_think_tbl_no": 1,
                     "level": 60,
                     "exp": 9860,
-                    "is_boss": true,
-                    "index": 1
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_2.json
@@ -49,9 +49,8 @@
         {
             "stage_id": {
                 "id": 1,
-                "group_id": 446
+                "group_id": 460
             },
-            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Hellfire Drake (Drake)",
@@ -60,8 +59,7 @@
                     "start_think_tbl_no": 1,
                     "level": 60,
                     "exp": 9860,
-                    "is_boss": true,
-                    "index": 1
+                    "is_boss": true
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085009.json
@@ -49,48 +49,55 @@
                 "id": 65,
                 "group_id": 0
             },
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Brutal Skeleton Warrior",
                     "enemy_id": "0x010302",
                     "named_enemy_params_id": 54,
                     "level": 47,
-                    "exp": 224
+                    "exp": 224,
+                    "index": 0
                 },
                 {
                     "comment": "Brutal Skeleton Warrior",
                     "enemy_id": "0x010302",
                     "named_enemy_params_id": 54,
                     "level": 47,
-                    "exp": 224
+                    "exp": 224,
+                    "index": 3
                 },
                 {
                     "comment": "Brutal Ghost Mail",
                     "enemy_id": "0x010311",
                     "named_enemy_params_id": 54,
                     "level": 47,
-                    "exp": 576
+                    "exp": 576,
+                    "index": 6
                 },
                 {
                     "comment": "Brutal Skeleton Warrior",
                     "enemy_id": "0x010302",
                     "named_enemy_params_id": 54,
                     "level": 47,
-                    "exp": 224
+                    "exp": 224,
+                    "index": 7
+                },
+                {
+                    "comment": "Brutal Skeleton Warrior",
+                    "enemy_id": "0x010302",
+                    "named_enemy_params_id": 54,
+                    "level": 47,
+                    "exp": 224,
+                    "index": 8
                 },
                 {
                     "comment": "Brutal Ghost Mail",
                     "enemy_id": "0x010311",
                     "named_enemy_params_id": 54,
                     "level": 47,
-                    "exp": 576
-                },
-                {
-                    "comment": "Brutal Skeleton Warrior",
-                    "enemy_id": "0x010302",
-                    "named_enemy_params_id": 54,
-                    "level": 47,
-                    "exp": 224
+                    "exp": 576,
+                    "index": 9
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000_1.json
@@ -1,26 +1,27 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Dead City's Chronicles",
+    "comment": "The Dead City's Chronicles (II)",
     "quest_id": 20090000,
-    "base_level": 49,
+    "base_level": 50,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 1,
     "rewards": [
         {
             "type": "exp",
-            "amount": 1880
+            "amount": 2500
         },
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1340
+            "amount": 1650
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 210
+            "amount": 280
         },
         {
             "type": "select",
@@ -49,7 +50,7 @@
                 "id": 77,
                 "group_id": 23
             },
-            "starting_index": 8,
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Vigilant Shadow Harpy",
@@ -59,17 +60,8 @@
                     "level": 49,
                     "exp": 222,
                     "repop_count": 2,
-                    "repop_wait_second": 10
-                },
-                {
-                    "comment": "Vigilant Shadow Goblin",
-                    "enemy_id": "0x011130",
-                    "named_enemy_params_id": 53,
-                    "start_think_tbl_no": 1,
-                    "level": 49,
-                    "exp": 204,
-                    "repop_count": 1,
-                    "repop_wait_second": 10
+                    "repop_wait_second": 10,
+                    "index": 8
                 },
                 {
                     "comment": "Vigilant Shadow Harpy",
@@ -79,17 +71,17 @@
                     "level": 49,
                     "exp": 222,
                     "repop_count": 2,
-                    "repop_wait_second": 10
+                    "repop_wait_second": 10,
+                    "index": 10
                 },
                 {
-                    "comment": "Vigilant Shadow Goblin",
-                    "enemy_id": "0x011130",
-                    "named_enemy_params_id": 53,
-                    "start_think_tbl_no": 1,
-                    "level": 49,
-                    "exp": 204,
-                    "repop_count": 1,
-                    "repop_wait_second": 10
+                    "comment": "Brutal Shadow Chimera",
+                    "enemy_id": "0x015203",
+                    "named_enemy_params_id": 54,
+                    "level": 50,
+                    "exp": 5110,
+                    "is_boss": true,
+                    "index": 11
                 }
             ]
         }
@@ -110,7 +102,7 @@
                     "comment": "Idle dialogue - Plum",
                     "type": "QstTalkChg",
                     "Param1": 500,
-                    "Param2": 8729
+                    "Param2": 8730
                }
            ],
             "stage_id": {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001.json
@@ -1,13 +1,13 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The One Called ‘Knight-Devourer",
+    "comment": "The One Called Knight-Devourer",
     "quest_id": 20090001,
     "base_level": 53,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
-    "news_image": 181,	
+    "area_id": "ZandoraWastelands", 
+    "news_image": 181,  
     "rewards": [
         {
             "type": "exp",
@@ -27,30 +27,34 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Mystery Organs",
                     "item_id": 7744,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Lockpick",
                     "item_id": 9403,
                     "num": 3
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
-                    "num": 1					
+                    "num": 1                    
                 }
             ]
-          },
+        },
+        {
+            "type": "random",
+            "loot_pool": [
                 {
-                    "type": "random",
-                    "loot_pool": [
-                      {
-                        "item_id": 7554,
-                        "num": 1,
-                        "chance": 0.6
-                      }
-                    ]
-                  }
-                ],
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
     "enemy_groups" : [
         {
             "stage_id": {
@@ -60,22 +64,23 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Eight-Knight Eater (Ghoul)",
                     "enemy_id": "0x015503",
                     "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 248,
+                    "named_enemy_params_id": 59,
                     "level": 53,
-                    "exp": 15632,
+                    "exp": 4180,
                     "is_boss": true,
-                    "index": 2					
+                    "index": 3                  
                 }
             ]
         }
-    ],	
+    ],  
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1076, "comment": "Spawns WhiteKnight1 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1076, "comment": "Spawns WhiteKnight1 NPC"}             
             ],
             "stage_id": {
                 "id": 1,
@@ -83,11 +88,19 @@
                 "layer_no": 1
             },
             "npc_id": "WhiteKnight1",
-            "message_id": 11372
+            "message_id": 11304
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 505,
+                    "Param2": 11310
+               }
+           ],
             "groups": [0]
         },
         {
@@ -96,7 +109,7 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {       
             "type": "NewTalkToNpc",
             "stage_id": {
                 "id": 1,
@@ -105,7 +118,7 @@
             },
             "announce_type": "Update",
             "npc_id": "WhiteKnight1",
-            "message_id": 11842
+            "message_id": 11307
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_1.json
@@ -1,14 +1,14 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The One Called ‘Knight-Devourer",
+    "comment": "The One Called Knight-Devourer (II)",
     "quest_id": 20090001,
     "base_level": 55,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands", 
     "news_image": 181,
-	"variant_index": 1,
+    "variant_index": 1,
     "rewards": [
         {
             "type": "exp",
@@ -28,35 +28,40 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Sinister Horn",
                     "item_id": 7748,
                     "num": 1
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 3
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
-                    "num": 1					
+                    "num": 1                    
                 }
             ]
-          },
+        },
+        {
+            "type": "random",
+            "loot_pool": [
                 {
-                    "type": "random",
-                    "loot_pool": [
-                      {
-                        "item_id": 7554,
-                        "num": 1,
-                        "chance": 0.6
-                      },
-                      {
-                        "item_id": 61,
-                        "num": 1,
-                        "chance": 0.6
-                      }
-                    ]
-                  }
-                ],
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Superior Gala Extract",
+                    "item_id": 61,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
     "enemy_groups" : [
         {
             "stage_id": {
@@ -66,38 +71,39 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Brutal Skull Lord",
+                    "enemy_id": "0x010313",
+                    "named_enemy_params_id": 54,
+                    "level": 55,
+                    "exp": 1280,
+                    "index": 0                  
+                },
+                {
+                    "comment": "Brutal Skull Lord",
+                    "enemy_id": "0x010313",
+                    "named_enemy_params_id": 54,
+                    "level": 55,
+                    "exp": 1280,
+                    "index": 1                  
+                },
+                {
+                    "comment": "Hundred Knight-Eater (Shadow Chimera)",
                     "enemy_id": "0x015203",
+                    "named_enemy_params_id": 60,
                     "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 914,
                     "level": 55,
-                    "exp": 19700,
+                    "exp": 5440,
                     "is_boss": true,
-                    "index": 3					
-                },
-                {
-                    "enemy_id": "0x010313",
-                    "start_think_tbl_no": 0,
-                    "level": 55,
-                    "exp": 6476,
-                    "is_boss": false,
-                    "index": 2					
-                },
-                {
-                    "enemy_id": "0x010313",
-                    "start_think_tbl_no": 0,
-                    "level": 55,
-                    "exp": 6476,
-                    "is_boss": false,
-                    "index": 4					
+                    "index": 3                  
                 }
             ]
         }
-    ],	
+    ],  
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1076, "comment": "Spawns WhiteKnight1 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1076, "comment": "Spawns WhiteKnight1 NPC"}             
             ],
             "stage_id": {
                 "id": 1,
@@ -105,11 +111,19 @@
                 "layer_no": 1
             },
             "npc_id": "WhiteKnight1",
-            "message_id": 11372
+            "message_id": 11304
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 505,
+                    "Param2": 11310
+               }
+           ],
             "groups": [0]
         },
         {
@@ -118,7 +132,7 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {       
             "type": "NewTalkToNpc",
             "stage_id": {
                 "id": 1,
@@ -127,7 +141,7 @@
             },
             "announce_type": "Update",
             "npc_id": "WhiteKnight1",
-            "message_id": 11842
+            "message_id": 11307
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_2.json
@@ -1,14 +1,14 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The One Called ‘Knight-Devourer",
+    "comment": "The One Called Knight-Devourer (III)",
     "quest_id": 20090001,
     "base_level": 55,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "news_image": 181,
-	"variant_index": 2,
+    "variant_index": 2,
     "rewards": [
         {
             "type": "exp",
@@ -28,35 +28,40 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Mergan Cloth",
                     "item_id": 7950,
                     "num": 1
                 },
                 {
+                    "comment": "Ogre Claw",
                     "item_id": 7766,
                     "num": 2
                 },
                 {
+                    "comment": "Alchemic Wood",
                     "item_id": 9159,
-                    "num": 2					
+                    "num": 2
                 }
             ]
           },
+        {
+            "type": "random",
+            "loot_pool": [
                 {
-                    "type": "random",
-                    "loot_pool": [
-                      {
-                        "item_id": 7554,
-                        "num": 1,
-                        "chance": 0.6
-                      },
-                      {
-                        "item_id": 61,
-                        "num": 1,
-                        "chance": 0.6
-                      }
-                    ]
-                  }
-                ],
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Superior Gala Extract",
+                    "item_id": 61,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
     "enemy_groups" : [
         {
             "stage_id": {
@@ -66,40 +71,39 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Vigilant Ogre",
+                    "enemy_id": "0x015500",
+                    "named_enemy_params_id": 53,
+                    "level": 53,
+                    "exp": 3680,
+                    "index": 0
+                },
+                {
+                    "comment": "Vigilant Ogre",
+                    "enemy_id": "0x015500",
+                    "named_enemy_params_id": 53,
+                    "level": 53,
+                    "exp": 3680,
+                    "index": 1
+                },
+                {
+                    "comment": "Ten Thousand Knight-Eater (Chimera)",
                     "enemy_id": "0x015200",
                     "start_think_tbl_no": 1,
                     "named_enemy_params_id": 61,
-                    "level": 55,
-                    "exp": 19700,
+                    "level": 57,
+                    "exp": 4620,
                     "is_boss": true,
-                    "index": 3					
-                },
-                {
-                    "enemy_id": "0x015500",
-                    "start_think_tbl_no": 0,
-                    "named_enemy_params_id": 53,
-                    "level": 53,
-                    "exp": 6254,
-                    "is_boss": false,
-                    "index": 2					
-                },
-                {
-                    "enemy_id": "0x015500",
-                    "start_think_tbl_no": 0,
-                    "named_enemy_params_id": 53,
-                    "level": 53,
-                    "exp": 6254,
-                    "is_boss": false,
-                    "index": 4					
+                    "index": 3
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1076, "comment": "Spawns WhiteKnight1 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1076, "comment": "Spawns WhiteKnight1 NPC"}
             ],
             "stage_id": {
                 "id": 1,
@@ -107,11 +111,19 @@
                 "layer_no": 1
             },
             "npc_id": "WhiteKnight1",
-            "message_id": 11372
+            "message_id": 11304
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 505,
+                    "Param2": 11310
+               }
+           ],
             "groups": [0]
         },
         {
@@ -120,7 +132,7 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "NewTalkToNpc",
             "stage_id": {
                 "id": 1,
@@ -129,7 +141,7 @@
             },
             "announce_type": "Update",
             "npc_id": "WhiteKnight1",
-            "message_id": 11842
+            "message_id": 11307
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_1.json
@@ -1,12 +1,13 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Fiery Titan",
+    "comment": "The Fiery Titan (II)",
     "quest_id": 20095000,
     "base_level": 49,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 1,
     "rewards": [
         {
             "type": "wallet",
@@ -26,30 +27,19 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Burn Prevention",
-                    "item_id": 9315,
+                    "comment": "Black Iron Ingot",
+                    "item_id": 7878,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Freeze Prevention",
-                    "item_id": 9318,
-                    "num": 1
+                    "comment": "Chipped Gold Lump",
+                    "item_id": 8025,
+                    "num": 2
                 },
                 {
-                    "comment": "Crest of Shock Prevention",
-                    "item_id": 9321,
-                    "num": 1
-                }
-            ]
-        },
-        {
-            "type": "random",
-            "loot_pool": [
-                {
-                    "comment": "Healing Potion",
-                    "item_id": 34,
-                    "num": 9,
-                    "chance": 1.0
+                    "comment": "Enhanced Lockpick",
+                    "item_id": 9403,
+                    "num": 3
                 }
             ]
         }
@@ -62,11 +52,11 @@
             },
             "enemies": [
                 {
-                    "comment": "Brutal Geo Golem",
-                    "enemy_id": "0x015104",
+                    "comment": "Brutal Damned Golem",
+                    "enemy_id": "0x015103",
                     "named_enemy_params_id": 54,
                     "level": 49,
-                    "exp": 4736,
+                    "exp": 4617,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_2.json
@@ -1,55 +1,45 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Fiery Titan",
+    "comment": "The Fiery Titan (III)",
     "quest_id": 20095000,
-    "base_level": 49,
+    "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 2,
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1610
+            "amount": 1840
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 250
+            "amount": 290
         },
         {
             "type": "exp",
-            "amount": 2260
+            "amount": 2580
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Burn Prevention",
-                    "item_id": 9315,
+                    "comment": "Alchemite",
+                    "item_id": 7871,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Freeze Prevention",
-                    "item_id": 9318,
+                    "comment": "Dirty Sheet Metal",
+                    "item_id": 8029,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Shock Prevention",
-                    "item_id": 9321,
-                    "num": 1
-                }
-            ]
-        },
-        {
-            "type": "random",
-            "loot_pool": [
-                {
-                    "comment": "Healing Potion",
-                    "item_id": 34,
-                    "num": 9,
-                    "chance": 1.0
+                    "comment": "Chipped Gold Lump",
+                    "item_id": 8025,
+                    "num": 3
                 }
             ]
         }
@@ -62,11 +52,11 @@
             },
             "enemies": [
                 {
-                    "comment": "Brutal Geo Golem",
-                    "enemy_id": "0x015104",
-                    "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 4736,
+                    "comment": "Dangerous Damned Golem",
+                    "enemy_id": "0x015103",
+                    "named_enemy_params_id": 56,
+                    "level": 56,
+                    "exp": 5054,
                     "is_boss": true
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001.json
@@ -6,7 +6,7 @@
     "base_level": 49,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "rewards": [
         {
             "type": "exp",
@@ -26,16 +26,19 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Alchemic Wood",
                     "item_id": 9159,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Pickaxe",
                     "item_id": 9401,
                     "num": 3
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         }
@@ -44,23 +47,26 @@
         {
             "stage_id": {
                 "id": 77,
-                "group_id": 17
+                "group_id": 6
             },
+            "starting_index": 1,
             "enemies": [
                 {
-                    "enemy_id": "0x015202",
-                    "level": 50,
-                    "exp": 20000,
-                    "is_boss": true					
+                    "comment": "Brutal Chimera",
+                    "enemy_id": "0x015200",
+                    "named_enemy_params_id": 54,
+                    "level": 49,
+                    "exp": 4140,
+                    "is_boss": true
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1656, "comment": "Spawns Marquis NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1656, "comment": "Spawns Marquis NPC"}
             ],
             "stage_id": {
                 "id": 1,
@@ -68,11 +74,19 @@
                 "layer_no": 1
             },
             "npc_id": "Marquis",
-            "message_id": 11372
+            "message_id": 16052
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 518,
+                    "Param2": 16053
+               }
+           ],
             "groups": [0]
         },
         {
@@ -81,7 +95,7 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "NewTalkToNpc",
             "stage_id": {
                 "id": 1,
@@ -90,7 +104,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Marquis",
-            "message_id": 11842
+            "message_id": 16054
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001_1.json
@@ -1,13 +1,18 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Fiery Titan",
-    "quest_id": 20095000,
+    "comment": "A Thirst for Knowledge (II)",
+    "quest_id": 20095001,
     "base_level": 49,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 1,
     "rewards": [
+        {
+            "type": "exp",
+            "amount": 2450
+        },
         {
             "type": "wallet",
             "wallet_type": "Gold",
@@ -16,40 +21,25 @@
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 250
-        },
-        {
-            "type": "exp",
-            "amount": 2260
+            "amount": 280
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Burn Prevention",
-                    "item_id": 9315,
+                    "comment": "Alchemic Wood",
+                    "item_id": 9159,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Freeze Prevention",
-                    "item_id": 9318,
+                    "comment": "Pure White Mane",
+                    "item_id": 7780,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Shock Prevention",
-                    "item_id": 9321,
+                    "comment": "White Lion Pelt",
+                    "item_id": 7739,
                     "num": 1
-                }
-            ]
-        },
-        {
-            "type": "random",
-            "loot_pool": [
-                {
-                    "comment": "Healing Potion",
-                    "item_id": 34,
-                    "num": 9,
-                    "chance": 1.0
                 }
             ]
         }
@@ -58,15 +48,16 @@
         {
             "stage_id": {
                 "id": 77,
-                "group_id": 24
+                "group_id": 6
             },
+            "starting_index": 1,
             "enemies": [
                 {
-                    "comment": "Brutal Geo Golem",
-                    "enemy_id": "0x015104",
+                    "comment": "Brutal White Chimera",
+                    "enemy_id": "0x015202",
                     "named_enemy_params_id": 54,
                     "level": 49,
-                    "exp": 4736,
+                    "exp": 5337,
                     "is_boss": true
                 }
             ]
@@ -76,15 +67,15 @@
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1655, "comment": "Spawns Christoph NPC"}
+                {"type": "QstLayout", "action": "Set", "value": 1656, "comment": "Spawns Marquis NPC"}
             ],
             "stage_id": {
                 "id": 1,
                 "group_id": 1,
                 "layer_no": 1
             },
-            "npc_id": "Christoph",
-            "message_id": 16102
+            "npc_id": "Marquis",
+            "message_id": 16052
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -93,8 +84,8 @@
                {
                     "comment": "Idle dialogue",
                     "type": "QstTalkChg",
-                    "Param1": 513,
-                    "Param2": 16103
+                    "Param1": 518,
+                    "Param2": 16053
                }
            ],
             "groups": [0]
@@ -113,8 +104,8 @@
                 "layer_no": 1
             },
             "announce_type": "Update",
-            "npc_id": "Christoph",
-            "message_id": 16104
+            "npc_id": "Marquis",
+            "message_id": 16054
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002.json
@@ -28,14 +28,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Moist Black Leather",
                     "item_id": 7742,
                     "num": 1
                 },
                 {
+                    "comment": "Enhanced Lumber Knife",
                     "item_id": 9402,
                     "num": 3
                 },
                 {
+                    "comment": "Strong Gala Extract",
                     "item_id": 9363,
                     "num": 3
                 }
@@ -48,35 +51,40 @@
                 "id": 1,
                 "group_id": 397
             },
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 49,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 53
+                    "exp": 135,
+                    "index": 0
                 },
                 {
                     "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 49,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 53
-                },
-                {
-                    "comment": "Vigilant Harpy",
-                    "enemy_id": "0x010600",
-                    "level": 49,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 53
+                    "exp": 135,
+                    "index": 1
                 },
                 {
                     "comment": "Brutal Black Griffin",
                     "enemy_id": "0x015303",
-                    "level": 49,
-                    "exp_scheme": "Automatic",
                     "named_enemy_params_id": 54,
-                    "is_boss": true
+                    "level": 49,
+                    "exp": 5343,
+                    "is_boss": true,
+                    "index": 6
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 49,
+                    "exp": 135,
+                    "index": 7
                 }
             ]
         }
@@ -103,6 +111,14 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 4701,
+                    "Param2": 16056
+               }
+           ],
             "groups": [ 0 ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_1.json
@@ -1,12 +1,12 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Dark Shadow Covering the Sky",
+    "comment": "The Dark Shadow Covering the Sky (II)",
     "quest_id": 20095002,
     "base_level": 50,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "variant_index": 1,
     "news_image": 182,
     "rewards": [
@@ -28,16 +28,19 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Moist Black Leather",
                     "item_id": 7742,
                     "num": 1
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 1
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         }
@@ -48,44 +51,49 @@
                 "id": 1,
                 "group_id": 397
             },
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 50,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 53
+                    "exp": 138,
+                    "index": 0
                 },
                 {
                     "comment": "Vigilant Harpy",
                     "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
                     "level": 50,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 53
-                },
-                {
-                    "comment": "Vigilant Harpy",
-                    "enemy_id": "0x010600",
-                    "level": 50,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 53
+                    "exp": 138,
+                    "index": 1
                 },
                 {
                     "comment": "Brutal Black Griffin",
                     "enemy_id": "0x015303",
-                    "level": 50,
-                    "exp_scheme": "Automatic",
                     "named_enemy_params_id": 54,
-                    "is_boss": true
+                    "level": 50,
+                    "exp": 5420,
+                    "is_boss": true,
+                    "index": 6
+                },
+                {
+                    "comment": "Vigilant Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 53,
+                    "level": 50,
+                    "exp": 138,
+                    "index": 7
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}
             ],
             "stage_id": {
                 "id": 1,
@@ -98,6 +106,14 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 4701,
+                    "Param2": 16056
+               }
+           ],
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_2.json
@@ -1,23 +1,23 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Dark Shadow Covering the Sky",
+    "comment": "The Dark Shadow Covering the Sky (III)",
     "quest_id": 20095002,
-    "base_level": 55,
+    "base_level": 58,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "variant_index": 2,
     "news_image": 182,
     "rewards": [
         {
             "type": "exp",
-            "amount": 2690
+            "amount": 2670
         },
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1650
+            "amount": 1910
         },
         {
             "type": "wallet",
@@ -28,16 +28,19 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7742,
+                    "comment": "Nightmare's Vocal Cords",
+                    "item_id": 7746,
                     "num": 1
                 },
                 {
-                    "item_id": 7818,
+                    "comment": "Demonic Fowl Feather",
+                    "item_id": 7819,
                     "num": 1
                 },
                 {
-                    "item_id": 7772,
-                    "num": 1					
+                    "comment": "Emerald",
+                    "item_id": 7898,
+                    "num": 1
                 }
             ]
         }
@@ -48,44 +51,49 @@
                 "id": 1,
                 "group_id": 397
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "comment": "Skull Lord",
-                    "enemy_id": "0x010313",
-                    "level": 55,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 56
+                    "comment": "Brutal Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 151,
+                    "index": 0
                 },
                 {
-                    "comment": "Skull Lord",
-                    "enemy_id": "0x010313",
-                    "level": 55,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 56
+                    "comment": "Brutal Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 151,
+                    "index": 1
                 },
                 {
-                    "comment": "Skull Lord",
-                    "enemy_id": "0x010313",
-                    "level": 55,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 56
+                    "comment": "Brutal Nightmare",
+                    "enemy_id": "0x015305",
+                    "level": 58,
+                    "exp": 8831,
+                    "named_enemy_params_id": 54,
+                    "is_boss": true,
+                    "index": 6
                 },
                 {
-                    "comment": "Blackwing (Black Griffin)",
-                    "enemy_id": "0x015303",
-                    "level": 55,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 515,
-                    "is_boss": true
+                    "comment": "Brutal Harpy",
+                    "enemy_id": "0x010600",
+                    "named_enemy_params_id": 54,
+                    "level": 56,
+                    "exp": 151,
+                    "index": 7
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}
             ],
             "stage_id": {
                 "id": 1,
@@ -98,6 +106,14 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 4701,
+                    "Param2": 16056
+               }
+           ],
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_3.json
@@ -1,23 +1,23 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Dark Shadow Covering the Sky",
+    "comment": "The Dark Shadow Covering the Sky (Twelve Calamities)",
     "quest_id": 20095002,
-    "base_level": 58,
+    "base_level": 55,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "variant_index": 3,
     "news_image": 182,
     "rewards": [
         {
             "type": "exp",
-            "amount": 2670
+            "amount": 2690
         },
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1910
+            "amount": 1650
         },
         {
             "type": "wallet",
@@ -28,16 +28,19 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7746,
+                    "comment": "Moist Black Leather",
+                    "item_id": 7742,
                     "num": 1
                 },
                 {
-                    "item_id": 7819,
+                    "comment": "Glossy Black Feather",
+                    "item_id": 7818,
                     "num": 1
                 },
                 {
-                    "item_id": 7898,
-                    "num": 1					
+                    "comment": "Cursed Skull",
+                    "item_id": 7772,
+                    "num": 1
                 }
             ]
         }
@@ -48,44 +51,49 @@
                 "id": 1,
                 "group_id": 397
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "comment": "Brutal Harpy",
-                    "enemy_id": "0x010600",
-                    "level": 56,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 608
+                    "comment": "Dangerous Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 55,
+                    "exp": 1280,
+                    "named_enemy_params_id": 56,
+                    "index": 0
                 },
                 {
-                    "comment": "Brutal Harpy",
-                    "enemy_id": "0x010600",
-                    "level": 56,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 608
+                    "comment": "Dangerous Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 55,
+                    "exp": 1280,
+                    "named_enemy_params_id": 56,
+                    "index": 1
                 },
                 {
-                    "comment": "Brutal Harpy",
-                    "enemy_id": "0x010600",
-                    "level": 56,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 608
+                    "comment": "Blackwing (Black Griffin)",
+                    "enemy_id": "0x015303",
+                    "named_enemy_params_id": 515,
+                    "level": 55,
+                    "exp": 5805,
+                    "is_boss": true,
+                    "index": 6
                 },
                 {
-                    "comment": "Brutal Nightmare",
-                    "enemy_id": "0x015305",
-                    "level": 58,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 661,
-                    "is_boss": true
+                    "comment": "Dangerous Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 55,
+                    "exp": 1280,
+                    "named_enemy_params_id": 56,
+                    "index": 7
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}
             ],
             "stage_id": {
                 "id": 1,
@@ -98,6 +106,14 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 4701,
+                    "Param2": 16056
+               }
+           ],
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_4.json
@@ -1,43 +1,46 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Dark Shadow Covering the Sky",
+    "comment": "The Dark Shadow Covering the Sky (Twelve Calamities II)",
     "quest_id": 20095002,
     "base_level": 60,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "variant_index": 4,
     "news_image": 182,
     "rewards": [
         {
             "type": "exp",
-            "amount": 2670
+            "amount": 5540
         },
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1910
+            "amount": 3960
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 300
+            "amount": 310
         },
         {
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Crest of Perseverance+",
                     "item_id": 11742,
                     "num": 1
                 },
                 {
+                    "comment": "Griffin Glossy Plume",
                     "item_id": 9439,
                     "num": 1
                 },
                 {
+                    "comment": "Spirit Crystal",
                     "item_id": 7909,
-                    "num": 1					
+                    "num": 1
                 }
             ]
         }
@@ -48,44 +51,49 @@
                 "id": 1,
                 "group_id": 397
             },
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment": "Death Knight Noir",
                     "enemy_id": "0x010310",
+                    "named_enemy_params_id": 620,
                     "level": 60,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 620
+                    "exp": 1700,
+                    "index": 0
                 },
                 {
                     "comment": "Death Knight Noir",
                     "enemy_id": "0x010310",
+                    "named_enemy_params_id": 620,
                     "level": 60,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 620
+                    "exp": 1700,
+                    "index": 0
                 },
                 {
-                    "comment": "Death Knight Noir",
-                    "enemy_id": "0x010310",
-                    "level": 60,
-                    "exp_scheme": "Automatic",
-                    "named_enemy_params_id": 620
-                },
-                {
-                    "comment": "Griffin Noir",
+                    "comment": "Griffin Noir (Black Griffin)",
                     "enemy_id": "0x015303",
-                    "level": 60,
-                    "exp_scheme": "Automatic",
                     "named_enemy_params_id": 619,
-                    "is_boss": true
+                    "level": 60,
+                    "exp": 6190,
+                    "is_boss": true,
+                    "index": 6
+                },
+                {
+                    "comment": "Death Knight Noir",
+                    "enemy_id": "0x010310",
+                    "named_enemy_params_id": 620,
+                    "level": 60,
+                    "exp": 1700,
+                    "index": 0
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}				
+                {"type": "QstLayout", "action": "Set", "value": 1657, "comment": "Spawns 禁域守の神官 NPC"}
             ],
             "stage_id": {
                 "id": 1,
@@ -98,6 +106,14 @@
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 4701,
+                    "Param2": 16056
+               }
+           ],
             "groups": [0]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_1.json
@@ -1,17 +1,18 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Sinister Beasts",
+    "comment": "The Sinister Beasts (II)",
     "quest_id": 20095003,
-    "base_level": 48,
+    "base_level": 49,
     "minimum_item_rank": 0,
     "discoverable": false,
     "area_id": "ZandoraWastelands",
+    "variant_index": 1,
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1050
+            "amount": 1070
         },
         {
             "type": "wallet",
@@ -20,7 +21,7 @@
         },
         {
             "type": "exp",
-            "amount": 1320
+            "amount": 1340
         },
         {
             "type": "select",
@@ -31,14 +32,14 @@
                     "num": 2
                 },
                 {
-                    "comment": "Strong Gala Extract",
-                    "item_id": 9363,
+                    "comment": "Enhanced Lockpick",
+                    "item_id": 9403,
                     "num": 3
                 },
                 {
-                    "comment": "Panacea",
-                    "item_id": 41,
-                    "num": 1
+                    "comment": "Enhanced Lumber Knife",
+                    "item_id": 9402,
+                    "num": 3
                 }
             ]
         }
@@ -55,8 +56,8 @@
                     "comment": "Brutal Shadow Wolf",
                     "enemy_id": "0x010206",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 248,
+                    "level": 49,
+                    "exp": 252,
                     "repop_count": 1,
                     "repop_wait_second": 10
                 },
@@ -64,35 +65,35 @@
                     "comment": "Brutal Shadow Wolf",
                     "enemy_id": "0x010206",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 248,
+                    "level": 49,
+                    "exp": 252,
                     "repop_count": 1,
                     "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Shadow Goblin",
-                    "enemy_id": "0x011130",
+                    "comment": "Brutal Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 201,
+                    "level": 49,
+                    "exp": 204,
                     "repop_count": 1,
                     "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Shadow Goblin",
-                    "enemy_id": "0x011130",
+                    "comment": "Brutal Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 201,
+                    "level": 49,
+                    "exp": 204,
                     "repop_count": 1,
                     "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Shadow Goblin",
-                    "enemy_id": "0x011130",
+                    "comment": "Brutal Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 201,
+                    "level": 49,
+                    "exp": 204,
                     "repop_count": 1,
                     "repop_wait_second": 10
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_2.json
@@ -1,0 +1,106 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "The Sinister Beasts (III)",
+    "quest_id": 20095003,
+    "base_level": 57,
+    "minimum_item_rank": 0,
+    "discoverable": false,
+    "area_id": "ZandoraWastelands",
+    "variant_index": 2,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 1880
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "exp",
+            "amount": 2630
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "comment": "Pearl Shell",
+                    "item_id": 9796,
+                    "num": 1
+                },
+                {
+                    "comment": "Blue Steel Ingot",
+                    "item_id": 7885,
+                    "num": 1
+                },
+                {
+                    "comment": "Sand of Reminiscence",
+                    "item_id": 9441,
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 164,
+                "group_id": 0
+            },
+            "starting_index": 8,
+            "enemies": [
+                {
+                    "comment": "Legendary Chimera",
+                    "enemy_id": "0x015200",
+                    "named_enemy_params_id": 57,
+                    "level": 57,
+                    "exp": 4620,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Brutal Shadow Goblin Leader",
+                    "enemy_id": "0x011160",
+                    "named_enemy_params_id": 54,
+                    "level": 55,
+                    "exp": 270
+                },
+                {
+                    "comment": "Brutal Shadow Goblin Leader",
+                    "enemy_id": "0x011160",
+                    "named_enemy_params_id": 54,
+                    "level": 55,
+                    "exp": 270
+                },
+                {
+                    "comment": "Brutal Shadow Goblin Leader",
+                    "enemy_id": "0x011160",
+                    "named_enemy_params_id": 54,
+                    "level": 55,
+                    "exp": 270
+                },
+                {
+                    "comment": "Brutal Shadow Goblin Leader",
+                    "enemy_id": "0x011160",
+                    "named_enemy_params_id": 54,
+                    "level": 55,
+                    "exp": 270
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [0]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004.json
@@ -6,7 +6,7 @@
     "base_level": 47,
     "minimum_item_rank": 0,
     "discoverable": true,
-  "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "rewards": [
         {
             "type": "wallet",
@@ -26,16 +26,19 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Gold-Striped Hardwood",
                     "item_id": 9059,
                     "num": 2
                 },
                 {
+                    "comment": "Giant Tough Pelt",
                     "item_id": 7925,
                     "num": 1
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         },
@@ -43,6 +46,7 @@
             "type": "random",
             "loot_pool": [
                 {
+                    "comment": "Healing Potion",
                     "item_id": 34,
                     "num": 9,
                     "chance": 1.0
@@ -54,14 +58,17 @@
         {
             "stage_id": {
                 "id": 164,
-                "group_id": 4
+                "group_id": 3
             },
+            "starting_index": 1,
             "enemies": [
                 {
-                    "enemy_id": "0x015102",
-                    "level": 48,
-                    "exp": 13000,
-                    "is_boss": true								
+                    "comment": "Dangerous Colossus",
+                    "enemy_id": "0x015020",
+                    "named_enemy_params_id": 56,
+                    "level": 47,
+                    "exp": 4032,
+                    "is_boss": true
                 }
             ]
         }
@@ -78,11 +85,19 @@
                 "layer_no": 1
             },
             "npc_id": "Sorcerer0",
-            "message_id": 11372
+            "message_id": 16058
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+               {
+                    "comment": "Idle dialogue",
+                    "type": "QstTalkChg",
+                    "Param1": 543,
+                    "Param2": 16059
+               }
+           ],
             "groups": [0]
         },
         {
@@ -96,11 +111,11 @@
             "stage_id": {
                 "id": 1,
                 "group_id": 1,
-                "layer_no": 1				
+                "layer_no": 1
             },
             "announce_type": "Update",
             "npc_id": "Sorcerer0",
-            "message_id": 11835
+            "message_id": 16060
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_1.json
@@ -1,12 +1,13 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Fiery Titan",
-    "quest_id": 20095000,
+    "comment": "The Forgotten Guardian (II)",
+    "quest_id": 20095004,
     "base_level": 49,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 1,
     "rewards": [
         {
             "type": "wallet",
@@ -26,30 +27,19 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Burn Prevention",
-                    "item_id": 9315,
+                    "comment": "Blue Steel Ingot",
+                    "item_id": 7885,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Freeze Prevention",
-                    "item_id": 9318,
-                    "num": 1
+                    "comment": "Enhanced Lockpick",
+                    "item_id": 9403,
+                    "num": 3
                 },
                 {
-                    "comment": "Crest of Shock Prevention",
-                    "item_id": 9321,
+                    "comment": "Panacea",
+                    "item_id": 41,
                     "num": 1
-                }
-            ]
-        },
-        {
-            "type": "random",
-            "loot_pool": [
-                {
-                    "comment": "Healing Potion",
-                    "item_id": 34,
-                    "num": 9,
-                    "chance": 1.0
                 }
             ]
         }
@@ -57,16 +47,17 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 77,
-                "group_id": 24
+                "id": 164,
+                "group_id": 3
             },
+            "starting_index": 1,
             "enemies": [
                 {
-                    "comment": "Brutal Geo Golem",
-                    "enemy_id": "0x015104",
+                    "comment": "Brutal Damned Golem",
+                    "enemy_id": "0x015103",
                     "named_enemy_params_id": 54,
                     "level": 49,
-                    "exp": 4736,
+                    "exp": 4617,
                     "is_boss": true
                 }
             ]
@@ -76,15 +67,15 @@
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1655, "comment": "Spawns Christoph NPC"}
+                {"type": "QstLayout", "action": "Set", "value": 1617, "comment": "Spawns Sorcerer0 NPC"}
             ],
             "stage_id": {
                 "id": 1,
                 "group_id": 1,
                 "layer_no": 1
             },
-            "npc_id": "Christoph",
-            "message_id": 16102
+            "npc_id": "Sorcerer0",
+            "message_id": 16058
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -93,8 +84,8 @@
                {
                     "comment": "Idle dialogue",
                     "type": "QstTalkChg",
-                    "Param1": 513,
-                    "Param2": 16103
+                    "Param1": 543,
+                    "Param2": 16059
                }
            ],
             "groups": [0]
@@ -113,8 +104,8 @@
                 "layer_no": 1
             },
             "announce_type": "Update",
-            "npc_id": "Christoph",
-            "message_id": 16104
+            "npc_id": "Sorcerer0",
+            "message_id": 16060
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_2.json
@@ -1,55 +1,45 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Fiery Titan",
-    "quest_id": 20095000,
-    "base_level": 49,
+    "comment": "The Forgotten Guardian (III)",
+    "quest_id": 20095004,
+    "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 2,
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1610
+            "amount": 1840
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 250
+            "amount": 290
         },
         {
             "type": "exp",
-            "amount": 2260
+            "amount": 2580
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Burn Prevention",
-                    "item_id": 9315,
+                    "comment": "Alchemite",
+                    "item_id": 7871,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Freeze Prevention",
-                    "item_id": 9318,
+                    "comment": "Dirty Sheet Metal",
+                    "item_id": 8029,
                     "num": 1
                 },
                 {
-                    "comment": "Crest of Shock Prevention",
-                    "item_id": 9321,
-                    "num": 1
-                }
-            ]
-        },
-        {
-            "type": "random",
-            "loot_pool": [
-                {
-                    "comment": "Healing Potion",
-                    "item_id": 34,
-                    "num": 9,
-                    "chance": 1.0
+                    "comment": "Chipped Gold Lump",
+                    "item_id": 8025,
+                    "num": 3
                 }
             ]
         }
@@ -57,16 +47,17 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 77,
-                "group_id": 24
+                "id": 164,
+                "group_id": 3
             },
+            "starting_index": 1,
             "enemies": [
                 {
-                    "comment": "Brutal Geo Golem",
-                    "enemy_id": "0x015104",
-                    "named_enemy_params_id": 54,
-                    "level": 49,
-                    "exp": 4736,
+                    "comment": "Dangerous Damned Golem",
+                    "enemy_id": "0x015103",
+                    "named_enemy_params_id": 56,
+                    "level": 56,
+                    "exp": 5054,
                     "is_boss": true
                 }
             ]
@@ -76,15 +67,15 @@
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1655, "comment": "Spawns Christoph NPC"}
+                {"type": "QstLayout", "action": "Set", "value": 1617, "comment": "Spawns Sorcerer0 NPC"}
             ],
             "stage_id": {
                 "id": 1,
                 "group_id": 1,
                 "layer_no": 1
             },
-            "npc_id": "Christoph",
-            "message_id": 16102
+            "npc_id": "Sorcerer0",
+            "message_id": 16058
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -93,8 +84,8 @@
                {
                     "comment": "Idle dialogue",
                     "type": "QstTalkChg",
-                    "Param1": 513,
-                    "Param2": 16103
+                    "Param1": 543,
+                    "Param2": 16059
                }
            ],
             "groups": [0]
@@ -113,8 +104,8 @@
                 "layer_no": 1
             },
             "announce_type": "Update",
-            "npc_id": "Christoph",
-            "message_id": 16104
+            "npc_id": "Sorcerer0",
+            "message_id": 16060
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_3.json
@@ -1,55 +1,45 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Fiery Titan",
-    "quest_id": 20095000,
+    "comment": "The Forgotten Guardian (Bounty)",
+    "quest_id": 20095004,
     "base_level": 49,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 3,
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1610
+            "amount": 3380
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 250
+            "amount": 290
         },
         {
             "type": "exp",
-            "amount": 2260
+            "amount": 4640
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Burn Prevention",
-                    "item_id": 9315,
-                    "num": 1
+                    "comment": "Strong Gala Extract",
+                    "item_id": 9363,
+                    "num": 3
                 },
                 {
-                    "comment": "Crest of Freeze Prevention",
-                    "item_id": 9318,
-                    "num": 1
+                    "comment": "Enhanced Pickaxe",
+                    "item_id": 9401,
+                    "num": 3
                 },
                 {
-                    "comment": "Crest of Shock Prevention",
-                    "item_id": 9321,
-                    "num": 1
-                }
-            ]
-        },
-        {
-            "type": "random",
-            "loot_pool": [
-                {
-                    "comment": "Healing Potion",
-                    "item_id": 34,
-                    "num": 9,
-                    "chance": 1.0
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 3
                 }
             ]
         }
@@ -57,16 +47,17 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 77,
-                "group_id": 24
+                "id": 164,
+                "group_id": 3
             },
+            "starting_index": 1,
             "enemies": [
                 {
-                    "comment": "Brutal Geo Golem",
-                    "enemy_id": "0x015104",
-                    "named_enemy_params_id": 54,
+                    "comment": "Bounty Damned Golem",
+                    "enemy_id": "0x015103",
+                    "named_enemy_params_id": 458,
                     "level": 49,
-                    "exp": 4736,
+                    "exp": 4617,
                     "is_boss": true
                 }
             ]
@@ -76,15 +67,15 @@
         {
             "type": "NewNpcTalkAndOrder",
             "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 1655, "comment": "Spawns Christoph NPC"}
+                {"type": "QstLayout", "action": "Set", "value": 1617, "comment": "Spawns Sorcerer0 NPC"}
             ],
             "stage_id": {
                 "id": 1,
                 "group_id": 1,
                 "layer_no": 1
             },
-            "npc_id": "Christoph",
-            "message_id": 16102
+            "npc_id": "Sorcerer0",
+            "message_id": 16058
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
@@ -93,8 +84,8 @@
                {
                     "comment": "Idle dialogue",
                     "type": "QstTalkChg",
-                    "Param1": 513,
-                    "Param2": 16103
+                    "Param1": 543,
+                    "Param2": 16059
                }
            ],
             "groups": [0]
@@ -113,8 +104,8 @@
                 "layer_no": 1
             },
             "announce_type": "Update",
-            "npc_id": "Christoph",
-            "message_id": 16104
+            "npc_id": "Sorcerer0",
+            "message_id": 16060
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
@@ -124,7 +124,7 @@
                     "comment": "Brutal Cyclops",
                     "enemy_id": "0x015000",
                     "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 53,
+                    "named_enemy_params_id": 54,
                     "level": 56,
                     "exp": 6476,
                     "is_boss": true

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
@@ -6,7 +6,7 @@
     "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "news_image": 183,
     "rewards": [
         {
@@ -27,35 +27,40 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Giant Single Pelt",
                     "item_id": 9438,
                     "num": 1
                 },
                 {
+                    "comment": "Giant Eyeball",
                     "item_id": 7740,
                     "num": 1
                 },
                 {
+                    "comment": "Rugged Leather",
                     "item_id": 7924,
-                    "num": 3					
+                    "num": 3
                 }
             ]
-          },
+        },
+        {
+            "type": "random",
+            "loot_pool": [
                 {
-                    "type": "random",
-                    "loot_pool": [
-                      {
-                        "item_id": 7554,
-                        "num": 1,
-                        "chance": 0.6
-                      },
-                      {
-                        "item_id": 41,
-                        "num": 1,
-                        "chance": 0.6
-                      }
-                    ]
-                  }
-                ],
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Panacea",
+                    "item_id": 41,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
     "enemy_groups" : [
         {
             "stage_id": {
@@ -65,103 +70,194 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Vigilant Sling Shadow Goblin",
+                    "enemy_id": "0x011132",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 223,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 0
+                },
+                {
+                    "comment": "Vigilant Sling Shadow Goblin",
+                    "enemy_id": "0x011132",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 223,
+                    "index": 1
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin",
                     "enemy_id": "0x011130",
                     "start_think_tbl_no": 1,
                     "named_enemy_params_id": 53,
                     "level": 55,
-                    "exp": 6476,
-                    "is_boss": false,
-                    "index": 3                    
-        },
-        {
-            "enemy_id": "0x011130",
-            "start_think_tbl_no": 1,
-            "named_enemy_params_id": 53,
-            "level": 55,
-            "exp": 6476,
-            "is_boss": false,
-            "index": 6                    
-},
-{
-    "enemy_id": "0x011130",
-    "start_think_tbl_no": 1,
-    "named_enemy_params_id": 53,
-    "level": 55,
-    "exp": 6476,
-    "is_boss": false,
-    "index": 4                    
-},
-{
-    "enemy_id": "0x011130",
-    "start_think_tbl_no": 1,
-    "named_enemy_params_id": 53,
-    "level": 55,
-    "exp": 6476,
-    "is_boss": false,
-    "index": 5                    
-},
-        {
-                    "enemy_id": "0x011132",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 53,
-                    "level": 55,
-                    "exp": 6476,
-                    "is_boss": false,
-                    "index": 0
-        },
-        {
-                    "enemy_id": "0x011132",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 53,
-                    "level": 55,
-                    "exp": 6476,
-                    "is_boss": false,
-                    "index": 1					
+                    "exp": 223,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 6
                 },
                 {
+                    "comment": "Vigilant Shadow Goblin",
+                    "enemy_id": "0x011130",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 223,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 7
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 393
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Brutal Cyclops",
                     "enemy_id": "0x015000",
                     "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 56,
+                    "named_enemy_params_id": 53,
                     "level": 56,
-                    "exp": 21700,
-                    "is_boss": true,
-                    "index": 2
-        }
+                    "exp": 6476,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 374
+            },
+            "starting_index": 1,
+            "enemies": [
+                {
+                    "comment": "Vigilant Shadow Goblin",
+                    "enemy_id": "0x011130",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 53,
+                    "level": 55,
+                    "exp": 223,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 7
+                }
             ]
         }
-    ],	
-    "blocks": [
+    ],
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",
-            "stage_id": {
-                "id": 55,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "npc_id": "Bayard",
-            "message_id": 11372
+            "blocks": [
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 55
+                    },
+                    "npc_id": "Bayard",
+                    "message_id": 16105
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {
+                            "comment": "Idle dialogue",
+                            "type": "QstTalkChg",
+                            "Param1": 4504,
+                            "Param2": 16106
+                        }
+                    ],
+                    "set_flags": [0],
+                    "check_flags": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "check_flags": [2, 3, 4]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 55
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Bayard",
+                    "message_id": 16107
+                }
+            ]
         },
         {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Accept",
-            "groups": [0]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [0]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [0]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 2 ]
+                }
+            ]
         },
         {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "reset_group": false,
-            "groups": [0]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [1]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 3 ]
+                }
+            ]
         },
-        {		
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 55,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Bayard",
-            "message_id": 11842
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [2]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [2]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 4 ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_1.json
@@ -1,14 +1,14 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Accursed Wanderer",
+    "comment": "The Accursed Wanderer (Twelve Calamities)",
     "quest_id": 20095007,
     "base_level": 55,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "news_image": 183,
-	"variant_index": 1,
+    "variant_index": 1,
     "rewards": [
         {
             "type": "exp",
@@ -28,35 +28,40 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Gleipnir",
                     "item_id": 7959,
                     "num": 1
                 },
                 {
+                    "comment": "Cockatrice Poison Gland",
                     "item_id": 7745,
                     "num": 1
                 },
                 {
+                    "comment": "Mystery Organs",
                     "item_id": 7744,
-                    "num": 1					
+                    "num": 1
                 }
             ]
           },
+        {
+            "type": "random",
+            "loot_pool": [
                 {
-                    "type": "random",
-                    "loot_pool": [
-                      {
-                        "item_id": 7554,
-                        "num": 1,
-                        "chance": 0.6
-                      },
-                      {
-                        "item_id": 41,
-                        "num": 1,
-                        "chance": 0.6
-                      }
-                    ]
-                  }
-                ],
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Panacea",
+                    "item_id": 41,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
     "enemy_groups" : [
         {
             "stage_id": {
@@ -66,103 +71,187 @@
             "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Darkness-Cursing Demon (Ghoul)",
+                    "enemy_id": "0x015503",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 524,
+                    "level": 55,
+                    "exp": 4300,
+                    "is_boss": true,
+                    "index": 0
+                },
+                {
+                    "comment": "Darkness-Cursing Demon (Ghoul)",
+                    "enemy_id": "0x015503",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 524,
+                    "level": 55,
+                    "exp": 4300,
+                    "is_boss": true,
+                    "index": 1
+                },
+                {
+                    "comment": "Dangerous Shadow Harpy",
                     "enemy_id": "0x010607",
                     "start_think_tbl_no": 2,
                     "named_enemy_params_id": 56,
                     "level": 55,
-                    "exp": 6476,
-                    "is_boss": false,
-                    "index": 3                    
-        },
-        {
-            "enemy_id": "0x010607",
-            "start_think_tbl_no": 2,
-            "named_enemy_params_id": 56,
-            "level": 55,
-            "exp": 6476,
-            "is_boss": false,
-            "index": 6                    
-},
-{
-    "enemy_id": "0x010607",
-    "start_think_tbl_no": 2,
-    "named_enemy_params_id": 56,
-    "level": 55,
-    "exp": 6476,
-    "is_boss": false,
-    "index": 4                    
-},
-{
-    "enemy_id": "0x010607",
-    "start_think_tbl_no": 2,
-    "named_enemy_params_id": 56,
-    "level": 55,
-    "exp": 6476,
-    "is_boss": false,
-    "index": 5                    
-},
-        {
-                    "enemy_id": "0x070200",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 524,
-                    "level": 55,
-                    "exp": 19700,
-                    "is_boss": true,
-                    "index": 0
-        },
-        {
-                    "enemy_id": "0x070200",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 524,
-                    "level": 55,
-                    "exp": 19700,
-                    "is_boss": true,
-                    "index": 1					
+                    "exp": 240,
+                    "index": 6
                 },
                 {
+                    "comment": "Dangerous Shadow Harpy",
+                    "enemy_id": "0x010607",
+                    "start_think_tbl_no": 2,
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 240,
+                    "index": 7
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 393
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Petrification-Spreading Demon (Cockatrice)",
                     "enemy_id": "0x015301",
                     "start_think_tbl_no": 1,
                     "named_enemy_params_id": 522,
                     "level": 55,
-                    "exp": 19700,
-                    "is_boss": true,
-                    "index": 2
-        }
+                    "exp": 5890,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 374
+            },
+            "starting_index": 1,
+            "enemies": [
+                {
+                    "comment": "Dangerous Shadow Harpy",
+                    "enemy_id": "0x010607",
+                    "start_think_tbl_no": 2,
+                    "named_enemy_params_id": 56,
+                    "level": 55,
+                    "exp": 240
+                }
             ]
         }
-    ],	
-    "blocks": [
+    ],
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",
-            "stage_id": {
-                "id": 55,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "npc_id": "Bayard",
-            "message_id": 11372
+            "blocks": [
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 55
+                    },
+                    "npc_id": "Bayard",
+                    "message_id": 16105
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {
+                            "comment": "Idle dialogue",
+                            "type": "QstTalkChg",
+                            "Param1": 4504,
+                            "Param2": 16106
+                        }
+                    ],
+                    "set_flags": [0],
+                    "check_flags": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "check_flags": [2, 3, 4]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 55
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Bayard",
+                    "message_id": 16107
+                }
+            ]
         },
         {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Accept",
-            "groups": [0]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [0]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [0]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 2 ]
+                }
+            ]
         },
         {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "reset_group": false,
-            "groups": [0]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [1]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 3 ]
+                }
+            ]
         },
-        {		
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 55,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Bayard",
-            "message_id": 11842
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [2]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [2]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 4 ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_2.json
@@ -1,14 +1,14 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "The Accursed Wanderer",
+    "comment": "The Accursed Wanderer (Twelve Calamities II)",
     "quest_id": 20095007,
     "base_level": 60,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "news_image": 183,
-	"variant_index": 2,
+    "variant_index": 2,
     "rewards": [
         {
             "type": "exp",
@@ -28,118 +28,202 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Crest of Crystallization",
                     "item_id": 9254,
                     "num": 1
                 },
                 {
+                    "comment": "Cockatrice Gastrolith",
                     "item_id": 9440,
                     "num": 1
                 },
                 {
+                    "comment": "Giant Single Pelt",
                     "item_id": 9438,
-                    "num": 1					
-                },
-                {
-                    "item_id": 11740,
                     "num": 1
-                },
-                {
-                    "item_id": 11741,
-                    "num": 1					
-                },
-                {
-                    "item_id": 13812,
-                    "num": 1					
                 }
             ]
-          },
+        },
+        {
+            "type": "random",
+            "loot_pool": [
                 {
-                    "type": "random",
-                    "loot_pool": [
-                      {
-                        "item_id": 7554,
-                        "num": 1,
-                        "chance": 0.6
-                      },
-                      {
-                        "item_id": 41,
-                        "num": 1,
-                        "chance": 0.6
-                      }
-                    ]
-                  }
-                ],
+                    "comment": "Healing Remedy",
+                    "item_id": 7554,
+                    "num": 1,
+                    "chance": 0.6
+                },
+                {
+                    "comment": "Panacea",
+                    "item_id": 41,
+                    "num": 1,
+                    "chance": 0.6
+                }
+            ]
+        }
+    ],
     "enemy_groups" : [
         {
             "stage_id": {
                 "id": 1,
                 "group_id": 391
             },
-            "placement_type": "manual",
+            "starting_index": 6,
             "enemies": [
-                
-        {
+                {
+                    "comment": "One-Eyed Tyrant (Cyclops)",
                     "enemy_id": "0x015000",
                     "start_think_tbl_no": 1,
                     "named_enemy_params_id": 623,
                     "level": 60,
-                    "exp": 34700,
-                    "is_boss": true,
-                    "index": 0
+                    "exp": 4080,
+                    "is_boss": true
+                }
+            ]
         },
         {
-                    "enemy_id": "0x015000",
-                    "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 623,
-                    "level": 60,
-                    "exp": 34700,
-                    "is_boss": true,
-                    "index": 1					
-                },
+            "stage_id": {
+                "id": 1,
+                "group_id": 393
+            },
+            "starting_index": 3,
+            "enemies": [
                 {
+                    "comment": "Petrifying Demon Cockerel (Cockatrice)",
                     "enemy_id": "0x015301",
                     "start_think_tbl_no": 1,
-                    "named_enemy_params_id": 622,
+                    "named_enemy_params_id": 522,
                     "level": 60,
-                    "exp": 34700,
-                    "is_boss": true,
-                    "index": 2
-        }
+                    "exp": 6310,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 374
+            },
+            "starting_index": 1,
+            "enemies": [
+                {
+                    "comment": "One-Eyed Tyrant (Cyclops)",
+                    "enemy_id": "0x015000",
+                    "start_think_tbl_no": 1,
+                    "named_enemy_params_id": 623,
+                    "level": 60,
+                    "exp": 4080,
+                    "is_boss": true
+                }
             ]
         }
-    ],	
-    "blocks": [
+    ],
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",
-            "stage_id": {
-                "id": 55,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "npc_id": "Bayard",
-            "message_id": 11372
+            "blocks": [
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 55
+                    },
+                    "npc_id": "Bayard",
+                    "message_id": 16105
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {
+                            "comment": "Idle dialogue",
+                            "type": "QstTalkChg",
+                            "Param1": 4504,
+                            "Param2": 16106
+                        }
+                    ],
+                    "set_flags": [0],
+                    "check_flags": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "check_flags": [2, 3, 4]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 55
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Bayard",
+                    "message_id": 16107
+                }
+            ]
         },
         {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Accept",
-            "groups": [0]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [0]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [0]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 2 ]
+                }
+            ]
         },
         {
-            "type": "KillGroup",
-            "announce_type": "Update",
-            "reset_group": false,
-            "groups": [0]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [1]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 3 ]
+                }
+            ]
         },
-        {		
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 55,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Bayard",
-            "message_id": 11842
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [ 0 ]
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "groups": [2]
+                },
+                {
+                    "type": "KillGroup",
+                    "result_commands": [{ "type": "MyQstFlagOn", "Param1": 1 }],
+                    "reset_group": false,
+                    "groups": [2]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [ 4 ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095008.json
@@ -6,7 +6,7 @@
     "base_level": 48,
     "minimum_item_rank": 0,
     "discoverable": false,
-  "area_id": "ZandoraWastelands",	
+    "area_id": "ZandoraWastelands",
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +26,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Cracked Black Horn",
                     "item_id": 7753,
                     "num": 2
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 1
                 },
                 {
+                    "comment": "Healing Remedy",
                     "item_id": 7554,
                     "num": 3
                 }
@@ -46,36 +49,63 @@
                 "id": 41,
                 "group_id": 0
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Vigilant Shadow Wolf",
                     "enemy_id": "0x010206",
-                    "level": 47,
-                    "exp": 1250,
-                    "is_boss": false
-        },
-        {
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 248,
+                    "index": 0
+                },
+                {
+                    "comment": "Vigilant Shadow Wolf",
                     "enemy_id": "0x010206",
-                    "level": 47,
-                    "exp": 1250,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010206",
-                    "level": 47,
-                    "exp": 1350,
-                    "is_boss": false
-        },
-        {
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 248,
+                    "index": 1
+                },
+                {
+                    "comment": "Vigilant Shadow Goblin Leader",
                     "enemy_id": "0x011160",
-                    "level": 47,
-                    "exp": 1350,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x011160",
-                    "level": 47,
-                    "exp": 1350,
-                    "is_boss": false					
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 244,
+                    "index": 2
+                },
+                {
+                    "comment": "Vigilant Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 248,
+                    "index": 10
+                },
+                {
+                    "comment": "Vigilant Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 248,
+                    "index": 11
+                },
+                {
+                    "comment": "Vigilant Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 248,
+                    "index": 12
+                },
+                {
+                    "comment": "Vigilant Shadow Wolf",
+                    "enemy_id": "0x010206",
+                    "named_enemy_params_id": 53,
+                    "level": 48,
+                    "exp": 248,
+                    "index": 13
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010_1.json
@@ -1,44 +1,45 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "A Clash With the Orc Elite Corps",
+    "comment": "A Clash With the Orc Elite Corps (II)",
     "quest_id": 20095010,
-    "base_level": 48,
+    "base_level": 50,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "variant_index": 1,
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 1320
+            "amount": 1370
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 210
+            "amount": 220
         },
         {
             "type": "exp",
-            "amount": 1320
+            "amount": 1370
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "comment": "Crest of Holy Drain Prevention",
-                    "item_id": 9324,
-                    "num": 1
+                    "comment": "Mithril Ore",
+                    "item_id": 7862,
+                    "num": 3
                 },
                 {
-                    "comment": "Crest of Blind Prevention",
-                    "item_id": 9327,
-                    "num": 1
+                    "comment": "Orc's War Tusk",
+                    "item_id": 7761,
+                    "num": 3
                 },
                 {
-                    "comment": "Panacea",
-                    "item_id": 41,
-                    "num": 1
+                    "comment": "Orc Decoration",
+                    "item_id": 8020,
+                    "num": 2
                 }
             ]
         },
@@ -62,46 +63,52 @@
             },
             "enemies": [
                 {
-                    "comment": "Brutal Orc General",
+                    "comment": "Dangerous Orc General",
                     "enemy_id": "0x015830",
-                    "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 1358
+                    "named_enemy_params_id": 56,
+                    "level": 50,
+                    "exp": 1400,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Orc Battler",
-                    "enemy_id": "0x015810",
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 251
+                    "level": 50,
+                    "exp": 292,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Orc Battler",
-                    "enemy_id": "0x015810",
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 251
+                    "level": 50,
+                    "exp": 292,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
                 },
                 {
-                    "comment": "Brutal Orc Battler",
-                    "enemy_id": "0x015810",
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 251
+                    "level": 50,
+                    "exp": 292
                 },
                 {
-                    "comment": "Brutal Orc Battler",
-                    "enemy_id": "0x015810",
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 251
+                    "level": 50,
+                    "exp": 292
                 },
                 {
-                    "comment": "Brutal Orc Battler",
-                    "enemy_id": "0x015810",
+                    "comment": "Brutal Orc Blitzer",
+                    "enemy_id": "0x015811",
                     "named_enemy_params_id": 54,
-                    "level": 48,
-                    "exp": 251
+                    "level": 50,
+                    "exp": 292
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012.json
@@ -49,6 +49,7 @@
         "id": 1,
         "group_id": 423
       },
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Brutal Geo Golem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_1.json
@@ -50,6 +50,7 @@
         "id": 1,
         "group_id": 423
       },
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Dangerous Geo Golem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_2.json
@@ -50,6 +50,7 @@
         "id": 1,
         "group_id": 423
       },
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Bounty Geo Golem",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000.json
@@ -50,40 +50,8 @@
         "id": 113,
         "group_id": 6
       },
-      "starting_index": 3,
+      "starting_index": 2,
       "enemies": [
-        {
-          "comment": "Vigilant Direwolf",
-          "enemy_id": "0x010201",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 148,
-          "is_boss": false
-        },
-        {
-          "comment": "Vigilant Direwolf",
-          "enemy_id": "0x010201",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 148,
-          "is_boss": false
-        },
-        {
-          "comment": "Vigilant Direwolf",
-          "enemy_id": "0x010201",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 148,
-          "is_boss": false
-        },
-        {
-          "comment": "Vigilant Direwolf",
-          "enemy_id": "0x010201",
-          "named_enemy_params_id": 53,
-          "level": 40,
-          "exp": 148,
-          "is_boss": false
-        },
         {
           "comment": "Brutal Silver Roar",
           "enemy_id": "0x015505",
@@ -91,6 +59,38 @@
           "level": 41,
           "exp": 3287,
           "is_boss": true
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Direwolf",
+          "enemy_id": "0x010201",
+          "named_enemy_params_id": 53,
+          "level": 40,
+          "exp": 148,
+          "is_boss": false
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100000_1.json
@@ -51,7 +51,7 @@
         "id": 113,
         "group_id": 6
       },
-      "starting_index": 6,
+      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Brutal Silver Roar",
@@ -59,7 +59,8 @@
           "named_enemy_params_id": 54,
           "level": 41,
           "exp": 3287,
-          "is_boss": true
+          "is_boss": true,
+          "index": 4
         },
         {
           "comment": "Brutal Silver Roar",
@@ -67,7 +68,8 @@
           "named_enemy_params_id": 54,
           "level": 41,
           "exp": 3287,
-          "is_boss": true
+          "is_boss": true,
+          "index": 6
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Wicked Pursuer (Calamity)",
+  "comment": "The Wicked Pursuer (Twelve Calamities)",
   "quest_id": 20100003,
   "base_level": 55,
   "minimum_item_rank": 0,
@@ -43,6 +43,28 @@
           "num": 1
         }
       ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Sheer Intelligence",
+          "item_id": 9293,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Greater Intelligence",
+          "item_id": 9292,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
     }
   ],
   "enemy_groups": [
@@ -51,7 +73,7 @@
         "id": 114,
         "group_id": 0
       },
-      "starting_index": 6,
+      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Fierce Winged Lion (Griffin)",
@@ -59,7 +81,8 @@
           "named_enemy_params_id": 517,
           "level": 55,
           "exp": 5625,
-          "is_boss": true
+          "is_boss": true,
+          "index": 6
         },
         {
           "comment": "Fierce Silver Lion (White Chimera)",
@@ -67,7 +90,8 @@
           "named_enemy_params_id": 518,
           "level": 55,
           "exp": 5787,
-          "is_boss": true
+          "is_boss": true,
+          "index": 8
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100003_3.json
@@ -51,7 +51,7 @@
         "id": 114,
         "group_id": 0
       },
-      "starting_index": 7,
+      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Sharp Fang Mist Dragon (Mist Drake)",
@@ -59,7 +59,8 @@
           "named_enemy_params_id": 624,
           "level": 60,
           "exp": 9860,
-          "is_boss": true
+          "is_boss": true,
+          "index": 6
         },
         {
           "comment": "Wicked Clawed White Lion (White Chimera)",
@@ -67,7 +68,8 @@
           "named_enemy_params_id": 625,
           "level": 60,
           "exp": 6162,
-          "is_boss": true
+          "is_boss": true,
+          "index": 8
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000.json
@@ -53,42 +53,6 @@
       "starting_index": 4,
       "enemies": [
         {
-          "comment": "Vigilant Harpy",
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 117,
-          "is_boss": false
-        },
-        {
-          "comment": "Vigilant Harpy",
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 117,
-          "is_boss": false
-        },
-        {
-          "comment": "Vigilant Harpy",
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 2,
-          "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 117,
-          "is_boss": false
-        },
-        {
-          "comment": "Vigilant Harpy",
-          "enemy_id": "0x010600",
-          "start_think_tbl_no": 1,
-          "named_enemy_params_id": 53,
-          "level": 41,
-          "exp": 117,
-          "is_boss": false
-        },
-        {
           "comment": "Brutal White Chimera",
           "enemy_id": "0x015202",
           "start_think_tbl_no": 1,
@@ -96,6 +60,42 @@
           "level": 43,
           "exp": 4887,
           "is_boss": true
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
+        },
+        {
+          "comment": "Vigilant Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 1,
+          "named_enemy_params_id": 53,
+          "level": 41,
+          "exp": 117,
+          "is_boss": false
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002.json
@@ -59,7 +59,7 @@
           "level": 42,
           "exp": 4020,
           "is_boss": true,
-          "index": 5
+          "index": 0
         },
         {
           "comment": "Brutal Mole Troll",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002_1.json
@@ -60,7 +60,7 @@
           "level": 42,
           "exp": 4020,
           "is_boss": true,
-          "index": 5
+          "index": 0
         },
         {
           "comment": "Brutal Mole Troll",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_2.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Keeper of the Woods (Calamity)",
+  "comment": "The Keeper of the Woods (Twelve Calamities)",
   "quest_id": 20105004,
   "base_level": 45,
   "minimum_item_rank": 0,
@@ -41,6 +41,28 @@
           "comment": "Sprite's Talisman",
           "item_id": 9390,
           "num": 1
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Sheer Magick",
+          "item_id": 9201,
+          "num": 1,
+          "chance": 0.15
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Crest of Greater Magick",
+          "item_id": 9200,
+          "num": 1,
+          "chance": 0.15
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_3.json
@@ -1,7 +1,7 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "The Keeper of the Woods (Calamity II)",
+  "comment": "The Keeper of the Woods (Twelve Calamities II)",
   "quest_id": 20105004,
   "base_level": 55,
   "minimum_item_rank": 0,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
@@ -48,8 +48,9 @@
         {
             "stage_id": {
                 "id": 1,
-                "group_id": 340
+                "group_id": 322
             },
+            "starting_index": 4,
             "enemies": [
                 {
                     "comment": "Brutal Ent",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007.json
@@ -50,7 +50,7 @@
         "id": 97,
         "group_id": 7
       },
-      "starting_index": 5,
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Brutal Silver Roar",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_1.json
@@ -53,18 +53,18 @@
       },
       "enemies": [
         {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 56,
+          "exp": 279
+        },
+        {
           "comment": "Shadow Harpy",
           "enemy_id": "0x010607",
           "level": 56,
           "exp": 243,
           "repop_count": 1,
           "repop_wait_second": 10
-        },
-        {
-          "comment": "Shadow Wolf",
-          "enemy_id": "0x010206",
-          "level": 56,
-          "exp": 279
         },
         {
           "comment": "Shadow Wolf",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_2.json
@@ -51,7 +51,7 @@
         "id": 97,
         "group_id": 7
       },
-      "starting_index": 5,
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Bounty Silver Roar",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995000.json
@@ -25,6 +25,10 @@
           "group_id": 1
         }
       ],
+    "order_conditions": [
+      {"type": "MinimumLevel", "Param1": 55},
+      {"type": "MainQuestCompleted", "Param1": 30}
+    ],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
@@ -47,10 +47,7 @@
         {
             "stage_id": {
                 "id": 76,
-                "group_id": 4,
-                "sub_group_id": 0,
-                "layer_no": 0
-                
+                "group_id": 4
             },
             "placement_type": "manual",
             "enemies": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
@@ -48,10 +48,7 @@
         {
             "stage_id": {
                 "id": 76,
-                "group_id": 4,
-                "sub_group_id": 0,
-                "layer_no": 0
-                
+                "group_id": 4
             },
             "starting_index": 10,
             "enemies": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009.json
@@ -49,40 +49,8 @@
                 "id": 84,
                 "group_id": 5
             },
-            "starting_index": 6,
+            "starting_index": 7,
             "enemies": [
-                {
-                    "comment": "Vigilant Alchemized Sling Goblin",
-                    "enemy_id": "0x011122",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 205,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Vigilant Alchemized Sling Goblin",
-                    "enemy_id": "0x011122",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 205,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Vigilant Alchemized Sling Goblin",
-                    "enemy_id": "0x011122",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 205,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Vigilant Alchemized Sling Goblin",
-                    "enemy_id": "0x011122",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 205,
-                    "is_boss": false
-                },
                 {
                     "comment": "Brutal Silver Roar",
                     "enemy_id": "0x015505",
@@ -90,6 +58,38 @@
                     "level": 52,
                     "exp": 3914,
                     "is_boss": true
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Sling Goblin",
+                    "enemy_id": "0x011122",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 205,
+                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009_1.json
@@ -50,40 +50,8 @@
                 "id": 84,
                 "group_id": 5
             },
-            "starting_index": 6,
+            "starting_index": 7,
             "enemies": [
-                {
-                    "comment": "Vigilant Alchemized Harpy",
-                    "enemy_id": "0x010606",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 252,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Vigilant Alchemized Harpy",
-                    "enemy_id": "0x010606",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 252,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Vigilant Alchemized Harpy",
-                    "enemy_id": "0x010606",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 252,
-                    "is_boss": false
-                },
-                {
-                    "comment": "Vigilant Alchemized Harpy",
-                    "enemy_id": "0x010606",
-                    "named_enemy_params_id": 53,
-                    "level": 52,
-                    "exp": 252,
-                    "is_boss": false
-                },
                 {
                     "comment": "Brutal Silver Roar",
                     "enemy_id": "0x015505",
@@ -91,6 +59,38 @@
                     "level": 52,
                     "exp": 3914,
                     "is_boss": true
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
+                },
+                {
+                    "comment": "Vigilant Alchemized Harpy",
+                    "enemy_id": "0x010606",
+                    "named_enemy_params_id": 53,
+                    "level": 52,
+                    "exp": 252,
+                    "is_boss": false
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
@@ -59,7 +59,7 @@
                     "is_boss": true
                 },
                 {
-                    "comment": "Critical Alchemized Harpy",
+                    "comment": "Dangerous Alchemized Harpy",
                     "enemy_id": "0x010606",
                     "named_enemy_params_id": 56,
                     "level": 56,
@@ -69,7 +69,7 @@
                     "repop_wait_second": 10
                 },
                 {
-                    "comment": "Critical Alchemized Harpy",
+                    "comment": "Dangerous Alchemized Harpy",
                     "enemy_id": "0x010606",
                     "named_enemy_params_id": 56,
                     "level": 56,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000018.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 8, "Param2": 11 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000019.json
@@ -1,0 +1,434 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Demon Eradication",
+  "quest_id": 21000019,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BetlandPlains",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 8, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 9379
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Twilight (Decreased Dark Resist)",
+          "item_id": 16065,
+          "num": 2
+        },
+        {
+          "comment": "Crest of Twilight",
+          "item_id": 9266,
+          "num": 2
+        },
+        {
+          "comment": "Crest of Diminished Dark Resist",
+          "item_id": 9276,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 167,
+        "group_id": 0
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 0
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 1
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 2
+        },
+        {
+          "comment": "Empress Ghost",
+          "enemy_id": "0x015605",
+          "level": 65,
+          "exp": 4900,
+          "is_boss": true,
+          "index": 5
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 167,
+        "group_id": 1
+      },
+      "enemies": [
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 65,
+          "exp": 792
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 65,
+          "exp": 792
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 65,
+          "exp": 792
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 65,
+          "exp": 792
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 431,
+        "group_id": 1
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 65,
+          "exp": 792,
+          "index": 2
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 65,
+          "exp": 792,
+          "index": 3
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 65,
+          "exp": 792,
+          "index": 4
+        },
+        {
+          "comment": "Shadow Sling Goblin",
+          "enemy_id": "0x011132",
+          "level": 65,
+          "exp": 792,
+          "index": 6
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 792,
+          "index": 9
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 792,
+          "index": 10
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 431,
+        "group_id": 5
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Shadow Chimera",
+          "enemy_id": "0x015203",
+          "level": 63,
+          "exp": 3908,
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 65,
+          "exp": 792,
+          "index": 4
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 65,
+          "exp": 792,
+          "index": 5
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 65,
+          "exp": 792,
+          "index": 6
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 65,
+          "exp": 792,
+          "index": 7
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 65,
+          "exp": 792,
+          "index": 9
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 431,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Empress Ghost",
+          "enemy_id": "0x015605",
+          "level": 65,
+          "exp": 4900,
+          "is_boss": true,
+          "index": 6
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 65,
+          "exp": 792,
+          "index": 7
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 65,
+          "exp": 792,
+          "index": 8
+        },
+        {
+          "comment": "Empress Ghost",
+          "enemy_id": "0x015605",
+          "level": 65,
+          "exp": 4900,
+          "is_boss": true,
+          "index": 9
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 65,
+          "exp": 792,
+          "index": 10
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 11
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 12
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 13
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 65,
+          "exp": 792,
+          "index": 14
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 66
+          },
+          "npc_id": "Scherzo",
+          "message_id": 17078
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 1905,
+              "Param2": 17079
+            }
+          ],
+          "groups": [0, 1]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [0, 1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 66
+          },
+          "npc_id": "Scherzo",
+          "message_id": 17080
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [4]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [4]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000020.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MysreeGrove",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000021.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MysreeGrove",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 11 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000030.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 8, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000031.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000031.json
@@ -1,0 +1,451 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: To Rest, Once More",
+  "quest_id": 21000031,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeGrove",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 9379
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Incineration (Decreased Fire Resist)",
+          "item_id": 16061,
+          "num": 2
+        },
+        {
+          "comment": "Crest of Incineration",
+          "item_id": 9258,
+          "num": 2
+        },
+        {
+          "comment": "Crest of Diminished Fire Resist",
+          "item_id": 9268,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 2
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Silver Roar",
+          "enemy_id": "0x015505",
+          "level": 65,
+          "exp": 3026,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 65,
+          "exp": 630,
+          "index": 10
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 65,
+          "exp": 630,
+          "index": 11
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 65,
+          "exp": 630,
+          "index": 12
+        },
+        {
+          "comment": "Skeleton Mage",
+          "enemy_id": "0x010308",
+          "level": 65,
+          "exp": 630,
+          "index": 13
+        },
+        {
+          "comment": "Skeleton Mage",
+          "enemy_id": "0x010308",
+          "level": 65,
+          "exp": 630,
+          "index": 14
+        },
+        {
+          "comment": "Skeleton Mage",
+          "enemy_id": "0x010308",
+          "level": 65,
+          "exp": 630,
+          "index": 15
+        },
+        {
+          "comment": "Skeleton Mage",
+          "enemy_id": "0x010308",
+          "level": 65,
+          "exp": 630,
+          "index": 16
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 11
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Cockatrice",
+          "enemy_id": "0x015301",
+          "level": 65,
+          "exp": 3026,
+          "is_boss": true
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 13
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Scarlet Fighter",
+          "enemy_id": "0x011070",
+          "hm_present_no": 87,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Fighter",
+          "enemy_id": "0x011070",
+          "hm_present_no": 87,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Defender",
+          "enemy_id": "0x011074",
+          "hm_present_no": 91,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Defender",
+          "enemy_id": "0x011074",
+          "hm_present_no": 91,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Defender",
+          "enemy_id": "0x011074",
+          "hm_present_no": 91,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Healer",
+          "enemy_id": "0x011073",
+          "hm_present_no": 90,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Healer",
+          "enemy_id": "0x011073",
+          "hm_present_no": 90,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Healer",
+          "enemy_id": "0x011073",
+          "hm_present_no": 90,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Scarlet Healer",
+          "enemy_id": "0x011073",
+          "hm_present_no": 90,
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 15
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Drake",
+          "enemy_id": "0x015700",
+          "level": 65,
+          "exp": 15761,
+          "is_boss": true
+        },
+        {
+          "comment": "Rock Saurian",
+          "enemy_id": "0x010450",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Rock Saurian",
+          "enemy_id": "0x010450",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Rock Saurian",
+          "enemy_id": "0x010450",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Rock Saurian",
+          "enemy_id": "0x010450",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Oil Jelly",
+          "enemy_id": "0x010920",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Oil Jelly",
+          "enemy_id": "0x010920",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Oil Jelly",
+          "enemy_id": "0x010920",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Oil Jelly",
+          "enemy_id": "0x010920",
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 137
+          },
+          "npc_id": "Christine",
+          "message_id": 17099
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 4506,
+              "Param2": 17100
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 137
+          },
+          "npc_id": "Christine",
+          "message_id": 17101
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000032.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000032.json
@@ -1,0 +1,169 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Remain for Eternity",
+  "quest_id": 21000032,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MysreeGrove",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 7034
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Ash Quartz",
+          "item_id": 11768,
+          "num": 3
+        },
+        {
+          "comment": "Quality Gala Mushroom",
+          "item_id": 7994,
+          "num": 7
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 427,
+        "group_id": 4
+      },
+      "enemies": [
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 63,
+          "exp": 775
+        },
+        {
+          "comment": "Mole Troll",
+          "enemy_id": "0x015041",
+          "level": 63,
+          "exp": 3876,
+          "is_boss": true
+        },
+        {
+          "comment": "Ent",
+          "enemy_id": "0x015031",
+          "level": 63,
+          "exp": 3876,
+          "is_boss": true
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 137
+      },
+      "npc_id": "Christine",
+      "message_id": 17103
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 137
+      },
+      "npc_id": "Christine",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4506,
+          "Param2": 17104
+        }
+      ],
+      "items": [
+        {
+          "comment": "Gleipnir",
+          "id": 7959,
+          "amount": 2
+        }
+      ],
+      "message_id": 17105
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4506,
+          "Param2": 17106
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 137
+      },
+      "announce_type": "Update",
+      "npc_id": "Christine",
+      "message_id": 17107
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
@@ -50,7 +50,7 @@
         "id": 152,
         "group_id": 3
       },
-      "starting_index": 4,
+      "starting_index": 7,
       "enemies": [
         {
           "comment": "Infected Gorecyclops (Severe)",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000034.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000034.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "VoldenMines",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 11 } ],
   "rewards": [
     {
       "type": "exp",
@@ -26,18 +27,18 @@
       "type": "select",
       "loot_pool": [
         {
-          "comment": "Cursed Cloth",
-          "item_id": 7948,
+          "comment": "Blow-Resistant Cloth",
+          "item_id": 7942,
           "num": 2
         },
         {
-          "comment": "Large Scallop Shell",
-          "item_id": 8018,
-          "num": 5
+          "comment": "Quality Gala Mushroom",
+          "item_id": 7995,
+          "num": 7
         },
         {
-          "comment": "Superior Strong Gala Extract",
-          "item_id": 9364,
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
           "num": 3
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000039.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000039.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "BetlandPlains",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 8, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -156,7 +157,7 @@
               "item_min": 1,
               "item_max": 1,
               "quality": 0,
-              "drop_chance": 0.1
+              "drop_chance": 0.15
             }
           ]
         },
@@ -193,7 +194,7 @@
               "item_min": 1,
               "item_max": 1,
               "quality": 0,
-              "drop_chance": 0.1
+              "drop_chance": 0.15
             }
           ]
         },
@@ -230,8 +231,8 @@
               "item_min": 1,
               "item_max": 1,
               "quality": 0,
-              "drop_chance": 0.1
-            }
+              "drop_chance": 0.15
+			}
           ]
         }
       ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "MysreeGrove",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000043.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000043.json
@@ -1,0 +1,420 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Thank You for Your Trouble",
+  "quest_id": 21000043,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "VoldenMines",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 9379
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2144
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 275
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Superior Magick (Lowered Magick Defense)",
+          "item_id": 16058,
+          "num": 2
+        },
+        {
+          "comment": "Crest of Superior Magick",
+          "item_id": 9202,
+          "num": 2
+        },
+        {
+          "comment": "Crest of Dwindled Magick Defense",
+          "item_id": 9284,
+          "num": 2
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 72,
+        "group_id": 12
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "level": 65,
+          "exp": 630,
+          "index": 6
+        },
+        {
+          "comment": "Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "level": 65,
+          "exp": 630,
+          "index": 7
+        },
+        {
+          "comment": "Colossus",
+          "enemy_id": "0x015020",
+          "level": 63,
+          "exp": 3026,
+          "is_boss": true,
+          "index": 11
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 65,
+          "exp": 630,
+          "index": 12
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 65,
+          "exp": 630,
+          "index": 13
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 65,
+          "exp": 630,
+          "index": 14
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 410,
+        "group_id": 2
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Redcap Slinger",
+          "enemy_id": "0x011112",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Redcap Slinger",
+          "enemy_id": "0x011112",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Redcap Slinger",
+          "enemy_id": "0x011112",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Redcap Slinger",
+          "enemy_id": "0x011112",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Redcap Slinger",
+          "enemy_id": "0x011112",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Redcap Slinger",
+          "enemy_id": "0x011112",
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 410,
+        "group_id": 3
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Griffin",
+          "enemy_id": "0x015300",
+          "level": 65,
+          "exp": 3026,
+          "is_boss": true
+        },
+        {
+          "comment": "Ghost Mail",
+          "enemy_id": "0x010311",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Ghost Mail",
+          "enemy_id": "0x010311",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 410,
+        "group_id": 6
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Golem",
+          "enemy_id": "0x015100",
+          "start_think_tbl_no": 2,
+          "level": 65,
+          "exp": 15761,
+          "is_boss": true
+        },
+        {
+          "comment": "Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Rock Saurian Spinel",
+          "enemy_id": "0x010451",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        },
+        {
+          "comment": "Flame Skeleton Brute",
+          "enemy_id": "0x010320",
+          "level": 65,
+          "exp": 630
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 80
+          },
+          "npc_id": "Roy",
+          "message_id": 17116
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 1604,
+              "Param2": 17117
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 80
+          },
+          "npc_id": "Roy",
+          "message_id": 17118
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000044.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000044.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "VoldenMines",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -28,7 +29,7 @@
         {
           "comment": "Volden Quality Coal",
           "item_id": 11770,
-          "num": 1
+          "num": 3
         },
         {
           "comment": "Iron Ore Fragment",
@@ -79,13 +80,6 @@
           "enemy_id": "0x010309",
           "level": 63,
           "exp": 756,
-          "index": 8
-        },
-        {
-          "comment": "Skeleton Sorcerer",
-          "enemy_id": "0x010309",
-          "level": 63,
-          "exp": 756,
           "index": 9
         },
         {
@@ -115,6 +109,13 @@
           "level": 63,
           "exp": 756,
           "index": 13
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 63,
+          "exp": 756,
+          "index": 14
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000045.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000045.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "VoldenMines",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -184,39 +185,6 @@
             }
           ],
           "is_manual_set": true,
-          "index": 3
-        },
-        {
-          "comment": "Treasure-Bearing Skull Lord",
-          "enemy_id": "0x010313",
-          "named_enemy_params_id": 1119,
-          "start_think_tbl_no": 8,
-          "level": 63,
-          "exp": 1408,
-          "drop_items": [
-            {
-              "item_id": 7850,
-              "item_min": 1,
-              "item_max": 2,
-              "quality": 0,
-              "drop_chance": 0.8
-            },
-            {
-              "item_id": 7772,
-              "item_min": 1,
-              "item_max": 1,
-              "quality": 0,
-              "drop_chance": 0.3
-            },
-            {
-              "item_id": 19509,
-              "item_min": 1,
-              "item_max": 1,
-              "quality": 0,
-              "drop_chance": 1.0
-            }
-          ],
-          "is_manual_set": true,
           "index": 5
         },
         {
@@ -284,6 +252,39 @@
           ],
           "is_manual_set": true,
           "index": 7
+        },
+        {
+          "comment": "Treasure-Bearing Skull Lord",
+          "enemy_id": "0x010313",
+          "named_enemy_params_id": 1119,
+          "start_think_tbl_no": 8,
+          "level": 63,
+          "exp": 1408,
+          "drop_items": [
+            {
+              "item_id": 7850,
+              "item_min": 1,
+              "item_max": 2,
+              "quality": 0,
+              "drop_chance": 0.8
+            },
+            {
+              "item_id": 7772,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 0.3
+            },
+            {
+              "item_id": 19509,
+              "item_min": 1,
+              "item_max": 1,
+              "quality": 0,
+              "drop_chance": 1.0
+            }
+          ],
+          "is_manual_set": true,
+          "index": 8
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000054.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000054.json
@@ -1,0 +1,420 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Danger at the Ruins",
+  "quest_id": 21000054,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "DeenanWoods",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 48420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5138
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 940
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Unappraised Moon Trinket (King)",
+          "item_id": 13477,
+          "num": 2
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 163,
+        "group_id": 0
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Ent",
+          "enemy_id": "0x015031",
+          "level": 78,
+          "exp": 3908,
+          "is_boss": true
+        },
+        {
+          "comment": "Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Hobgoblin Fighter",
+          "enemy_id": "0x010111",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 1
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Dread Ape",
+          "enemy_id": "0x015502",
+          "level": 78,
+          "exp": 3908,
+          "is_boss": true
+        },
+        {
+          "comment": "Dread Ape",
+          "enemy_id": "0x015502",
+          "level": 78,
+          "exp": 3908,
+          "is_boss": true
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 7
+      },
+      "starting_index": 8,
+      "enemies": [
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Large Newt",
+          "enemy_id": "0x010461",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Large Newt",
+          "enemy_id": "0x010461",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Forest Goblin Fighter",
+          "enemy_id": "0x011101",
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 428,
+        "group_id": 13
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Mist Wyrm",
+          "enemy_id": "0x015711",
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 80,
+          "exp": 630,
+          "index": 6
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 80,
+          "exp": 630,
+          "index": 7
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 80,
+          "exp": 630,
+          "index": 8
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630,
+          "index": 9
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630,
+          "index": 10
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630,
+          "index": 11
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630,
+          "index": 12
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 80,
+          "exp": 630,
+          "index": 13
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 105
+          },
+          "npc_id": "Rondejeel0",
+          "message_id": 17312
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 4508,
+              "Param2": 17313
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 105
+          },
+          "npc_id": "Rondejeel0",
+          "message_id": 17314
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000055.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000055.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "EasternZandora",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000056.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000056.json
@@ -1,0 +1,427 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Monsters Full of Ambition",
+  "quest_id": 21000056,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "EasternZandora",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16020
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Crest of Power+",
+          "item_id": 11719,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Herculean Power (Stun)",
+          "item_id": 16044,
+          "num": 1
+        },
+        {
+          "comment": "Crest of Herculean Power (Lowered Defense)",
+          "item_id": 16050,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 37,
+        "group_id": 1
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 432,
+        "group_id": 1
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 432,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Empress Ghost",
+          "enemy_id": "0x015605",
+          "level": 70,
+          "exp": 5925,
+          "is_boss": true,
+          "index": 4
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 70,
+          "exp": 1335,
+          "index": 5
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 70,
+          "exp": 1335,
+          "index": 6
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 8
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 9
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 10
+        },
+        {
+          "comment": "Dark Skeleton",
+          "enemy_id": "0x010318",
+          "start_think_tbl_no": 2,
+          "level": 70,
+          "exp": 1335,
+          "index": 11
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 432,
+        "group_id": 9
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Death Knight",
+          "enemy_id": "0x010310",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Death Knight",
+          "enemy_id": "0x010310",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 70,
+          "exp": 1335
+        },
+        {
+          "comment": "Dark Skeleton Brute",
+          "enemy_id": "0x010324",
+          "level": 70,
+          "exp": 1335
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 61
+          },
+          "npc_id": "Nadia",
+          "message_id": 17333
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 1811,
+              "Param2": 17334
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 61
+          },
+          "npc_id": "Nadia",
+          "message_id": 17335
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000066.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000066.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DeenanWoods",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
   "rewards": [
     {
       "type": "wallet",
@@ -57,7 +58,7 @@
           "level": 68,
           "exp": 5925,
           "is_boss": true,
-          "index": 0
+          "index": 5
         },
         {
           "comment": "Bolt Grimwarg",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000067.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000067.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "DeenanWoods",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
   "rewards": [
     {
       "type": "wallet",
@@ -60,29 +61,29 @@
           "index": 0
         },
         {
-          "comment": "Aqua Jelly",
-          "enemy_id": "0x010904",
+          "comment": "Direwolf",
+          "enemy_id": "0x010201",
           "level": 68,
           "exp": 1185,
           "index": 1
         },
         {
-          "comment": "Aqua Jelly",
-          "enemy_id": "0x010904",
+          "comment": "Direwolf",
+          "enemy_id": "0x010201",
           "level": 68,
           "exp": 1185,
           "index": 2
         },
         {
-          "comment": "Direwolf",
-          "enemy_id": "0x010201",
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
           "level": 68,
           "exp": 1185,
           "index": 6
         },
         {
-          "comment": "Direwolf",
-          "enemy_id": "0x010201",
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
           "level": 68,
           "exp": 1185,
           "index": 7

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000068.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000068.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "EasternZandora",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 11 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000069.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000069.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "EasternZandora",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000076.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000076.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "DeenanWoods",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -170,30 +171,6 @@
           "is_boss": true
         },
         {
-          "comment": "Saurian Sage",
-          "enemy_id": "0x010430",
-          "level": 68,
-          "exp": 1185
-        },
-        {
-          "comment": "Saurian Sage",
-          "enemy_id": "0x010430",
-          "level": 68,
-          "exp": 1185
-        },
-        {
-          "comment": "Saurian Sage",
-          "enemy_id": "0x010430",
-          "level": 68,
-          "exp": 1185
-        },
-        {
-          "comment": "Saurian Sage",
-          "enemy_id": "0x010430",
-          "level": 68,
-          "exp": 1185
-        },
-        {
           "comment": "Jewelry-Bearing Lux Corpse Punisher",
           "enemy_id": "0x010515",
           "named_enemy_params_id": 1121,
@@ -282,6 +259,30 @@
               "drop_chance": 0.1
             }
           ]
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 68,
+          "exp": 1185
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000077.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000077.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "EasternZandora",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -49,7 +50,6 @@
         "id": 432,
         "group_id": 10
       },
-      "starting_index": 1,
       "comment": "Up to 66000G",
       "enemies": [
         {
@@ -141,6 +141,12 @@
             }
           ],
           "is_boss": true
+        },
+        {
+          "comment": "Shadow Harpy",
+          "enemy_id": "0x010607",
+          "level": 65,
+          "exp": 788
         },
         {
           "comment": "Shadow Harpy",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000079.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000079.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MergodaRuins",
   "news_image": 562,
+  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
   "rewards": [
     {
       "type": "wallet",
@@ -50,7 +51,7 @@
         "id": 424,
         "group_id": 4
       },
-      "starting_index": 1,
+      "starting_index": 5,
       "enemies": [
         {
           "comment": "Lux Skeleton",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000080.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000080.json
@@ -1,0 +1,87 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "That Day and Now",
+  "quest_id": 21000080,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MergodaRuins",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 11 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3940
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5360
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 687
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Mergan Cloth",
+          "item_id": 7950,
+          "num": 1
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 63
+      },
+      "npc_id": "Theodor",
+      "message_id": 17410
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 2
+      },
+      "npc_id": "Renton0",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Theodor",
+          "type": "QstTalkChg",
+          "Param1": 10,
+          "Param2": 17411
+        },
+        {
+          "comment": "Idle dialogue - Renton",
+          "type": "QstTalkChg",
+          "Param1": 1029,
+          "Param2": 17412
+        }
+      ],
+      "items": [
+        {
+          "comment": "Slimy Hide",
+          "id": 11806,
+          "amount": 6
+        }
+      ],
+      "message_id": 17413
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000081.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000081.json
@@ -1,0 +1,400 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: The Sealed Darkness",
+  "quest_id": 21000081,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MergodaRuins",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 48420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5138
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 940
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Unappraised Star Trinket (King)",
+          "item_id": 13481,
+          "num": 2
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 62,
+        "group_id": 1
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Mergan Healer",
+          "enemy_id": "0x011023",
+          "hm_present_no": 62,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Healer",
+          "enemy_id": "0x011023",
+          "hm_present_no": 62,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Defender",
+          "enemy_id": "0x011024",
+          "hm_present_no": 63,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Defender",
+          "enemy_id": "0x011024",
+          "hm_present_no": 63,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Defender",
+          "enemy_id": "0x011024",
+          "hm_present_no": 63,
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 424,
+        "group_id": 3
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Goliath",
+          "enemy_id": "0x015102",
+          "level": 80,
+          "exp": 3026,
+          "is_boss": true
+        },
+        {
+          "comment": "Lux Brute Skeleton",
+          "enemy_id": "0x010323",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Lux Brute Skeleton",
+          "enemy_id": "0x010323",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemized Harpy",
+          "enemy_id": "0x010606",
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 424,
+        "group_id": 1
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Mergan Mage",
+          "enemy_id": "0x011025",
+          "hm_present_no": 64,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Mage",
+          "enemy_id": "0x011025",
+          "hm_present_no": 64,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Element Archer",
+          "enemy_id": "0x011027",
+          "hm_present_no": 66,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Mergan Element Archer",
+          "enemy_id": "0x011027",
+          "hm_present_no": 66,
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Alchemy Eye",
+          "enemy_id": "0x015420",
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 424,
+        "group_id": 5
+      },
+      "starting_index": 1,
+      "enemies": [
+        {
+          "comment": "Wyrm",
+          "enemy_id": "0x015701",
+          "level": 78,
+          "exp": 15761,
+          "is_boss": true
+        },
+        {
+          "comment": "Giant Saurian",
+          "enemy_id": "0x010401",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Giant Saurian",
+          "enemy_id": "0x010401",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Giant Saurian",
+          "enemy_id": "0x010401",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 80,
+          "exp": 630
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 80,
+          "exp": 630
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 237
+          },
+          "npc_id": "Beatrix",
+          "message_id": 17414
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 2301,
+              "Param2": 17415
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 237
+          },
+          "npc_id": "Beatrix",
+          "message_id": 17416
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000084.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000084.json
@@ -1,0 +1,177 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "At the End of One's Wandering",
+  "quest_id": 21000084,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ZandoraWastelands",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 10, "Param2": 13 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 13814
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Slimy Hide",
+          "item_id": 11806,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 363,
+        "group_id": 1
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 70,
+          "exp": 788,
+          "index": 0
+        },
+        {
+          "comment": "Goliath",
+          "enemy_id": "0x015102",
+          "level": 67,
+          "exp": 3876,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Alchemized Skeleton",
+          "enemy_id": "0x010312",
+          "level": 70,
+          "exp": 788,
+          "index": 7
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 70,
+          "exp": 788,
+          "index": 9
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 70,
+          "exp": 788,
+          "index": 10
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 70,
+          "exp": 788,
+          "index": 11
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 70,
+          "exp": 788,
+          "index": 12
+        },
+        {
+          "comment": "Aqua Jelly",
+          "enemy_id": "0x010904",
+          "level": 70,
+          "exp": 788,
+          "index": 13
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 139
+      },
+      "npc_id": "Dian",
+      "message_id": 17192
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 139
+      },
+      "npc_id": "Dian",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4507,
+          "Param2": 17209
+        }
+      ],
+      "items": [
+        {
+          "comment": "Scroll of Defense",
+          "id": 8008,
+          "amount": 2
+        }
+      ],
+      "message_id": 17210
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue",
+          "type": "QstTalkChg",
+          "Param1": 4507,
+          "Param2": 17211
+        }
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 139
+      },
+      "announce_type": "Update",
+      "npc_id": "Dian",
+      "message_id": 17212
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000088.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000088.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 11 } ],
     "rewards": [
         {
             "type": "exp",
@@ -81,14 +82,14 @@
                     "enemy_id": "0x010312",
                     "level": 68,
                     "exp": 788,
-                    "index": 15
+                    "index": 16
                 },
                 {
                     "comment": "Alchemized Skeleton",
                     "enemy_id": "0x010312",
                     "level": 68,
                     "exp": 788,
-                    "index": 16
+                    "index": 17
                 },
                 {
                     "comment": "Alchemized Skeleton",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000089.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000089.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MergodaRuins",
   "news_image": 562,
+  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
   "rewards": [
     {
       "type": "wallet",
@@ -50,7 +51,7 @@
         "id": 424,
         "group_id": 4
       },
-      "starting_index": 1,
+      "starting_index": 5,
       "enemies": [
         {
           "comment": "Alchemized Skeleton",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "MergodaRuins",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000092.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000092.json
@@ -7,7 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "ZandoraWastelands",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 13 } ],
+  "order_conditions": [ { "type": "AreaRank", "Param1": 10, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -71,21 +71,21 @@
       "enemies": [
         {
           "comment": "Infected Orc Tosser",
-          "enemy_id": "0x015801",
+          "enemy_id": "0x015814",
           "level": 68,
           "exp": 1185,
           "index": 0
         },
         {
           "comment": "Infected Orc Tosser",
-          "enemy_id": "0x015801",
+          "enemy_id": "0x015814",
           "level": 68,
           "exp": 1185,
           "index": 4
         },
         {
           "comment": "Infected Orc Tosser",
-          "enemy_id": "0x015801",
+          "enemy_id": "0x015814",
           "level": 68,
           "exp": 1185,
           "index": 6

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000093.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000093.json
@@ -1,0 +1,87 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Solitary Master",
+  "quest_id": 21000093,
+  "base_level": 65,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ZandoraWastelands",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 10, "Param2": 11 } ],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 3940
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5360
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 687
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Slimy Hide",
+          "item_id": 11806,
+          "num": 2
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 139
+      },
+      "npc_id": "Dian",
+      "message_id": 17194
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 1
+      },
+      "npc_id": "Alkane",
+      "announce_type": "Accept",
+      "result_commands": [
+        {
+          "comment": "Idle dialogue - Dian",
+          "type": "QstTalkChg",
+          "Param1": 4507,
+          "Param2": 17227
+        },
+        {
+          "comment": "Idle dialogue - Alkane",
+          "type": "QstTalkChg",
+          "Param1": 1403,
+          "Param2": 17228
+        }
+      ],
+      "items": [
+        {
+          "comment": "Gold-Stained Animal Fur",
+          "id": 11803,
+          "amount": 6
+        }
+      ],
+      "message_id": 17232
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000095.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000095.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": false,
   "area_id": "ZandoraWastelands",
+  "order_conditions": [ { "type": "AreaRank", "Param1": 10, "Param2": 13 } ],
   "rewards": [
     {
       "type": "exp",
@@ -50,6 +51,7 @@
         "group_id": 5
       },
       "comment": "Up to 99000G",
+      "placement_type": "manual",
       "enemies": [
         {
           "comment": "Treasure-Bearing Drake",
@@ -94,7 +96,8 @@
               "drop_chance": 0.1
             }
           ],
-          "is_boss": true
+          "is_boss": true,
+          "index": 0
         },
         {
           "comment": "Treasure-Bearing Witch",
@@ -146,7 +149,8 @@
               "drop_chance": 0.1
             }
           ],
-          "is_boss": true
+          "is_boss": true,
+          "index": 3
         },
         {
           "comment": "Treasure-Bearing Strix",
@@ -176,7 +180,10 @@
               "quality": 0,
               "drop_chance": 0.1
             }
-          ]
+          ],
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 4
         },
         {
           "comment": "Treasure-Bearing Strix",
@@ -206,7 +213,10 @@
               "quality": 0,
               "drop_chance": 0.1
             }
-          ]
+          ],
+          "repop_count": 1,
+          "repop_wait_second": 10,
+          "index": 5
         },
         {
           "comment": "Treasure-Bearing Strix",
@@ -236,7 +246,8 @@
               "quality": 0,
               "drop_chance": 0.1
             }
-          ]
+          ],
+          "index": 6
         },
         {
           "comment": "Treasure-Bearing Strix",
@@ -266,7 +277,8 @@
               "quality": 0,
               "drop_chance": 0.1
             }
-          ]
+          ],
+          "index": 7
         },
         {
           "comment": "Treasure-Bearing Strix",
@@ -296,67 +308,8 @@
               "quality": 0,
               "drop_chance": 0.1
             }
-          ]
-        },
-        {
-          "comment": "Treasure-Bearing Strix",
-          "enemy_id": "0x010610",
-          "named_enemy_params_id": 1119,
-          "level": 70,
-          "exp": 456,
-          "drop_items": [
-            {
-              "item_id": 7778,
-              "item_min": 1,
-              "item_max": 4,
-              "quality": 0,
-              "drop_chance": 0.9
-            },
-            {
-              "item_id": 19508,
-              "item_min": 9,
-              "item_max": 9,
-              "quality": 0,
-              "drop_chance": 1.0
-            },
-            {
-              "item_id": 19508,
-              "item_min": 2,
-              "item_max": 2,
-              "quality": 0,
-              "drop_chance": 0.1
-            }
-          ]
-        },
-        {
-          "comment": "Treasure-Bearing Strix",
-          "enemy_id": "0x010610",
-          "named_enemy_params_id": 1119,
-          "level": 70,
-          "exp": 456,
-          "drop_items": [
-            {
-              "item_id": 7778,
-              "item_min": 1,
-              "item_max": 4,
-              "quality": 0,
-              "drop_chance": 0.9
-            },
-            {
-              "item_id": 19508,
-              "item_min": 9,
-              "item_max": 9,
-              "quality": 0,
-              "drop_chance": 1.0
-            },
-            {
-              "item_id": 19508,
-              "item_min": 2,
-              "item_max": 2,
-              "quality": 0,
-              "drop_chance": 0.1
-            }
-          ]
+          ],
+          "index": 8
         }
       ]
     }


### PR DESCRIPTION
Many world quests needed another look after we figured out which groups and indexes we should be using, so here they are!
I've also finished the still pending areas of Mysree Grove, Betland Plans and Zandora Wastelands. Northern Betland Plains (the last one) will come with the remaining areas revisions.

Here's a list of important changes (index and clear reward changes are being skipped for brevity):

Betland Plains:

- q20020001: Named params added.
- q20020003: Named params and three Grimwargs added.
- q20020004: Optional enemy spawns added.
- q20020005: Group ID changed to 0.
- q20020006: Group ID changed to 240.
- q20020007: Group ID changed to 222, variants 1 and 2 added.
- q20020009: Named params and variant 1 added.
- q20020010: Named params added.
- q20020011: Named params and an Orc Tosser added.
- q20025001: Armoured Cyclops now wields a club, named param added.
- q20025002: Now has order conditions (level 55 and White Dragon Eternal MSQ).
- q20025003: Named params added, added one Orc Captain in place of a Tosser.
- q20025005: Named param added.
- q20025006: Named params changed, removed night spawn condition.
- q20025007: Named params and a Skeleton Knight added.
- q20025008: Group ID changed to 269, now spawns an Angules instead of a Lindwurm, variants 1 and 2 added.
- q20025009: Black Griffin changed to Griffin for both variants, named params changed, night spawn condition added.
- q21000018: Now has order conditions (AR11).
- q21000019: Added.
- q21000030: Now has order conditions (AR13).
- q21000039: Now has order conditions (AR13).

Volden Mines:

- q20040005: Optional enemy spawns added.
- q20045000 and variants: Group ID changed to 21.
- q20045006: Now has order conditions (level 55 and White Dragon Eternal MSQ).
- q21000034: Now has order conditions (AR11).
- q21000043: Added.
- q21000044: Now has order conditions (AR13).
- q21000045: Now has order conditions (AR13).

Mysree Grove

- q20060001: Named param and variants 1 and 2 added.
- q20060002: Variant 1 added.
- q20065000: Now uses group IDs 135 and 136, enemy composition adjusted, added night spawn condition, variant 1 added.
- q20065001: Group ID changed to 1, named param added, variants 1 and 2 added.
- q20065002: Named params and variant 1 added.
- q20065003: Group ID changed to 149.
- q20065004: Now has order conditions (level 55 and White Dragon Eternal MSQ).
- q21000020: Now has order conditions (AR13).
- q21000021: Now has order conditions (AR11).
- q21000031: Added.
- q21000032: Added.
- q21000041: Now has order conditions (AR13).

Deenan Woods

- q20105005: Group ID changed to 322.
- q21000054: Added.
- q21000066: Now has order conditions (AR13).
- q21000067: Now has order conditions (AR13).
- q21000076: Now has order conditions (AR13).

Eastern Zandora

- q20080000: Optional enemy spawns added.
- q20080006: Added one more enemy to each variant.
- q20080007_2: Variant index fixed.
- q20085001: Enemy composition changed, variant 1 added.
- q20085003_2: Added a repop.
- q20085005: Night spawn condition added.
- q20085006: Group ID moved to 460.
- q21000055: Now has order conditions (AR13).
- q21000056: Added.
- q21000068: Now has order conditions (AR11).
- q21000069: Now has order conditions (AR13).
- q21000078: Now has order conditions (AR13), added a Shadow Harpy.

Zandora Wastelands

- q20090000: Now spawns Shadow Goblins instead of a Shadow Chimera, variant 1 added (with the Chimera).
- q20090001: Named params changed.
- q20095000: Enemy changed to Geo Golem, named param added and variants 1 and 2 added.
- q20095001: Group ID changed to 6, enemy changed to Chimera, variant 1 added.
- q20095003: Base level lowered to 48, spawns Shadow Wolves instead of a Chimera, variant 1 and 2 (with the Chimera) added
- q20095004: Enemy changed to Colossus, variants 1 2 and 3 added.
- q20095007: Enemies are now split in three groups (374, 391 and 393), enemy composition changed where needed.
- q20095008: Named params and more Shadow Wolves added.
- q20095010: Enemy composition changed, variant 1 added.
- q21000084: Added.
- q21000092: Fixed order condition, Orcs are now infected.
- q21000093: Added.
- q21000095: Now has order conditions (AR13).

Mergoda Ruins

- q20995000: Now has order conditions (level 55 and White Dragon Eternal MSQ).
- q21000079: Now has order conditions (AR13).
- q21000080: Added.
- q21000081: Added.
- q21000088: Now has order conditions (AR11).
- q21000089: Now has order conditions (AR13).
- q21000091: Now has order conditions (AR13).