### PR TITLE
fix: Resolve craft timer exception

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CraftSkillAnalyzeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CraftSkillAnalyzeHandler.cs
@@ -116,12 +116,23 @@ namespace Arrowgene.Ddon.GameServer.Handler
             if (reducedTime > recipeTime)
             {
                 Logger.Error($"Overflow detected in [AnalyzeProductionSpeed]: {reducedTime} > {recipeTime} when crafting {itemInfo.Name}");
-                timeFactor = 100;
+                timeFactor = 0;
+            }
+            else if (recipeTime > 0)
+            {
+                uint deltaTime = recipeTime - reducedTime;
+                double reductionPercentage = (deltaTime * 100.0) / recipeTime;
+                
+                if (reductionPercentage > 100.0)
+                {
+                    reductionPercentage = 100.0;
+                }
+
+                timeFactor = (byte)reductionPercentage;
             }
             else
             {
-                uint deltaTime = recipeTime - reducedTime;
-                timeFactor = (byte)(deltaTime * 100.0 / reducedTime);
+                timeFactor = 100;
             }
 
             CDataCraftSkillAnalyzeResult productionSpeedAnalysisResult = new CDataCraftSkillAnalyzeResult
@@ -129,6 +140,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 SkillType = CraftSkillType.ProductionSpeed,
                 Rate = timeFactor
             };
+
             return productionSpeedAnalysisResult;
         }
 


### PR DESCRIPTION
First draft for a fix to prevent the Server from throwing a `System.OverflowException: Arithmetic operation resulted in an overflow.` when setting `AdditionalProductionSpeedFactor` to anything lower than 0.3 in the `GameServerSettings.csx`.

Previous code caused an overflow in `timeFactor`, which is a `byte`. Example:
Crafting Time: 100 seconds. ( `recipeTime = 100` )
Pawns reduce crafting time to 10 seconds. ( `reducedTime = 10` )
`deltaTime` = 100 - 10 = 90.
Calculation would end up as: `(90 * 100.0) / 10 = 900.0`, which leads to the Overflow.
Added an "Edge Case"-Fix with `if (reductionPercentage > 100.0)`.

Please review for possible improvements or changes, since this is a quick fix that got whipped up in minutes. Tested it myself real quick with different values for `AdditionalProductionSpeedFactor` and had no further issues.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
