### PR TITLE
fix: Fix quest enemy spawn when loading into area

### DIFF
--- a/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Enemies/InstanceEnemyManager.cs
@@ -145,6 +145,14 @@ public class InstanceEnemyManager : InstanceAssetManager<Enemy, InstancedEnemy>
         }
     }
 
+    public bool HasEnemyGroup(StageLayoutId stageId)
+    {
+        lock (_EnemyData)
+        {
+            return _EnemyData.ContainsKey(stageId);
+        }
+    }
+
     public void ResetEnemyNode(StageLayoutId stageId)
     {
         lock (_EnemyData)

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -69,6 +69,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
                     res.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
                     client.Party.QuestState.AddNewQuest(quest, 0);
+                    // Enemy requests arrive before the quest list, so loaded groups may have generic enemies. Reset them.
+                    quest.ResetEnemiesForStage(client, client.Character.Stage, onlyLoaded: true);
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -916,11 +916,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
         }
 
-        public virtual void ResetEnemiesForStage(GameClient client, StageLayoutId stageId)
+        public virtual void ResetEnemiesForStage(GameClient client, StageLayoutId stageId, bool onlyLoaded = false)
         {
             foreach (var (groupId, group) in EnemyGroups)
             {
-                if (group.StageLayoutId.Id == stageId.Id)
+                if (group.StageLayoutId.Id == stageId.Id
+                    && (!onlyLoaded || client.Party.InstanceEnemyManager.HasEnemyGroup(group.StageLayoutId)))
                 {
                     // Cleanup old contexts if we are replacing monsters with new ones
                     foreach (var enemy in group.Enemies)
@@ -929,13 +930,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
                         ContextManager.RemoveContext(client.Party, uid);
                     }
 
-                    S2CInstanceEnemyGroupResetNtc resetNtc = new S2CInstanceEnemyGroupResetNtc()
+                    client.Party.InstanceEnemyManager.ResetEnemyNode(group.StageLayoutId);
+                    client.Party.SendToAll(new S2CInstanceEnemyGroupResetNtc()
                     {
                         LayoutId = group.StageLayoutId.ToCDataStageLayoutId()
-                    };
-
-                    client.Party.InstanceEnemyManager.ResetEnemyNode(group.StageLayoutId);
-                    client.Party.SendToAll(resetNtc);
+                    });
                 }
             }
         }


### PR DESCRIPTION
Fixed an issue when the player teleports to a location right next to a set of enemies which is also used for a quest. Since the client can query the default enemy list before the active quest list for the area, it is possible that the quest enemies will not spawn. This change issues a reset packet to the groups which are required for the quest if they were requested before the area quest list was sent to the player.
