### PR TITLE
feat: Filter World Quests by party Leader Area Rank

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
@@ -27,6 +27,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             party.AddHost(client);
 
             PlayerPartyMember join = party.Join(client);
+            // Re-roll any world quests the leader can't take yet (base constructor rolls unfiltered).
+            party.QuestState.EnforceInitialPoolEligibility();
             
             var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
             foreach (var questProgress in progress)

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -40,6 +41,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                  * are random fetch, deliver and kill type quests.
                  */
 
+                var leaderCharacter = client.Party.Leader?.Client.Character;
+
                 // Populate state for all quests currently in progress by the player
                 foreach (var questScheduleId in client.Party.QuestState.GetActiveQuestScheduleIds())
                 {
@@ -49,7 +52,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
+                    CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
                     QuestState questState = client.Party.QuestState.GetQuestState(quest);
                     res.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, questStats?.ClearCount ?? 0));
                 }
@@ -66,7 +69,15 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    CompletedQuest questStats = client.Party.Leader?.Client.Character.CompletedQuests.GetValueOrDefault(quest.QuestId);
+                    if (quest.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
+                        && (leaderCharacter == null
+                            || !leaderCharacter.AreaRanks.ContainsKey((QuestAreaId)c.Param01)
+                            || Server.AreaRankManager.GetEffectiveRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02)))
+                    {
+                        continue;
+                    }
+
+                    CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
                     res.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
                     client.Party.QuestState.AddNewQuest(quest, 0);
                     // Enemy requests arrive before the quest list, so loaded groups may have generic enemies. Reset them.

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -177,7 +177,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
         protected Dictionary<uint, QuestState> ActiveQuests { get; set; }
         private Dictionary<StageLayoutId, HashSet<uint>> QuestLookupTable { get; set; }
         private List<QuestId> CompletedWorldQuests { get; set; }
-        private Dictionary<QuestAreaId, HashSet<uint>> RolledInstanceWorldQuests { get; set; }
+        protected Dictionary<QuestAreaId, HashSet<uint>> RolledInstanceWorldQuests { get; set; }
 
         // Deferred Generic Work to be triggered at various points
         public Dictionary<QuestProgressWorkType, List<QuestProgressWork>> ProgressWork { get; set; }
@@ -529,6 +529,24 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
         }
 
+        protected virtual uint GetEffectiveAreaRank(Character character, QuestAreaId areaId)
+        {
+            return character.AreaRanks.TryGetValue(areaId, out var rank) ? rank.Rank : 0;
+        }
+
+        protected Quest RollEligibleQuestVariant(QuestId questId, Character leaderCharacter)
+        {
+            var candidates = QuestManager.GetQuestScheduleIdsForQuestId(questId)
+                .Select(id => QuestManager.GetQuestByScheduleId(id))
+                .Where(q => q != null && !q.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
+                    && (leaderCharacter == null
+                        || GetEffectiveAreaRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02)))
+                .ToList();
+
+            if (candidates.Count == 0) return null;
+            return candidates[Random.Shared.Next(candidates.Count)];
+        }
+
         public QuestState GetQuestState(uint questScheduleId)
         {
             lock (ActiveQuests)
@@ -707,14 +725,24 @@ namespace Arrowgene.Ddon.GameServer.Quests
             return packets;
         }
 
+        public virtual void EnforceInitialPoolEligibility() { }
+
+        protected virtual Quest RollQuestVariant(QuestId questId)
+        {
+            return QuestManager.RollQuestForQuestId(questId);
+        }
+
         public void ResetInstance()
         {
             lock (ActiveQuests)
             {
                 foreach (var questId in CompletedWorldQuests)
                 {
-                    var quest = QuestManager.RollQuestForQuestId(questId);
-                    RolledInstanceWorldQuests[quest.QuestAreaId].Add(quest.QuestScheduleId);
+                    var quest = RollQuestVariant(questId);
+                    if (quest != null)
+                    {
+                        RolledInstanceWorldQuests[quest.QuestAreaId].Add(quest.QuestScheduleId);
+                    }
                 }
                 CompletedWorldQuests.Clear();
             }
@@ -810,6 +838,45 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             this.Party = party;
             this.Server = server;
+        }
+
+        public override void EnforceInitialPoolEligibility()
+        {
+            var leaderCharacter = Party.Leader?.Client.Character;
+            if (leaderCharacter == null) return;
+
+            lock (ActiveQuests)
+            {
+                foreach (var (areaId, scheduleIds) in RolledInstanceWorldQuests)
+                {
+                    var ineligible = scheduleIds
+                        .Select(id => QuestManager.GetQuestByScheduleId(id))
+                        .Where(q => q != null && q.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
+                            && GetEffectiveAreaRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02))
+                        .ToList();
+
+                    foreach (var quest in ineligible)
+                    {
+                        scheduleIds.Remove(quest.QuestScheduleId);
+                        var replacement = RollEligibleQuestVariant(quest.QuestId, leaderCharacter);
+                        if (replacement != null)
+                        {
+                            scheduleIds.Add(replacement.QuestScheduleId);
+                        }
+                    }
+                }
+            }
+        }
+
+        protected override uint GetEffectiveAreaRank(Character character, QuestAreaId areaId)
+        {
+            if (!character.AreaRanks.ContainsKey(areaId)) return 0;
+            return Server.AreaRankManager.GetEffectiveRank(character, areaId);
+        }
+
+        protected override Quest RollQuestVariant(QuestId questId)
+        {
+            return RollEligibleQuestVariant(questId, Party.Leader?.Client.Character);
         }
 
         public override bool CompleteQuestProgress(uint questScheduleId, DbConnection? connectionIn = null)


### PR DESCRIPTION
Don't allow World quests to be selected when the server rolls them if the party leader does not meet the minimum area rank requirements. That way a large amount of quests won't show up for new players and show them as unable to participate.

