### PR TITLE
feat: Implement mutually exclusive quests

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -860,6 +860,49 @@ namespace Arrowgene.Ddon.GameServer.Quests
             this.Server = server;
         }
 
+        private Dictionary<QuestId, int> BuildMutualExclusionLookup()
+        {
+            var lookup = new Dictionary<QuestId, int>();
+            var groups = Server.GameSettings.GameServerSettings.MutuallyExclusiveWorldQuestGroups;
+            for (int i = 0; i < groups.Count; i++)
+            {
+                foreach (var questId in groups[i])
+                {
+                    lookup[(QuestId)questId] = i;
+                }
+            }
+            return lookup;
+        }
+
+        private void EnforceMutualExclusion()
+        {
+            var lookup = BuildMutualExclusionLookup();
+            var rolledGroups = new HashSet<int>();
+
+            lock (ActiveQuests)
+            {
+                foreach (var scheduleIds in RolledInstanceWorldQuests.Values)
+                {
+                    var toRemove = new List<uint>();
+                    foreach (var scheduleId in scheduleIds)
+                    {
+                        var quest = QuestManager.GetQuestByScheduleId(scheduleId);
+                        if (quest != null && lookup.TryGetValue(quest.QuestId, out int groupIndex))
+                        {
+                            if (!rolledGroups.Add(groupIndex))
+                            {
+                                toRemove.Add(scheduleId);
+                            }
+                        }
+                    }
+                    foreach (var scheduleId in toRemove)
+                    {
+                        scheduleIds.Remove(scheduleId);
+                    }
+                }
+            }
+        }
+
         public override void EnforceInitialPoolEligibility()
         {
             var settings = Server.GameSettings.GameServerSettings;
@@ -868,14 +911,23 @@ namespace Arrowgene.Ddon.GameServer.Quests
             {
                 // Copy the server-wide pool and apply rank filter (no re-roll replacement).
                 ApplyServerPool(Server.WorldQuestManager.GetCurrentPool());
+                EnforceMutualExclusion();
                 return;
             }
 
             // InstanceReset mode: re-roll ineligible slots for this party.
-            if (!settings.WorldQuestFilterByLeaderAreaRank) return;
+            if (!settings.WorldQuestFilterByLeaderAreaRank)
+            {
+                EnforceMutualExclusion();
+                return;
+            }
 
             var leaderCharacter = Party.Leader?.Client.Character;
-            if (leaderCharacter == null) return;
+            if (leaderCharacter == null)
+            {
+                EnforceMutualExclusion();
+                return;
+            }
 
             lock (ActiveQuests)
             {
@@ -898,6 +950,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     }
                 }
             }
+
+            EnforceMutualExclusion();
         }
 
         /// <summary>
@@ -949,6 +1003,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
 
             ApplyServerPool(serverPool);
+            EnforceMutualExclusion();
             SendWorldQuestListNtc();
         }
 
@@ -986,7 +1041,32 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         protected override Quest RollQuestVariant(QuestId questId)
         {
+            var lookup = BuildMutualExclusionLookup();
+            if (lookup.TryGetValue(questId, out int groupIndex))
+            {
+                var rolledQuestIds = GetRolledQuestIds();
+                var groups = Server.GameSettings.GameServerSettings.MutuallyExclusiveWorldQuestGroups;
+                if (groups[groupIndex].Any(gid => (QuestId)gid != questId && rolledQuestIds.Contains((QuestId)gid)))
+                {
+                    return null;
+                }
+            }
             return RollEligibleQuestVariant(questId, Party.Leader?.Client.Character);
+        }
+
+        private HashSet<QuestId> GetRolledQuestIds()
+        {
+            lock (ActiveQuests)
+            {
+                var result = new HashSet<QuestId>();
+                foreach (var scheduleIds in RolledInstanceWorldQuests.Values)
+                    foreach (var sid in scheduleIds)
+                    {
+                        var quest = QuestManager.GetQuestByScheduleId(sid);
+                        if (quest != null) result.Add(quest.QuestId);
+                    }
+                return result;
+            }
         }
 
         public override bool CompleteQuestProgress(uint questScheduleId, DbConnection? connectionIn = null)

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -259,6 +259,35 @@ namespace Arrowgene.Ddon.Server.Settings
         private const uint _AdventureGuideMaxQuestList = 50;
 
         /// <summary>
+        /// Groups of mutually exclusive world quest IDs. When rolling world quests for a party,
+        /// at most one quest from each group will be selected at a time. Use this to prevent
+        /// conflicting quests from appearing simultaneously. Quest IDs should be specified as
+        /// uint values (e.g. 21000079).
+        /// </summary>
+        [DefaultValue(
+            "new List<List<uint>>\n" +
+            "{\n" +
+            "    new List<uint> { 21000079, 21000089 },\n" +
+            "    new List<uint> { 20995009, 21000008 },\n" +
+            "}"
+        )]
+        public List<List<uint>> MutuallyExclusiveWorldQuestGroups
+        {
+            set
+            {
+                SetSetting("MutuallyExclusiveWorldQuestGroups", value);
+            }
+            get
+            {
+                return TryGetSetting("MutuallyExclusiveWorldQuestGroups", new List<List<uint>>
+                {
+                    new List<uint> { 21000079, 21000089 },
+                    new List<uint> { 20995009, 21000008 },
+                });
+            }
+        }
+
+        /// <summary>
         /// Uses the automatic exp calculation system for all enemies instead of just using the
         /// ones marked in quest files.
         /// </summary>


### PR DESCRIPTION
Some world quests should not be rolled and active at the same time. Allow a way for these dependencies to be described and give the user a way to override the list via the GameServerSettings.csx. Then on party create and instance reset when the party rolled world quest list is generated/updated, enforce those restrictions for the party. 