### PR TITLE
feat: Implement Server Reset World Quest Rotation

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 54;
+    public const uint Version = 55;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_world_quest_rotation.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_world_quest_rotation.sql
@@ -1,0 +1,20 @@
+INSERT INTO "ddon_schedule_next" ("type", "timestamp")
+VALUES (8, 0);
+
+CREATE UNIQUE INDEX idx_quest_progress_identity ON "ddon_quest_progress" ("character_common_id", "quest_schedule_id");
+
+DROP TABLE IF EXISTS ddon_priority_quests;
+CREATE TABLE IF NOT EXISTS "ddon_priority_quests"
+(
+    "character_common_id" INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
+    CONSTRAINT "fk_priority_to_progress"
+        FOREIGN KEY ("character_common_id", "quest_schedule_id")
+        REFERENCES "ddon_quest_progress" ("character_common_id", "quest_schedule_id")
+        ON DELETE CASCADE,
+    CONSTRAINT "fk_ddon_priority_quests_character_common_id"
+        FOREIGN KEY ("character_common_id")
+        REFERENCES "ddon_character_common" ("character_common_id")
+        ON DELETE CASCADE,
+    CONSTRAINT "uq_character_common_id_quest_schedule_id" UNIQUE ("character_common_id", "quest_schedule_id")
+);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -546,6 +546,7 @@ CREATE TABLE IF NOT EXISTS "ddon_quest_progress"
     "quest_type"          INTEGER NOT NULL,
     "quest_schedule_id"   INTEGER NOT NULL,
     "step"                INTEGER NOT NULL,
+    CONSTRAINT "pk_ddon_quest_progress" PRIMARY KEY ("character_common_id", "quest_schedule_id"),
     CONSTRAINT "fk_ddon_quest_progress_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS "idx_ddon_quest_progress_character_common_id" ON "ddon_quest_progress" ("character_common_id");
@@ -566,6 +567,7 @@ CREATE TABLE IF NOT EXISTS "ddon_priority_quests"
 (
     "character_common_id" INTEGER NOT NULL,
     "quest_schedule_id"   INTEGER NOT NULL,
+    CONSTRAINT "fk_priority_to_progress" FOREIGN KEY ("character_common_id", "quest_schedule_id") REFERENCES "ddon_quest_progress" ("character_common_id", "quest_schedule_id") ON DELETE CASCADE,
     CONSTRAINT "fk_ddon_priority_quests_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE,
     CONSTRAINT "uq_character_common_id_quest_schedule_id" UNIQUE ("character_common_id", "quest_schedule_id")
 );
@@ -1100,3 +1102,6 @@ VALUES (20, 0);
 
 INSERT INTO "ddon_schedule_next"(type, timestamp)
 VALUES (25, 0);
+
+INSERT INTO "ddon_schedule_next" ("type", "timestamp")
+VALUES (8, 0);

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -317,6 +317,7 @@ public interface IDatabase
     bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null);
     bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null);
     bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, DbConnection? connectionIn = null);
+    bool RemoveAllQuestProgressByType(QuestType questType, DbConnection? connectionIn = null);
     List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
     QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
 

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlQuestProgress.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlQuestProgress.cs
@@ -15,6 +15,9 @@ public partial class DdonSqlDb : SqlDb
     private readonly string SqlDeleteQuestProgress =
         "DELETE FROM \"ddon_quest_progress\" WHERE \"character_common_id\"=@character_common_id AND \"quest_type\"=@quest_type AND \"quest_schedule_id\"=@quest_schedule_id;";
 
+    private readonly string SqlDeleteAllQuestProgressByType =
+        "DELETE FROM \"ddon_quest_progress\" WHERE \"quest_type\"=@quest_type;";
+
     private readonly string SqlInsertQuestProgress =
         $"INSERT INTO \"ddon_quest_progress\" ({BuildQueryField(QuestProgressFields)}) VALUES ({BuildQueryInsert(QuestProgressFields)});";
 
@@ -107,6 +110,17 @@ public partial class DdonSqlDb : SqlDb
                 AddParameter(command, "quest_type", (uint)questType);
                 AddParameter(command, "quest_schedule_id", questScheduleId);
             }) == 1;
+        });
+    }
+
+    public override bool RemoveAllQuestProgressByType(QuestType questType, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            return ExecuteNonQuery(connection, SqlDeleteAllQuestProgressByType, command =>
+            {
+                AddParameter(command, "quest_type", (uint)questType);
+            }) >= 0;
         });
     }
 

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000055_WorldQuestRotationScheduleMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000055_WorldQuestRotationScheduleMigration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class WorldQuestRotationScheduleMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 54;
+        public uint To => 55;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/migration_world_quest_rotation.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -460,6 +460,7 @@ public abstract class SqlDb : IDatabase
     public abstract bool InsertQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null);
     public abstract bool UpdateQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, uint step, DbConnection? connectionIn = null);
     public abstract bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, DbConnection? connectionIn = null);
+    public abstract bool RemoveAllQuestProgressByType(QuestType questType, DbConnection? connectionIn = null);
     public abstract List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
     public abstract QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
     public abstract bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -96,6 +96,7 @@ namespace Arrowgene.Ddon.GameServer
             RentalPawnManager = new RentalPawnManager(this);
             OrbUnlockManager = new OrbUnlockManager(this);
             BitterblackMazeManager = new BitterblackMazeManager(this);
+            WorldQuestManager = new WorldQuestManager(this);
 
             S2CStageGetStageListRes stageListPacket =
                 EntitySerializer.Get<S2CStageGetStageListRes>().Read(GameDump.data_Dump_19);
@@ -141,6 +142,7 @@ namespace Arrowgene.Ddon.GameServer
         public JobEmblemManager JobEmblemManager { get; }
         public RentalPawnManager RentalPawnManager { get; }
         public BitterblackMazeManager BitterblackMazeManager { get; }
+        public WorldQuestManager WorldQuestManager { get; }
         public ChatLogHandler ChatLogHandler { get; }
         public LightQuestManager LightQuestManager { get; }
 
@@ -156,6 +158,7 @@ namespace Arrowgene.Ddon.GameServer
             ScriptManager.Initialize();
 
             QuestManager.LoadQuests(this);
+            WorldQuestManager.Initialize();
             GpCourseManager.EvaluateCourses();
 
             if (ServerUtils.IsHeadServer(this))

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -69,10 +69,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    if (quest.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
-                        && (leaderCharacter == null
-                            || !leaderCharacter.AreaRanks.ContainsKey((QuestAreaId)c.Param01)
-                            || Server.AreaRankManager.GetEffectiveRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02)))
+                    if (Server.GameSettings.GameServerSettings.WorldQuestFilterByLeaderAreaRank
+                        && quest.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
+                            && (leaderCharacter == null
+                                || !leaderCharacter.AreaRanks.ContainsKey((QuestAreaId)c.Param01)
+                                || Server.AreaRankManager.GetEffectiveRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02)))
                     {
                         continue;
                     }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestSetNavigationHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestSetNavigationHandler.cs
@@ -42,8 +42,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     case QuestType.World:
                         ntc.SetQuestOrderList.Add(quest.ToCDataSetQuestOrderList(0, 0));
                         break;
-                        // case QuestType.ExpiredQuestList:
-                        //    break;
+                    // case QuestType.ExpiredQuestList:
+                    //    break;
                 }
                 client.Party.SendToAll(ntc);
             }

--- a/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
@@ -128,6 +128,11 @@ public class PartyManager
         return true;
     }
 
+    public IEnumerable<PartyGroup> GetAllParties()
+    {
+        return _parties.Values;
+    }
+
     public PartyGroup GetParty(uint partyId)
     {
         if (!_parties.TryGetValue(partyId, out PartyGroup party))

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -9,10 +9,12 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 
 namespace Arrowgene.Ddon.GameServer.Quests
@@ -822,7 +824,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         public virtual CDataSetQuestList ToCDataSetQuestList(uint step, uint clearCount)
         {
-            return new CDataSetQuestList()
+            var data = new CDataSetQuestList()
             {
                 Param = ToCDataQuestList(step),
                 Detail = new CDataSetQuestDetail()
@@ -832,6 +834,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     ClearCount = clearCount
                 }
             };
+
+            // Does this work?
+            data.Param.DistributionStartDate = DateTimeOffset.FromUnixTimeSeconds(Server.ScheduleManager.TaskExpiry(TaskType.WorldQuestRotation));
+            data.Param.DistributionEndDate = DateTimeOffset.FromUnixTimeSeconds(Server.ScheduleManager.TaskExpiry(TaskType.WorldQuestRotation));
+
+            return data;
         }
 
         public virtual CDataContentsPlayStartData ToCDataContentsPlayStartData(uint step = 0)

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -176,7 +176,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         protected Dictionary<uint, QuestState> ActiveQuests { get; set; }
         private Dictionary<StageLayoutId, HashSet<uint>> QuestLookupTable { get; set; }
-        private List<QuestId> CompletedWorldQuests { get; set; }
+        protected List<QuestId> CompletedWorldQuests { get; set; }
         protected Dictionary<QuestAreaId, HashSet<uint>> RolledInstanceWorldQuests { get; set; }
 
         // Deferred Generic Work to be triggered at various points
@@ -842,6 +842,18 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         public override void EnforceInitialPoolEligibility()
         {
+            var settings = Server.GameSettings.GameServerSettings;
+
+            if (settings.WorldQuestSystem == WorldQuestSystemMode.ServerReset)
+            {
+                // Copy the server-wide pool and apply rank filter (no re-roll replacement).
+                ApplyServerPool(Server.WorldQuestManager.GetCurrentPool());
+                return;
+            }
+
+            // InstanceReset mode: re-roll ineligible slots for this party.
+            if (!settings.WorldQuestFilterByLeaderAreaRank) return;
+
             var leaderCharacter = Party.Leader?.Client.Character;
             if (leaderCharacter == null) return;
 
@@ -866,6 +878,84 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Replaces RolledInstanceWorldQuests with a copy of serverPool, then removes any quests
+        /// the party leader is not eligible for (no re-roll replacement — server pool is canonical).
+        /// </summary>
+        public void ApplyServerPool(Dictionary<QuestAreaId, HashSet<uint>> serverPool)
+        {
+            lock (ActiveQuests)
+            {
+                foreach (var (areaId, scheduleIds) in serverPool)
+                    RolledInstanceWorldQuests[areaId] = new HashSet<uint>(scheduleIds);
+
+                if (!Server.GameSettings.GameServerSettings.WorldQuestFilterByLeaderAreaRank) return;
+
+                var leaderCharacter = Party.Leader?.Client.Character;
+                if (leaderCharacter == null) return;
+
+                foreach (var (areaId, scheduleIds) in RolledInstanceWorldQuests)
+                {
+                    var ineligible = scheduleIds
+                        .Select(id => QuestManager.GetQuestByScheduleId(id))
+                        .Where(q => q != null && q.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
+                            && GetEffectiveAreaRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02))
+                        .Select(q => q.QuestScheduleId)
+                        .ToList();
+                    foreach (var sid in ineligible)
+                        scheduleIds.Remove(sid);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Called when the server broadcasts a world quest reset. Drops all in-progress world quests,
+        /// clears the completed list, applies the new server pool, and notifies online clients.
+        /// </summary>
+        public void OnServerWorldQuestReset(Dictionary<QuestAreaId, HashSet<uint>> serverPool)
+        {
+            lock (ActiveQuests)
+            {
+                var toRemove = ActiveQuests.Values
+                    .Where(qs => QuestManager.IsWorldQuest(qs.QuestId))
+                    .Select(qs => qs.QuestScheduleId)
+                    .ToList();
+                foreach (var schedId in toRemove)
+                    RemoveQuest(schedId);
+
+                CompletedWorldQuests.Clear();
+            }
+
+            ApplyServerPool(serverPool);
+            SendWorldQuestListNtc();
+        }
+
+        private void SendWorldQuestListNtc()
+        {
+            var leaderCharacter = Party.Leader?.Client?.Character;
+            if (leaderCharacter == null) return;
+
+            var areaId = leaderCharacter.AreaId;
+            var questList = new List<CDataSetQuestList>();
+
+            foreach (var scheduleId in AreaQuests(areaId))
+            {
+                var quest = QuestManager.GetQuestByScheduleId(scheduleId);
+                if (quest == null || IsQuestActive(scheduleId) || IsCompletedWorldQuest(scheduleId))
+                    continue;
+
+                CompletedQuest questStats = leaderCharacter.CompletedQuests.GetValueOrDefault(quest.QuestId);
+                questList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
+            }
+
+            Party.SendToAll(new S2CQuestGetSetQuestListNtc
+            {
+                DistributeId = areaId,
+                SelectCharacterId = leaderCharacter.CharacterId,
+                SetQuestList = questList
+            });
         }
 
         protected override uint GetEffectiveAreaRank(Character character, QuestAreaId areaId)

--- a/Arrowgene.Ddon.GameServer/Quests/WorldQuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/WorldQuestManager.cs
@@ -1,0 +1,140 @@
+using Arrowgene.Ddon.GameServer.Characters;
+using Arrowgene.Ddon.GameServer.Quests;
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Arrowgene.Ddon.GameServer
+{
+    public class WorldQuestManager
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(WorldQuestManager));
+
+        private readonly DdonGameServer _server;
+        private Dictionary<QuestAreaId, HashSet<uint>> _serverPool;
+        private readonly object _lock = new object();
+
+        public WorldQuestManager(DdonGameServer server)
+        {
+            _server = server;
+            _serverPool = new Dictionary<QuestAreaId, HashSet<uint>>();
+            foreach (var areaId in Enum.GetValues<QuestAreaId>())
+                _serverPool[areaId] = new HashSet<uint>();
+        }
+
+        /// <summary>
+        /// Called on server startup (after QuestManager.LoadQuests). Computes the seed for the
+        /// current period and populates the server pool so that newly-created parties get the
+        /// correct quests without waiting for the next weekly reset broadcast.
+        /// Only active when WorldQuestSystem = ServerReset.
+        /// </summary>
+        public void Initialize()
+        {
+            if (_server.GameSettings.GameServerSettings.WorldQuestSystem != WorldQuestSystemMode.ServerReset)
+                return;
+
+            var settings = _server.GameSettings.GameServerSettings;
+            long seed = ComputeCurrentPeriodSeed(settings.WorldQuestResetDay, settings.WorldQuestResetHour, settings.WorldQuestResetMinute);
+            Logger.Info($"WorldQuestManager initializing with seed {seed} (period starting {DateTimeOffset.FromUnixTimeSeconds(seed):u})");
+            RollPool(seed);
+        }
+
+        /// <summary>
+        /// Returns a copy of the current server-wide quest pool.
+        /// Each new party calls this via EnforceInitialPoolEligibility so it starts with the correct quests.
+        /// </summary>
+        public Dictionary<QuestAreaId, HashSet<uint>> GetCurrentPool()
+        {
+            lock (_lock)
+            {
+                var copy = new Dictionary<QuestAreaId, HashSet<uint>>();
+                foreach (var (areaId, ids) in _serverPool)
+                    copy[areaId] = new HashSet<uint>(ids);
+                return copy;
+            }
+        }
+
+        /// <summary>
+        /// Performs a server-wide reset using the given seed. Called via RPC on every game server
+        /// instance (including the originating head server) when the weekly task fires.
+        /// </summary>
+        public void PerformReset(long seed)
+        {
+            Logger.Info($"WorldQuestManager performing reset with seed {seed}");
+            RollPool(seed);
+
+            foreach (var party in _server.PartyManager.GetAllParties())
+            {
+                if (party.QuestState is SharedQuestStateManager shared)
+                {
+                    shared.OnServerWorldQuestReset(GetCurrentPool());
+                }
+            }
+
+            // Purge all persisted world quest progress so offline players don't reload
+            // stale quests on next login. Online players already had their in-memory
+            // state cleared above before this runs.
+            _server.Database.RemoveAllQuestProgressByType(QuestType.World);
+
+            _server.ChatManager.BroadcastMessage(
+                LobbyChatMsgType.ManagementAlertN,
+                "World quest pool has been refreshed for the new period.");
+        }
+
+        /// <summary>
+        /// Computes the Unix timestamp of the most recent past occurrence of the configured
+        /// reset day and hour (UTC). All server instances independently arrive at the same seed,
+        /// making the pool deterministic without a DB round-trip.
+        /// </summary>
+        public static long ComputeCurrentPeriodSeed(DayOfWeek resetDay, uint resetHour, uint resetMinute = 0)
+        {
+            var now = DateTimeOffset.UtcNow;
+            int dayDiff = ((int)now.DayOfWeek - (int)resetDay + 7) % 7;
+            var resetDate = now.UtcDateTime.Date.AddDays(-dayDiff);
+            var resetTime = new DateTimeOffset(
+                resetDate.Year, resetDate.Month, resetDate.Day,
+                (int)resetHour, (int)resetMinute, 0, TimeSpan.Zero);
+
+            // If the reset time for today hasn't happened yet, go back one full week
+            if (resetTime > now)
+                resetTime = resetTime.AddDays(-7);
+
+            return resetTime.ToUnixTimeSeconds();
+        }
+
+        private void RollPool(long seed)
+        {
+            var rng = new Random((int)(seed & 0x7FFFFFFF));
+            var newPool = new Dictionary<QuestAreaId, HashSet<uint>>();
+
+            foreach (var areaId in Enum.GetValues<QuestAreaId>())
+            {
+                newPool[areaId] = new HashSet<uint>();
+                foreach (var questId in QuestManager.GetWorldQuestIdsByAreaId(areaId))
+                {
+                    var quest = RollQuestWithRng(questId, rng);
+                    if (quest != null)
+                        newPool[areaId].Add(quest.QuestScheduleId);
+                }
+            }
+
+            lock (_lock)
+            {
+                _serverPool = newPool;
+            }
+        }
+
+        private static Quest RollQuestWithRng(QuestId questId, Random rng)
+        {
+            var scheduleIds = QuestManager.GetQuestScheduleIdsForQuestId(questId);
+            if (scheduleIds.Count == 0) return null;
+            var idx = rng.Next(0, scheduleIds.Count);
+            var scheduleId = scheduleIds.ElementAt(idx);
+            return QuestManager.GetQuestByScheduleId(scheduleId);
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -17,6 +17,7 @@ namespace Arrowgene.Ddon.GameServer
         private List<SchedulerTask> Tasks;
         private DdonGameServer Server;
         private List<Timer> Timers;
+        Dictionary<TaskType, SchedulerTaskEntry> TaskEntries = new();
 
         private static readonly int TIMER_TICK_HOURLY = 1 * 1000; // 1 second
         private static readonly int TIMER_TICK_DAILY = 10 * 1000; // 10 seconds
@@ -65,12 +66,12 @@ namespace Arrowgene.Ddon.GameServer
 
         public void StartServerTasks()
         {
-            Dictionary<TaskType, SchedulerTaskEntry> entries = Server.Database.SelectAllTaskEntries();
+            TaskEntries = Server.Database.SelectAllTaskEntries();
 
             var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             foreach (var task in Tasks)
             {
-                if (!entries.ContainsKey(task.Type))
+                if (!TaskEntries.ContainsKey(task.Type))
                 {
                     Logger.Error($"Task '{task.Type}' has no record in the database. Skipping.");
                     continue;
@@ -82,25 +83,25 @@ namespace Arrowgene.Ddon.GameServer
                     continue;
                 }
 
-                long nextAction = entries[task.Type].Timestamp;
+                long nextAction = TaskEntries[task.Type].Timestamp;
                 if (now >= nextAction)
                 {
                     task.RunTask(Server);
-                    entries[task.Type].Timestamp = task.NextTimestamp();
-                    Server.Database.UpdateScheduleInfo(task.Type, entries[task.Type].Timestamp);
+                    TaskEntries[task.Type].Timestamp = task.NextTimestamp();
+                    Server.Database.UpdateScheduleInfo(task.Type, TaskEntries[task.Type].Timestamp);
                 }
 
                 var timerTick = GetTimerTick(task.Interval);
                 var timer = new Timer(state =>
                 {
                     long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-                    if (now >= entries[task.Type].Timestamp)
+                    if (now >= TaskEntries[task.Type].Timestamp)
                     {
                         task.RunTask(Server);
-                        entries[task.Type].Timestamp = task.NextTimestamp();
+                        TaskEntries[task.Type].Timestamp = task.NextTimestamp();
                         if (task.Interval != ScheduleInterval.Secondly)
                         {
-                            Server.Database.UpdateScheduleInfo(task.Type, entries[task.Type].Timestamp);
+                            Server.Database.UpdateScheduleInfo(task.Type, TaskEntries[task.Type].Timestamp);
                         }
                     }
                 }, null, timerTick, timerTick);
@@ -112,16 +113,23 @@ namespace Arrowgene.Ddon.GameServer
         public long TimeToNextTaskUpdate(TaskType taskType)
         {
             long now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-
-            var task = Tasks.Where(x => x.Type == taskType).FirstOrDefault();
-            if (task == null)
+            if (!TaskEntries.ContainsKey(taskType))
             {
                 return 0;
             }
 
-            long next = task.NextTimestamp();
+            long next = TaskEntries[taskType].Timestamp;
 
-            return (next > now) ? (next - now) : 0;
+            return (now > next) ? 0 : (next - now);
+        }
+
+        public long TaskExpiry(TaskType taskType)
+        {
+            if (!TaskEntries.ContainsKey(taskType))
+            {
+                return 0;
+            }
+            return TaskEntries[taskType].Timestamp;
         }
 
         public List<SchedulerTask> GetTasks()

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -39,6 +39,10 @@ namespace Arrowgene.Ddon.GameServer
                 new PawnLikabilityIncreaseResetTask(5, 0),
                 new EquipmentRecycleResetTask(5, 0),
                 new BoardQuestRotationTask(5, 0),
+                new WorldQuestResetTask(
+                    server.GameSettings.GameServerSettings.WorldQuestResetDay,
+                    server.GameSettings.GameServerSettings.WorldQuestResetHour,
+                    server.GameSettings.GameServerSettings.WorldQuestResetMinute),
             };
         }
 

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
@@ -1,4 +1,3 @@
-using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Shared;
 using Arrowgene.Ddon.Shared.Asset;

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/CraftingSchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/CraftingSchedulerTask.cs
@@ -15,7 +15,5 @@ namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
         {
             server.RpcManager.AnnounceAll("internal/command", RpcInternalCommand.UpdateCrafting, null);
         }
-
-        public override string TaskTypeName() => "Crafting";
     }
 }

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/CraftingSchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/CraftingSchedulerTask.cs
@@ -1,7 +1,5 @@
-using System;
-using Arrowgene.Ddon.Shared.Model.Scheduler;
-using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Model.Rpc;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
 
 namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
 {

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/WorldQuestResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/WorldQuestResetTask.cs
@@ -1,0 +1,31 @@
+using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Model.Rpc;
+using Arrowgene.Ddon.Shared.Model.Scheduler;
+using Arrowgene.Logging;
+using System;
+
+namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
+{
+    public class WorldQuestResetTask : WeeklyTask
+    {
+        private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(WorldQuestResetTask));
+
+        public WorldQuestResetTask(DayOfWeek day, uint hour, uint minute) : base(TaskType.WorldQuestRotation, day, hour, minute)
+        {
+        }
+
+        public override bool IsEnabled(DdonGameServer server)
+        {
+            return server.GameSettings.GameServerSettings.WorldQuestSystem == WorldQuestSystemMode.ServerReset;
+        }
+
+        public override void RunTask(DdonGameServer server)
+        {
+            var settings = server.GameSettings.GameServerSettings;
+            long seed = WorldQuestManager.ComputeCurrentPeriodSeed(settings.WorldQuestResetDay, settings.WorldQuestResetHour, settings.WorldQuestResetMinute);
+            Logger.Info($"Triggering server-wide world quest reset with seed {seed}");
+            server.RpcManager.AnnounceAll("internal/command", RpcInternalCommand.WorldQuestReset, seed);
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Tasks/SecondlyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/SecondlyTask.cs
@@ -27,7 +27,7 @@ namespace Arrowgene.Ddon.GameServer.Tasks
 
         public override string TaskTypeName()
         {
-            return "Seconds Amount Task";
+            return "Secondly Task";
         }
     }
 }

--- a/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
@@ -135,6 +135,15 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                             gameServer.CraftManager.UpdateOnlineCraftingProgress();
                             return new RpcCommandResult(this, true);
                         }
+                    case RpcInternalCommand.WorldQuestReset:
+                        {
+                            long seed = _entry.GetData<long>();
+                            gameServer.WorldQuestManager.PerformReset(seed);
+                            return new RpcCommandResult(this, true)
+                            {
+                                Message = $"WorldQuestReset with seed {seed}"
+                            };
+                        }
                     default:
                         return new RpcCommandResult(this, false);
                 }

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Server.Scripting.utils;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -1782,5 +1783,100 @@ namespace Arrowgene.Ddon.Server.Settings
             }
         }
         private const uint _BBMResetGGCost = 1;
+
+        /// <summary>
+        /// Controls how world quests are rolled and refreshed.
+        /// Both modes cannot be active simultaneously.
+        /// Valid values:
+        ///   InstanceReset - each party instance rolls quests independently on area entry.
+        ///   ServerReset   - all players share a single server-wide pool that rotates on a weekly schedule (original game behavior).
+        /// </summary>
+        [DefaultValue("WorldQuestSystemMode.ServerReset")]
+        public WorldQuestSystemMode WorldQuestSystem
+        {
+            set
+            {
+                SetSetting("WorldQuestSystem", value);
+            }
+            get
+            {
+                return TryGetSetting("WorldQuestSystem", _WorldQuestSystem);
+            }
+        }
+        private const WorldQuestSystemMode _WorldQuestSystem = WorldQuestSystemMode.ServerReset;
+
+        /// <summary>
+        /// Day of the week (UTC) on which the server-wide world quest pool resets.
+        /// Only used when WorldQuestSystem = WorldQuestSystemMode.ServerReset.
+        /// </summary>
+        [DefaultValue("DayOfWeek.Thursday")]
+        public DayOfWeek WorldQuestResetDay
+        {
+            set
+            {
+                SetSetting("WorldQuestResetDay", value);
+            }
+            get
+            {
+                return TryGetSetting("WorldQuestResetDay", _WorldQuestResetDay);
+            }
+        }
+        private const DayOfWeek _WorldQuestResetDay = DayOfWeek.Thursday;
+
+        /// <summary>
+        /// Hour of the day (0-23, UTC) at which the server-wide world quest pool resets.
+        /// Only used when WorldQuestSystem = WorldQuestSystemMode.ServerReset.
+        /// </summary>
+        [DefaultValue(_WorldQuestResetHour)]
+        public uint WorldQuestResetHour
+        {
+            set
+            {
+                SetSetting("WorldQuestResetHour", value);
+            }
+            get
+            {
+                return TryGetSetting("WorldQuestResetHour", _WorldQuestResetHour);
+            }
+        }
+        private const uint _WorldQuestResetHour = 10;
+
+        /// <summary>
+        /// Minute of the hour (0-59, UTC) at which the server-wide world quest pool resets.
+        /// Only used when WorldQuestSystem = WorldQuestSystemMode.ServerReset.
+        /// </summary>
+        [DefaultValue(_WorldQuestResetMinute)]
+        public uint WorldQuestResetMinute
+        {
+            set
+            {
+                SetSetting("WorldQuestResetMinute", value);
+            }
+            get
+            {
+                return TryGetSetting("WorldQuestResetMinute", _WorldQuestResetMinute);
+            }
+        }
+        private const uint _WorldQuestResetMinute = 0;
+
+        /// <summary>
+        /// When true, world quests that the party leader does not meet the area rank requirement for
+        /// are hidden. In InstanceReset mode the slot is re-rolled with an eligible quest. In
+        /// ServerReset mode the ineligible quest is simply removed without replacement.
+        /// Applies to both WorldQuestSystem modes.
+        /// </summary>
+        [DefaultValue(_WorldQuestFilterByLeaderAreaRank)]
+        public bool WorldQuestFilterByLeaderAreaRank
+        {
+            set
+            {
+                SetSetting("WorldQuestFilterByLeaderAreaRank", value);
+            }
+            get
+            {
+                return TryGetSetting("WorldQuestFilterByLeaderAreaRank", _WorldQuestFilterByLeaderAreaRank);
+            }
+        }
+        private const bool _WorldQuestFilterByLeaderAreaRank = false;
     }
 }

--- a/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EnemySpawnAssetDeserializer.cs
@@ -1,10 +1,9 @@
-using System.Collections.Generic;
-using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text.Json;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
 
 namespace Arrowgene.Ddon.Shared.AssetReader
 {

--- a/Arrowgene.Ddon.Shared/Model/Quest/WorldQuestSystemMode.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/WorldQuestSystemMode.cs
@@ -1,0 +1,8 @@
+namespace Arrowgene.Ddon.Shared.Model.Quest
+{
+    public enum WorldQuestSystemMode
+    {
+        InstanceReset,
+        ServerReset
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
@@ -16,6 +16,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
         BoardQuestDailyRotation, //null
         
         UpdateCrafting, // RpcCraftingTimerData
+        WorldQuestReset, // long (seed)
 
         //InternalChatRoute
         SendTellMessage, // RpcChatData

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -269,6 +269,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertStorageItem(uint characterId, StorageType storageType, ushort slotNo, uint itemNum, Item item, DbConnection? connectionIn = null) { return true; }
         public bool InsertWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
         public bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, DbConnection? connectionIn = null) { return true; }
+        public bool RemoveAllQuestProgressByType(QuestType questType, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId, DbConnection? connectionIn = null) { return true; }


### PR DESCRIPTION
- Implemented the world quest rotation as it was in the original game.
- Added a settings which allows this version or the reset every instance version to be used.
- Added settings to configure which day, hour and minute the world quest reset task should trigger
- Added a setting which toggles filtering world quests by party leader area rank or not.

Small schema update to add a new entry for the World Quest Reset Task. Increments the version from 54 -> 55.

