### PR TITLE
Order conditions and unhiding quests

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/!BROKEN!q20990002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/!BROKEN!q20990002.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MergodaRuins",
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 8,
+  "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 4 } ],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000000_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 8,
+  "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 4 } ],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 555,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 5}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 555,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 5}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 555,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 5}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000005_3.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 555,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 5}],
   "variant_index": 3,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 9}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 9}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 9}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_3.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 9}],
   "variant_index": 3,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000006_4.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 9}],
   "variant_index": 4,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 13,
+  "order_conditions": [{"type": "AreaRank", "Param1": 8, "Param2": 6}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000012_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 13,
+  "order_conditions": [{"type": "AreaRank", "Param1": 8, "Param2": 6}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 14,
+  "order_conditions": [{"type": "ClearPersonalQuest", "Param1": 60000016}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 14,
+  "order_conditions": [{"type": "ClearPersonalQuest", "Param1": 60000016}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000014_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 14,
+  "order_conditions": [{"type": "ClearPersonalQuest", "Param1": 60000016}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 14,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 8}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 14,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 8}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000016_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 14,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 8}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000.json
@@ -5,7 +5,7 @@
   "quest_id": 20005000,
   "base_level": 14,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20005000,
   "base_level": 16,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20005000,
   "base_level": 20,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005000_3.json
@@ -5,7 +5,7 @@
   "quest_id": 20005000,
   "base_level": 34,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "variant_index": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001.json
@@ -5,7 +5,7 @@
   "quest_id": 20005001,
   "base_level": 8,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "quest_layout_set_info_flags": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20005001,
   "base_level": 18,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005001_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20005001,
   "base_level": 8,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 6,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002.json
@@ -5,7 +5,7 @@
   "quest_id": 20005002,
   "base_level": 11,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 501,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20005002,
   "base_level": 15,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 501,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005002_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20005002,
   "base_level": 12,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 501,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003.json
@@ -5,7 +5,7 @@
   "quest_id": 20005003,
   "base_level": 15,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 544,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005003_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20005003,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 544,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004.json
@@ -5,7 +5,7 @@
   "quest_id": 20005004,
   "base_level": 13,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005004_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20005004,
   "base_level": 25,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 541,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010.json
@@ -5,7 +5,7 @@
     "quest_id": 20005010,
     "base_level": 12,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "HidellPlains",
     "news_image": 5,
     "rewards": [
@@ -67,7 +67,6 @@
     "blocks": [
         {
             "type": "DiscoverEnemy",
-            "show_marker": false,
             "groups": [ 0 ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20005010,
     "base_level": 28,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "HidellPlains",
     "news_image": 5,
     "variant_index": 1,
@@ -68,7 +68,6 @@
     "blocks": [
         {
             "type": "DiscoverEnemy",
-            "show_marker": false,
             "groups": [ 0 ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005010_2.json
@@ -5,7 +5,7 @@
     "quest_id": 20005010,
     "base_level": 20,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "HidellPlains",
     "news_image": 5,
     "variant_index": 2,
@@ -68,7 +68,6 @@
     "blocks": [
         {
             "type": "DiscoverEnemy",
-            "show_marker": false,
             "groups": [ 0 ]
         },
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
@@ -5,7 +5,7 @@
   "quest_id": 20005011,
   "base_level": 26,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 7,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20005011,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "news_image": 7,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20010002.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 531,
+  "order_conditions": [{"type": "AreaRank", "Param1": 2, "Param2": 9}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000.json
@@ -5,7 +5,7 @@
   "quest_id": 20015000,
   "base_level": 15,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 22,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20015000,
   "base_level": 17,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 22,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20015000,
   "base_level": 20,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 22,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015000_3.json
@@ -5,7 +5,7 @@
   "quest_id": 20015000,
   "base_level": 18,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 22,
   "variant_index": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001.json
@@ -5,7 +5,7 @@
   "quest_id": 20015001,
   "base_level": 15,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 21,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20015001,
   "base_level": 24,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 21,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015001_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20015001,
   "base_level": 15,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 21,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002.json
@@ -5,7 +5,7 @@
   "quest_id": 20015002,
   "base_level": 14,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 25,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20015002,
   "base_level": 18,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 25,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20015002,
   "base_level": 21,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 25,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003.json
@@ -5,7 +5,7 @@
   "quest_id": 20015003,
   "base_level": 19,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 23,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20015003,
   "base_level": 36,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 23,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015003_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20015003,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 23,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015004.json
@@ -5,9 +5,10 @@
   "quest_id": 20015004,
   "base_level": 34,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "news_image": 537,
+  "order_conditions": [{"type": "AreaRank", "Param1": 2, "Param2": 9}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005.json
@@ -5,7 +5,7 @@
     "quest_id": 20015005,
     "base_level": 8,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "BreyaCoast",
     "news_image": 25,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20015005,
     "base_level": 11,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "BreyaCoast",
     "news_image": 25,
     "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015005_2.json
@@ -5,7 +5,7 @@
     "quest_id": 20015005,
     "base_level": 26,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "BreyaCoast",
     "news_image": 25,
     "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020002.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BetlandPlains",
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 29}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020004.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 527,
+  "order_conditions": [{"type": "AreaRank", "Param1": 8, "Param2": 7}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 42,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 8}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020006_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 42,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 8}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020009.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 546,
+  "order_conditions": [{"type": "AreaRank", "Param1": 8, "Param2": 4}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020009_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 546,
+  "order_conditions": [{"type": "AreaRank", "Param1": 8, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025000.json
@@ -5,7 +5,7 @@
   "quest_id": 20025000,
   "base_level": 38,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 54,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025001.json
@@ -5,7 +5,7 @@
   "quest_id": 20025001,
   "base_level": 38,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 55,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025003.json
@@ -5,9 +5,10 @@
   "quest_id": 20025003,
   "base_level": 38,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 544,
+  "order_conditions": [{"type": "AreaRank", "Param1": 8, "Param2": 4}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005.json
@@ -5,7 +5,7 @@
   "quest_id": 20025005,
   "base_level": 34,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 521,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025005_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20025005,
   "base_level": 41,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 521,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025006.json
@@ -5,7 +5,7 @@
   "quest_id": 20025006,
   "base_level": 36,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 41,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025007.json
@@ -5,7 +5,7 @@
   "quest_id": 20025007,
   "base_level": 38,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 511,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008.json
@@ -5,7 +5,7 @@
   "quest_id": 20025008,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 44,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20025008,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 44,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025008_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20025008,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 44,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009.json
@@ -5,7 +5,7 @@
   "quest_id": 20025009,
   "base_level": 36,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 43,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20025009,
   "base_level": 57,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "news_image": 43,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 71,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 10}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 71,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 10}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 71,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 10}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_3.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 71,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 10}],
   "variant_index": 3,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030003_4.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 71,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 10}],
   "variant_index": 4,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 548,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 7}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030005_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 548,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 7}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001.json
@@ -5,7 +5,7 @@
   "quest_id": 20035001,
   "base_level": 35,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 72,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035001_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20035001,
   "base_level": 56,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 72,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002.json
@@ -5,7 +5,7 @@
   "quest_id": 20035002,
   "base_level": 33,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 75,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20035002,
   "base_level": 36,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 75,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035002_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20035002,
   "base_level": 57,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 75,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035003.json
@@ -5,7 +5,7 @@
   "quest_id": 20035003,
   "base_level": 35,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004.json
@@ -5,8 +5,9 @@
   "quest_id": 20035004,
   "base_level": 38,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 7}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035004_1.json
@@ -5,8 +5,9 @@
   "quest_id": 20035004,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 7}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005.json
@@ -5,7 +5,7 @@
   "quest_id": 20035005,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 63,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20035005,
   "base_level": 34,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 63,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035005_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20035005,
   "base_level": 39,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 63,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035006.json
@@ -5,9 +5,10 @@
   "quest_id": 20035006,
   "base_level": 38,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 532,
+  "order_conditions": [{"type": "AreaRank", "Param1": 5, "Param2": 4}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007.json
@@ -5,7 +5,7 @@
   "quest_id": 20035007,
   "base_level": 35,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 537,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035007_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20035007,
   "base_level": 37,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 537,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008.json
@@ -5,7 +5,7 @@
   "quest_id": 20035008,
   "base_level": 32,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 535,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035008_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20035008,
   "base_level": 35,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 535,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20035009,
   "base_level": 40,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 64,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20035009_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20035009,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "news_image": 64,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 535,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 2}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040005_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 535,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 2}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 94,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 5}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 94,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 5}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040007_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 94,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 5}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 511,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 8}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20040009_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 511,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 8}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000.json
@@ -5,9 +5,10 @@
   "quest_id": 20045000,
   "base_level": 28,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 95,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 4}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20045000,
   "base_level": 56,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 95,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045000_2.json
@@ -5,9 +5,10 @@
   "quest_id": 20045000,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 95,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 4}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001.json
@@ -5,9 +5,10 @@
   "quest_id": 20045001,
   "base_level": 27,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 96,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 4}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20045001,
   "base_level": 34,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 96,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045001_2.json
@@ -5,9 +5,10 @@
   "quest_id": 20045001,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 96,
+  "order_conditions": [{"type": "AreaRank", "Param1": 4, "Param2": 4}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002.json
@@ -5,7 +5,7 @@
   "quest_id": 20045002,
   "base_level": 21,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 537,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20045002,
   "base_level": 24,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 537,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20045002,
   "base_level": 27,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 537,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003.json
@@ -5,7 +5,7 @@
   "quest_id": 20045003,
   "base_level": 23,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 533,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20045003,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 533,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20045003,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 533,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_3.json
@@ -5,7 +5,7 @@
   "quest_id": 20045003,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 533,
   "variant_index": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045003_4.json
@@ -5,7 +5,7 @@
   "quest_id": 20045003,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 533,
   "variant_index": 4,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004.json
@@ -5,7 +5,7 @@
   "quest_id": 20045004,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 83,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045004_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20045004,
   "base_level": 35,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 83,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005.json
@@ -5,7 +5,7 @@
   "quest_id": 20045005,
   "base_level": 25,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 93,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045005_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20045005,
   "base_level": 30,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "news_image": 93,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050001.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 522,
+  "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 6}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050001_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 522,
+  "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 6}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050002.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 533,
+  "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 9}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050002_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 533,
+  "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 9}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050003.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 102,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 6}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050003_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 102,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 6}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 111,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 6}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 111,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 6}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 111,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 6}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050005_3.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 111,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 6}],
   "variant_index": 3,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050009.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 103,
+    "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 3}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050009_1.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 103,
+    "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 3}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050009_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20050009_2.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 103,
+    "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 3}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000.json
@@ -5,7 +5,7 @@
   "quest_id": 20055000,
   "base_level": 16,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 105,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20055000,
   "base_level": 20,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 105,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20055000,
   "base_level": 24,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 105,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_0.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_0.json
@@ -5,7 +5,7 @@
     "quest_id": 20055001,
     "base_level": 15,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 101,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_1.json
@@ -6,7 +6,7 @@
     "variant_index": 1,
     "base_level": 18,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 101,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055001_2.json
@@ -6,7 +6,7 @@
     "variant_index": 2,
     "base_level": 26,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 101,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055002.json
@@ -5,9 +5,10 @@
   "quest_id": 20055002,
   "base_level": 34,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 536,
+  "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 9}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055002_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20055002,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 536,
+  "order_conditions": [{"type": "AreaRank", "Param1": 3, "Param2": 9}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003.json
@@ -5,7 +5,7 @@
   "quest_id": 20055003,
   "base_level": 18,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 113,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20055003,
   "base_level": 57,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 113,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055003_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20055003,
   "base_level": 25,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 113,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_0.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_0.json
@@ -5,7 +5,7 @@
     "quest_id": 20055004,
     "base_level": 19,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 111,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20055004,
     "base_level": 23,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 111,
     "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055004_2.json
@@ -5,7 +5,7 @@
     "quest_id": 20055004,
     "base_level": 31,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MysreeForest",
     "news_image": 111,
     "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005.json
@@ -5,7 +5,7 @@
   "quest_id": 20055005,
   "base_level": 32,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 109,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20055005,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 109,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20055005,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 109,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055005_3.json
@@ -5,7 +5,7 @@
   "quest_id": 20055005,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "news_image": 109,
   "variant_index": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 566,
+  "order_conditions": [{"type": "AreaRank", "Param1": 6, "Param2": 4}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20060002_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 566,
+  "order_conditions": [{"type": "AreaRank", "Param1": 6, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000.json
@@ -5,7 +5,7 @@
   "quest_id": 20065000,
   "base_level": 36,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 128,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20065000,
   "base_level": 40,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 128,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001.json
@@ -5,9 +5,10 @@
   "quest_id": 20065001,
   "base_level": 40,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 567,
+  "order_conditions": [{"type": "AreaRank", "Param1": 6, "Param2": 4}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20065001,
   "base_level": 41,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 567,
+  "order_conditions": [{"type": "AreaRank", "Param1": 6, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065001_2.json
@@ -5,9 +5,10 @@
   "quest_id": 20065001,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 567,
+  "order_conditions": [{"type": "AreaRank", "Param1": 6, "Param2": 4}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065002.json
@@ -5,7 +5,7 @@
   "quest_id": 20065002,
   "base_level": 35,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 564,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20065002,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 564,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065003.json
@@ -5,7 +5,7 @@
   "quest_id": 20065003,
   "base_level": 41,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "news_image": 125,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070001.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 542,
+  "order_conditions": [{"type": "AreaRank", "Param1": 9, "Param2": 4}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 150,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 16}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070003_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 150,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 16}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 151,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 16}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 151,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 16}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 151,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 16}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070004_3.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 151,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 16}],
   "variant_index": 3,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075000.json
@@ -5,8 +5,9 @@
   "quest_id": 20075000,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
+  "order_conditions": [{"type": "AreaRank", "Param1": 9, "Param2": 4}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001.json
@@ -5,8 +5,9 @@
   "quest_id": 20075001,
   "base_level": 49,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
+  "order_conditions": [{"type": "AreaRank", "Param1": 9, "Param2": 8}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075001_1.json
@@ -5,8 +5,9 @@
   "quest_id": 20075001,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
+  "order_conditions": [{"type": "AreaRank", "Param1": 9, "Param2": 8}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002.json
@@ -5,7 +5,7 @@
   "quest_id": 20075002,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 142,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20075002,
   "base_level": 57,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 142,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075002_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20075002,
   "base_level": 57,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 142,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003.json
@@ -5,7 +5,7 @@
   "quest_id": 20075003,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 144,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075003_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20075003,
   "base_level": 44,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 144,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075004.json
@@ -5,7 +5,7 @@
   "quest_id": 20075004,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 145,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075004_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20075004,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 145,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075005.json
@@ -5,7 +5,7 @@
   "quest_id": 20075005,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 146,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075005_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20075005,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 146,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006.json
@@ -5,7 +5,7 @@
   "quest_id": 20075006,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 142,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20075006,
   "base_level": 44,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 142,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20075006,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 142,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075007.json
@@ -5,7 +5,7 @@
   "quest_id": 20075007,
   "base_level": 44,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "news_image": 513,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080003.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "EasternZandora",
     "news_image": 168,
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 9}],
     "quest_layout_set_info_flags": [
         {
           "flag_no": 346,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080004.json
@@ -6,6 +6,7 @@
     "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 9}],
     "area_id": "EasternZandora",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20080006_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085000.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 6}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085000_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 6}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001.json
@@ -5,7 +5,7 @@
     "quest_id": 20085001,
     "base_level": 46,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085001_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20085001,
     "base_level": 47,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085002.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085002_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003.json
@@ -5,7 +5,7 @@
     "quest_id": 20085003,
     "base_level": 46,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20085003,
     "base_level": 47,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085003_2.json
@@ -5,7 +5,7 @@
     "quest_id": 20085003,
     "base_level": 55,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "variant_index": 2,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085004_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 3}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 3}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 3}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_3.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 3}],
     "variant_index": 3,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085005_4.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "EasternZandora",
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 3}],
     "variant_index": 4,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "EasternZandora",
     "news_image": 544,
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 19}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_1.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "EasternZandora",
     "news_image": 544,
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 6}, {"type": "MainQuestCompleted", "Param1": 24}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085006_2.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "EasternZandora",
     "news_image": 544,
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 6}, {"type": "MainQuestCompleted", "Param1": 24}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085008.json
@@ -5,9 +5,10 @@
     "quest_id": 20085008,
     "base_level": 57,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "news_image": 168,
+    "order_conditions": [{"type": "AreaRank", "Param1": 11, "Param2": 9}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085009.json
@@ -5,7 +5,7 @@
     "quest_id": 20085009,
     "base_level": 47,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20085009_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20085009,
     "base_level": 49,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "EasternZandora",
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090000_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001.json
@@ -7,7 +7,8 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands", 
-    "news_image": 181,  
+    "news_image": 181,
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 6}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_1.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "ZandoraWastelands", 
     "news_image": 181,
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 6}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20090001_2.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "ZandoraWastelands",
     "news_image": 181,
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 6}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095000_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095001_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002.json
@@ -7,7 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
-    "variant_index": 0,
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "news_image": 182,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 1,
     "news_image": 182,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 2,
     "news_image": 182,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_3.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 3,
     "news_image": 182,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_4.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095002_4.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20}],
     "variant_index": 4,
     "news_image": 182,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003.json
@@ -5,7 +5,7 @@
     "quest_id": 20095003,
     "base_level": 48,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "ZandoraWastelands",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20095003,
     "base_level": 49,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "ZandoraWastelands",
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095003_2.json
@@ -5,7 +5,7 @@
     "quest_id": 20095003,
     "base_level": 57,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "ZandoraWastelands",
     "variant_index": 2,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 2}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 2}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 2}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095004_3.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 2}],
     "variant_index": 3,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "ZandoraWastelands",
     "news_image": 183,
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 6}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_1.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "ZandoraWastelands",
     "news_image": 183,
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 6}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095007_2.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "ZandoraWastelands",
     "news_image": 183,
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 6}],
     "variant_index": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095008.json
@@ -5,7 +5,7 @@
     "quest_id": 20095008,
     "base_level": 48,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "ZandoraWastelands",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 2}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095010_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ZandoraWastelands",
+    "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 2}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "ZandoraWastelands",
+  "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 4}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_1.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "ZandoraWastelands",
+  "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20095012_2.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "ZandoraWastelands",
+  "order_conditions": [{"type": "AreaRank", "Param1": 10, "Param2": 4}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 201,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 2}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20100001_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 201,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 2}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000.json
@@ -5,7 +5,7 @@
   "quest_id": 20105000,
   "base_level": 42,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 565,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20105000,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 565,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105000_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20105000,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 565,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001.json
@@ -5,7 +5,7 @@
   "quest_id": 20105001,
   "base_level": 42,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 209,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20105001,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 209,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_2.json
@@ -5,7 +5,7 @@
   "quest_id": 20105001,
   "base_level": 56,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 209,
   "variant_index": 2,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105001_3.json
@@ -5,7 +5,7 @@
   "quest_id": 20105001,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 209,
   "variant_index": 3,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002.json
@@ -5,7 +5,7 @@
   "quest_id": 20105002,
   "base_level": 42,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 210,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105002_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20105002,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 210,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003.json
@@ -5,7 +5,7 @@
   "quest_id": 20105003,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 211,
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105003_1.json
@@ -5,7 +5,7 @@
   "quest_id": 20105003,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 211,
   "variant_index": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004.json
@@ -5,9 +5,10 @@
   "quest_id": 20105004,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 206,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 9}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20105004,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 206,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 9}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_2.json
@@ -5,9 +5,10 @@
   "quest_id": 20105004,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 206,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 9}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_3.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105004_3.json
@@ -5,9 +5,10 @@
   "quest_id": 20105004,
   "base_level": 55,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 206,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 9}],
   "variant_index": 3,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105005.json
@@ -5,7 +5,7 @@
     "quest_id": 20105005,
     "base_level": 41,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "DeenanWoods",
     "news_image": 203,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006.json
@@ -5,9 +5,10 @@
   "quest_id": 20105006,
   "base_level": 43,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 563,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 4}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20105006,
   "base_level": 56,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 563,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 4}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007.json
@@ -5,9 +5,10 @@
   "quest_id": 20105007,
   "base_level": 41,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 204,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 2}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_1.json
@@ -5,9 +5,10 @@
   "quest_id": 20105007,
   "base_level": 56,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 204,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 2}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105007_2.json
@@ -5,9 +5,10 @@
   "quest_id": 20105007,
   "base_level": 45,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "news_image": 204,
+  "order_conditions": [{"type": "AreaRank", "Param1": 7, "Param2": 2}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}, {"type": "AreaRank", "Param1": 12, "Param2": 4}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}, {"type": "AreaRank", "Param1": 12, "Param2": 4}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009.json
@@ -5,7 +5,7 @@
     "quest_id": 20995009,
     "base_level": 52,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MergodaRuins",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995009_1.json
@@ -5,7 +5,7 @@
     "quest_id": 20995009,
     "base_level": 52,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MergodaRuins",
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995010.json
@@ -5,8 +5,9 @@
     "quest_id": 20995010,
     "base_level": 52,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "variant_ìndex": 2,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
@@ -5,7 +5,7 @@
   "quest_id": 21000003,
   "base_level": 63,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
@@ -5,7 +5,7 @@
   "quest_id": 21000009,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BloodbaneIsle",
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000013.json
@@ -5,7 +5,7 @@
   "quest_id": 21000013,
   "base_level": 57,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000017.json
@@ -5,7 +5,7 @@
   "quest_id": 21000017,
   "base_level": 70,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "order_conditions": [ { "type": "AreaRank", "Param1": 3, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000024.json
@@ -6,7 +6,8 @@
     "base_level": 60,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+	"area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 2}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000025.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000025.json
@@ -5,8 +5,9 @@
     "quest_id": 21000025,
     "base_level": 63,
     "minimum_item_rank": 0,
-    "discoverable": false,
-    "area_id": "BloodbaneIsle", 
+    "discoverable": true,
+    "area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 2}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000026.json
@@ -5,7 +5,7 @@
   "quest_id": 21000026,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "HidellPlains",
   "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
@@ -5,7 +5,7 @@
   "quest_id": 21000027,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BreyaCoast",
   "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000028.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000028.json
@@ -5,7 +5,7 @@
   "quest_id": 21000028,
   "base_level": 70,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeForest",
   "order_conditions": [ { "type": "AreaRank", "Param1": 3, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000033.json
@@ -5,7 +5,7 @@
   "quest_id": 21000033,
   "base_level": 65,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000035.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000035.json
@@ -6,7 +6,8 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+	"area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 4}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000037.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000037.json
@@ -5,7 +5,7 @@
   "quest_id": 21000037,
   "base_level": 63,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BloodbaneIsle",
   "order_conditions": [ { "type": "AreaRank", "Param1": 13, "Param2": 4 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000039.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000039.json
@@ -5,7 +5,7 @@
   "quest_id": 21000039,
   "base_level": 63,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BetlandPlains",
   "order_conditions": [ { "type": "AreaRank", "Param1": 8, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000040.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000040.json
@@ -5,7 +5,7 @@
   "quest_id": 21000040,
   "base_level": 60,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000041.json
@@ -5,7 +5,7 @@
   "quest_id": 21000041,
   "base_level": 63,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MysreeGrove",
   "order_conditions": [ { "type": "AreaRank", "Param1": 6, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000045.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000045.json
@@ -5,7 +5,7 @@
   "quest_id": 21000045,
   "base_level": 63,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "VoldenMines",
   "order_conditions": [ { "type": "AreaRank", "Param1": 4, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000047.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000047.json
@@ -6,6 +6,7 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 8}],
 	"area_id": "BloodbaneIsle",	
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000048.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000048.json
@@ -6,6 +6,7 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 8}],
 	"area_id": "BloodbaneIsle",	
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000049.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000049.json
@@ -5,7 +5,8 @@
     "quest_id": 21000049,
     "base_level": 63,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 8}],
     "area_id": "BloodbaneIsle", 
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000051.json
@@ -5,7 +5,7 @@
   "quest_id": 21000051,
   "base_level": 68,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "order_conditions": [ { "type": "AreaRank", "Param1": 5, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000053.json
@@ -5,7 +5,7 @@
   "quest_id": 21000053,
   "base_level": 68,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000059.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000059.json
@@ -6,6 +6,7 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
 	"area_id": "BloodbaneIsle",	
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000061.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000061.json
@@ -5,7 +5,7 @@
   "quest_id": 21000061,
   "base_level": 65,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "BloodbaneIsle",
   "order_conditions": [ { "type": "AreaRank", "Param1": 13, "Param2": 11 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000062.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000062.json
@@ -6,6 +6,7 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "area_id": "BloodbaneIsle",
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000065.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000065.json
@@ -5,7 +5,7 @@
   "quest_id": 21000065,
   "base_level": 68,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DoweValley",
   "order_conditions": [ { "type": "AreaRank", "Param1": 5, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000070.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000070.json
@@ -5,7 +5,7 @@
   "quest_id": 21000070,
   "base_level": 70,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "order_conditions": [ { "type": "AreaRank", "Param1": 9, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000073.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000073.json
@@ -6,7 +6,8 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+	"area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000075.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000075.json
@@ -5,8 +5,9 @@
     "quest_id": 21000075,
     "base_level": 68,
     "minimum_item_rank": 0,
-    "discoverable": false,
-	"area_id": "BloodbaneIsle",	
+    "discoverable": true,
+	"area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 13}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000076.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000076.json
@@ -5,7 +5,7 @@
   "quest_id": 21000076,
   "base_level": 68,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "DeenanWoods",
   "order_conditions": [ { "type": "AreaRank", "Param1": 7, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000077.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000077.json
@@ -5,7 +5,7 @@
   "quest_id": 21000077,
   "base_level": 65,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "EasternZandora",
   "order_conditions": [ { "type": "AreaRank", "Param1": 11, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000078.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000078.json
@@ -5,7 +5,7 @@
   "quest_id": 21000078,
   "base_level": 65,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "NorthernBetlandPlains",
   "order_conditions": [ { "type": "AreaRank", "Param1": 9, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000085.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000085.json
@@ -6,7 +6,8 @@
     "base_level": 68,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+	"area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 12}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000087.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000087.json
@@ -5,8 +5,9 @@
     "quest_id": 21000087,
     "base_level": 68,
     "minimum_item_rank": 0,
-    "discoverable": false,
-    "area_id": "BloodbaneIsle", 
+    "discoverable": true,
+    "area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000090.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000090.json
@@ -5,7 +5,7 @@
   "quest_id": 21000090,
   "base_level": 65,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MergodaRuins",
   "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
@@ -5,7 +5,7 @@
   "quest_id": 21000091,
   "base_level": 68,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MergodaRuins",
   "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000092.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000092.json
@@ -5,7 +5,7 @@
   "quest_id": 21000092,
   "base_level": 70,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "ZandoraWastelands",
   "order_conditions": [ { "type": "AreaRank", "Param1": 10, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000095.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000095.json
@@ -5,7 +5,7 @@
   "quest_id": 21000095,
   "base_level": 70,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "ZandoraWastelands",
   "order_conditions": [ { "type": "AreaRank", "Param1": 10, "Param2": 13 } ],
   "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000096.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000096.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
 	"area_id": "BloodbaneIsle",	
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000097.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000097.json
@@ -6,7 +6,8 @@
     "base_level": 68,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+	"area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 13}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000099.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000099.json
@@ -5,8 +5,9 @@
     "quest_id": 21000099,
     "base_level": 70,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "BloodbaneIsle",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20100}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014001.json
@@ -6,7 +6,8 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+	"area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
 	"area_id": "ElanWaterGrove",	
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 8}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014007.json
@@ -5,8 +5,9 @@
     "quest_id": 21014007,
     "base_level": 70,
     "minimum_item_rank": 0,
-    "discoverable": false,
-    "area_id": "ElanWaterGrove",    
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014008.json
@@ -6,7 +6,8 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+	"area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 4}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+	"area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 8}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014011.json
@@ -6,7 +6,8 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+	"area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014012.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014014.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 7}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014024.json
@@ -5,8 +5,9 @@
   "quest_id": 21014024,
   "base_level": 75,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "ElanWaterGrove",
+  "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015000.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",	
+	"area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 7}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015003.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",	
+	"area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 7}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
@@ -6,7 +6,8 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",	
+	"area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 9}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015007.json
@@ -5,8 +5,9 @@
     "quest_id": 21015007,
     "base_level": 70,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015013.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016003.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "MorrowForest",	
+	"area_id": "MorrowForest",
+    "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016004.json
@@ -6,7 +6,8 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "MorrowForest",	
+	"area_id": "MorrowForest",
+    "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 2}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016006.json
@@ -6,7 +6,8 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "MorrowForest",	
+	"area_id": "MorrowForest",
+    "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 8}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016010.json
@@ -5,8 +5,9 @@
     "quest_id": 21016010,
     "base_level": 70,
     "minimum_item_rank": 0,
-    "discoverable": false,
-	"area_id": "MorrowForest",	
+    "discoverable": true,
+	"area_id": "MorrowForest",
+    "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 2}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016012.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "MorrowForest",	
+	"area_id": "MorrowForest",
+    "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016014.json
@@ -5,8 +5,9 @@
   "quest_id": 21016014,
   "base_level": 75,
   "minimum_item_rank": 0,
-  "discoverable": false,
+  "discoverable": true,
   "area_id": "MorrowForest",
+  "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 9}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017000.json
@@ -6,7 +6,8 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "KingalCanyon",	
+	"area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017006.json
@@ -6,7 +6,8 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "KingalCanyon",	
+	"area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 8}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017007.json
@@ -5,8 +5,9 @@
     "quest_id": 21017007,
     "base_level": 73,
     "minimum_item_rank": 0,
-    "discoverable": false,
-	"area_id": "KingalCanyon",	
+    "discoverable": true,
+	"area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 7}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017011.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "KingalCanyon",	
+	"area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 7}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017014.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
 	"area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 7}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017015.json
@@ -6,7 +6,8 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "KingalCanyon",	
+	"area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018003.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "RathniteFoothills",
     "news_image": 330,
+    "order_conditions": [{"type": "AreaRank", "Param1": 18, "Param2": 2}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_1.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "RathniteFoothills",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30050}],
   "variant_index": 1,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018006_2.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "RathniteFoothills",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30050}],
   "variant_index": 2,
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018008.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "RathniteFoothills",
   "news_image": 330,
+  "order_conditions": [{"type": "AreaRank", "Param1": 18, "Param2": 5}, {"type": "MainQuestCompleted", "Param1": 30050}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018009.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "RathniteFoothills",
     "news_image": 330,
+    "order_conditions": [{"type": "AreaRank", "Param1": 18, "Param2": 2}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018011.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "RathniteFoothills",
     "news_image": 330,
+    "order_conditions": [{"type": "AreaRank", "Param1": 18, "Param2": 5}, {"type": "MainQuestCompleted", "Param1": 30060}],
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018013.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "RathniteFoothills",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30050}, {"type": "AreaRank", "Param1": 18, "Param2": 8}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018014.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "RathniteFoothills",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30040}, {"type": "AreaRank", "Param1": 18, "Param2": 10}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018015.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "RathniteFoothills",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30060}, {"type": "AreaRank", "Param1": 18, "Param2": 8}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018020.json
@@ -177,18 +177,18 @@
       ]
     },
     {
-      "comment": "GroupId: 27 - Ogre, Squad Leader Dwarf Orc, Heavy Soldier Dwarf Orcs",
+      "comment": "GroupId: 27 - War-Ready Ogre (Light Armor), Squad Leader Dwarf Orc, Heavy Soldier Dwarf Orcs",
       "stage_id": {
         "id": 463,
         "group_id": 27
       },
       "enemies": [
         {
-          "enemy_id": "0x015500",
+          "enemy_id": "0x015510",
           "level": 88,
           "exp": 44000,
           "is_boss": true,
-          "comment": "Ogre"
+          "comment": "War-Ready Ogre (Light Armor)"
         },
         {
           "enemy_id": "0x015826",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018021.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "FeryanaWilderness",
   "news_image": 330,
+  "order_conditions": [{"type": "AreaRank", "Param1": 19, "Param2": 2}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018023.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "FeryanaWilderness",
   "news_image": 330,
+  "order_conditions": [{"type": "AreaRank", "Param1": 19, "Param2": 5}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018026.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "FeryanaWilderness",
   "news_image": 330,
+  "order_conditions": [{"type": "AreaRank", "Param1": 19, "Param2": 5}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018028.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018028.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "FeryanaWilderness",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30130}, {"type": "AreaRank", "Param1": 19, "Param2": 8}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018030.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "FeryanaWilderness",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30130}, {"type": "AreaRank", "Param1": 19, "Param2": 8}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018032.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018032.json
@@ -8,6 +8,7 @@
   "discoverable": true,
   "area_id": "FeryanaWilderness",
   "news_image": 330,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30130}, {"type": "AreaRank", "Param1": 19, "Param2": 10}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018033.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018033.json
@@ -5,7 +5,7 @@
     "quest_id": 22018033,
     "base_level": 90,
     "minimum_item_rank": 0,
-    "discoverable": false,
+    "discoverable": true,
     "area_id": "FeryanaWilderness",
     "news_image": 330,
     "rewards": [


### PR DESCRIPTION
- Added order conditions for most World Quests thar required either an Area Rank of 2 or above, a quest requirement, or both, up to Feryana Wilderness. Some order conditions are incomplete because their required quest is not yet implemented, so they only check for Area Rank or nothing. 
- All currently hidden quests are also now discoverable and show up on the map, as this is their default behaviour.
- An Ogre from q22018020 was changed to a War-Ready Ogre, as per wikis.