### PR TITLE
Fixing SQLite Spam from Crafting Task.

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/CraftManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CraftManager.cs
@@ -526,12 +526,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 {
                     if (pawn.CraftingFinishAt > 0 && currentTime >= pawn.CraftingFinishAt)
                     {
+                        pawn.PawnState = PawnState.None;
+                        pawn.CraftingFinishAt = 0;
+
                         _server.Database.ExecuteInTransaction(connection =>
                         {
                             _server.Database.UpdatePawnCraftFinishTime(client.Character.CharacterId, pawn.PawnId, 0, connection);
                         });
-
-                        pawn.CraftingFinishAt = 0;
+                        
                         client.Send(new S2CCraftFinishCraftNtc { PawnId = pawn.PawnId });
                     }
                 }

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -94,7 +94,10 @@ namespace Arrowgene.Ddon.GameServer
                     {
                         task.RunTask(Server);
                         entries[task.Type].Timestamp = task.NextTimestamp();
-                        Server.Database.UpdateScheduleInfo(task.Type, entries[task.Type].Timestamp);
+                        if (task.Interval != ScheduleInterval.Secondly)
+                        {
+                            Server.Database.UpdateScheduleInfo(task.Type, entries[task.Type].Timestamp);
+                        }
                     }
                 }, null, timerTick, timerTick);
 


### PR DESCRIPTION
A quick fix to the CraftManager and ScheduleManager, so that the SecondlyTask no longer fires non-stop. (Prevents non-stop SQLite Read/Write to 'finish_at'-Column)

Craft Timer and Task still work fine and will read/write the 'remain_time' whenever needed. (On Player Connect, Server Reboot, On Craft Finish etc)

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
