### PR TITLE
A Friendly Visit/Course of Life MSQ Updates

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000016.json
@@ -30,6 +30,7 @@
             "type": "fixed",
             "loot_pool": [
                 {
+                    "comment": "Coat of Plates",
                     "item_id": 8618,
                     "num": 1
                 }
@@ -39,6 +40,7 @@
             "type": "fixed",
             "loot_pool": [
                 {
+                    "comment": "Rebel Banded",
                     "item_id": 8743,
                     "num": 1
                 }
@@ -48,6 +50,7 @@
             "type": "fixed",
             "loot_pool": [
                 {
+                    "comment": "Raptor Mantle",
                     "item_id": 8878,
                     "num": 1
                 }
@@ -63,28 +66,28 @@
             },
             "enemies": [
                 {
-                    "comment" : "Captain Orc",
-                    "enemy_id": "0x085004",
+                    "comment" : "Orc Captain",
+                    "enemy_id": "0x015820",
                     "level": 43,
-                    "exp": 3742
+                    "exp": 537
                 },
                 {
-                    "comment" : "Orc Soldier",
-                    "enemy_id": "0x085001",
+                    "comment" : "Orc Trooper",
+                    "enemy_id": "0x015812",
                     "level": 43,
-                    "exp": 3742
+                    "exp": 258
                 },
                 {
-                    "comment" : "Orc Soldier",
-                    "enemy_id": "0x085002",
+                    "comment" : "Orc Trooper",
+                    "enemy_id": "0x015812",
                     "level": 43,
-                    "exp": 3742
+                    "exp": 258
                 },
                 {
-                    "comment" : "Orc Soldier",
-                    "enemy_id": "0x085003",
+                    "comment" : "Orc Trooper",
+                    "enemy_id": "0x015812",
                     "level": 43,
-                    "exp": 3742
+                    "exp": 258
                 }
             ]
         },
@@ -93,51 +96,67 @@
                 "id": 68,
                 "group_id": 4
             },
+            "placement_type": "manual",
             "enemies": [
                 {
                     "comment" : "Mogok",
                     "enemy_id": "0x015840",
                     "level": 43,
-                    "exp": 52640,
-                    "is_boss": true
+                    "exp": 5440,
+                    "is_boss": true,
+                    "index": 0
                 },
                 {
-                    "comment" : "Orc Soldier",
-                    "enemy_id": "0x085001",
-                    "level": 42,
-                    "exp": 4706,
-                    "is_boss_bgm": true
+                    "comment" : "Orc Major General",
+                    "enemy_id": "0x015830",
+                    "named_enemy_params_id": 162,
+                    "level": 43,
+                    "exp": 1523,
+                    "is_boss_bgm": true,
+                    "index": 2
                 },
                 {
-                    "comment" : "Orc Soldier",
-                    "enemy_id": "0x085002",
+                    "comment" : "Orc Grunt (Orc Blitzer)",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 164,
                     "level": 42,
-                    "exp": 3742,
-                    "is_boss_bgm": true
+                    "exp": 254,
+                    "is_boss_bgm": true,
+                    "index": 3
+                },
+                {
+                    "comment" : "Orc Grunt (Orc Blitzer)",
+                    "enemy_id": "0x015811",
+                    "named_enemy_params_id": 164,
+                    "level": 42,
+                    "exp": 254,
+                    "is_boss_bgm": true,
+                    "index": 4
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 68,
-                "group_id": 15
+                "group_id": 9
             },
             "enemies": [
                 {
-                    "comment" : "Colossus",
+                    "comment" : "Guard Colossus",
                     "enemy_id": "0x015020",
-                    "level": 43,
-                    "exp": 52640,
-                    "is_boss": true
-                },
-                {
-                    "comment" : "General Orc",
-                    "enemy_id": "0x085001",
+                    "named_enemy_params_id": 163,
                     "level": 42,
-                    "exp": 5264,
-                    "is_boss_bgm": true
+                    "exp": 3752,
+                    "is_boss": true
                 }
             ]
+        },
+        {
+            "stage_id": {
+                "id": 1,
+                "group_id": 281
+            },
+            "enemies": []
         }
     ],
     "processes": [
@@ -163,7 +182,6 @@
                 },
                 {
                     "type": "PlayEvent",
-                    "flags": [],
                     "stage_id": {
                         "id": 3
                     },
@@ -176,6 +194,22 @@
                     "stage_id": {
                         "id": 46
                     },
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 1013, "comment": "Vanessa (Audience Chamber)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 1221, "quest_id": 70000001, "comment": "Vanessa (Fort Gritten)"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 2248, "quest_id": 70000001, "comment": "Messenger (Fort Gritten)"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 5, "Param2": 8097, "comment": "Leo extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 11, "Param2": 8098, "comment": "Vanessa extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 8099, "comment": "Joseph extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 8100, "comment": "Klaus extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 2, "Param2": 8101, "comment": "Mysial extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1003, "Param2": 8102, "comment": "Pamela extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 14, "Param2": 8103, "comment": "Mayleaf extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1704, "Param2": 11546, "comment": "Regina extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1707, "Param2": 11547, "comment": "Jordan extra dialogue"}
+                    ],
                     "npc_id": "Gort",
                     "message_id": 11548
                 },
@@ -186,6 +220,9 @@
                     "stage_id": {
                         "id": 53
                     },
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 1703, "Param2": 13876, "comment": "Gort extra dialogue"}
+                    ],
                     "npc_id": "Sunny",
                     "message_id": 14876
                 },
@@ -193,14 +230,21 @@
                     "type": "DiscoverEnemy",
                     "announce_type": "Update",
                     "checkpoint": true,
-                    "flags": [],
+                    "flags": [
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 1218, "quest_id": 70000001, "comment": "Leo"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 1701, "Param2": 14877, "comment": "Sunny extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1704, "Param2": 11543, "comment": "Regina extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1707, "Param2": 11544, "comment": "Jordan extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1703, "Param2": 11545, "comment": "Gort extra dialogue"}
+                    ],
                     "groups": [0]
                 },
                 {
                     "type": "KillGroup",
                     "announce_type": "Update",
                     "reset_group": false,
-                    "flags": [],
                     "groups": [0]
                 },
                 {
@@ -213,44 +257,52 @@
                         "id": 1,
                         "group_id": 1,
                         "layer_no": 2
-                    },
-                    "layout_flags_on": []
+                    }
                 },
                 {
-                    "type": "IsStageNo",
+                    "type": "Raw",
                     "announce_type": "Update",
-                    "checkpoint": true,
                     "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 0, "comment": "Allows gardnox entrance FSM to play"},
                         {"type": "QstLayout", "action": "Clear", "value": 900, "comment": "General-purpose glitter points (key)"}
                     ],
                     "checkpoint": true,
-                    "stage_id": {
-                        "id": 68
-                    },
+                    "hand_items": [
+                        {"id": 1038, "amount": 1, "comment": "Key to Gardnox Fortress"}
+                    ],
+                    "check_commands": [
+                        {"type": "HasUsedKey", "Param1": 100, "Param2": 1, "Param3": 1, "Param4": 70002001}
+                    ]
+                },
+                {
+                    "type": "IsStageNo",
+                    "checkpoint": true,
+                    "flags": [
+                        {"type": "MyQst", "action": "Clear", "value": 0, "comment": "Allows gardnox entrance FSM to play"}
+                    ],
                     "contents_release": [
                         {
                             "type": "None",
                             "flag_info": "Lestania.GardnoxFortress"
                         }
-                    ]
+                    ],
+                    "consume_items": [
+                        {"id": 1038, "amount": 1, "comment": "Key to Gardnox Fortress"}
+                    ],
+                    "stage_id": {
+                        "id": 68
+                    }
                 },
                 {
-                    "type": "OmInteractEvent",
+                    "type": "Raw",
                     "announce_type": "Update",
-                    "flags": [],
-                    "quest_type": "WorldManageQuest",
-                    "interact_type": "Release",
-                    "quest_id": 70002001,
-                    "stage_id": {
-                        "id": 68,
-                        "group_id": 1,
-                        "layer_no": 1
-                    }
+                    "check_commands": [
+                        {"type": "QuestOmReleaseTouch", "Param1": 402, "Param2": 1, "Param3": 1, "Param4": 70002001}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
                     "announce_type": "Update",
-                    "flags": [],
                     "set_flags": [1],
                     "check_flags": [2, 3]
                 },
@@ -274,7 +326,6 @@
                 },
                 {
                     "type": "PlayEvent",
-                    "flags": [],
                     "stage_id": {
                         "id": 68
                     },
@@ -305,8 +356,26 @@
                     "type": "TalkToNpc",
                     "checkpoint": true,
                     "announce_type": "Update",
-                    "flags": [],
-                    "checkpoint": true,
+                    "hand_items": [
+                        {"id": 1050, "amount": 1, "comment": "Kieshildt's Vessel of Life"}
+                    ],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 1013, "comment": "Vanessa (Audience Chamber)"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 1218, "quest_id": 70000001, "comment": "Leo"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 1221, "quest_id": 70000001, "comment": "Vanessa (Fort Gritten)"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 2248, "quest_id": 70000001, "comment": "Messenger (Fort Gritten)"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 8113, "comment": "Joseph extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 8114, "comment": "Klaus extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 2, "Param2": 8115, "comment": "Mysial extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 14, "Param2": 8116, "comment": "Mayleaf extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1003, "Param2": 8117, "comment": "Pamela extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1701, "Param2": 14912, "comment": "Sunny extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1704, "Param2": 11550, "comment": "Regina extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1707, "Param2": 11551, "comment": "Jordan extra dialogue"},
+                        {"type": "QstTalkChg", "Param1": 1703, "Param2": 11552, "comment": "Gort extra dialogue"}
+                    ],
                     "stage_id": {
                         "id": 3
                     },
@@ -323,19 +392,13 @@
                     "check_flags": [1]
                 },
                 {
-                    "type": "OmInteractEvent",
-                    "quest_type": "WorldManageQuest",
-                    "interact_type": "Release",
-                    "quest_id": 70002001,
-                    "stage_id": {
-                        "id": 68,
-                        "group_id": 2,
-                        "layer_no": 1
-                    }
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "QuestOmReleaseTouch", "Param1": 402, "Param2": 2, "Param3": 1, "Param4": 70002001}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
-                    "flags": [],
                     "set_flags": [2]
                 }
             ]
@@ -348,20 +411,37 @@
                     "check_flags": [1]
                 },
                 {
-                    "type": "OmInteractEvent",
-                    "quest_type": "WorldManageQuest",
-                    "interact_type": "Release",
-                    "quest_id": 70002001,
-                    "stage_id": {
-                        "id": 68,
-                        "group_id": 2,
-                        "layer_no": 2
-                    }
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "QuestOmReleaseTouch", "Param1": 402, "Param2": 2, "Param3": 2, "Param4": 70002001}
+                    ]
                 },
                 {
                     "type": "MyQstFlags",
-                    "flags": [],
                     "set_flags": [3]
+                }
+            ]
+        },
+        {
+            "comment": "Process 3 (plays Gardnox fsm)",
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "comment": "Sends empty group so they don't break the incoming fsm",
+                    "type": "SpawnGroup",
+                    "groups": [3],
+                    "check_commands": [
+                        {"type": "SceHitInWithoutMarker", "Param1": 100, "Param2": 64}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "PlayCameraEvent", "Param1": 100, "Param2": 96}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000017.json
@@ -60,6 +60,13 @@
         {
             "type": "TalkToNpc",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2, "Param2": 13556, "comment": "Mysial extra dialogue"},
+                {"type": "QstTalkChg", "Param1": 3, "Param2": 13557, "comment": "Klaus extra dialogue"}
+            ],
+            "consume_items": [
+                {"id": 1050, "amount": 1, "comment": "Kieshildt's Vessel of Life"}
+            ],
             "flags": [
                 {"type": "WorldManageLayout", "action": "Clear", "value": 1294, "quest_id": 70000001, "comment": "The White Dragon (Less Dead)"},
                 {"type": "WorldManageLayout", "action": "Set", "value": 7389, "quest_id": 70032001, "comment": "The White Dragon (Less Less Dead)"}


### PR DESCRIPTION
q00000016 (A Friendly Visit):
- Several optional lines of NPC dialogue were implemented.
- Enemy groups had their IDs, levels, params, positions and experience updated.
- Vanessa stays in the Audience Chamber after the first cutscene. Her spot at Fort Gritten will be taken up by a Messenger NPC. She returns to her usual spot near the end of the quest.
- Leo now leaves the Audience Chamber midway though the quest.
- After beating the first group of Orcs, interacting with the glowing point now drops a key to Gardnox Fortress.
- Approaching Gardnox Fortress now plays a camera event.
- Gardnox Fortress is now unlocked by using the previously obtained key to unlock the door.
- Quest markers now show up for Gardnox Fortress quest objectives.
- Defeating Mogok and his party now drops a Vessel of Life after the cutscene.

q00000017 (Course of Life)
- Two lines of optional NPC dialogue were added.
- Now consumes the previously got Vessel of Life.