### PR TITLE
feat: World Quest Rewards

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 57;
+    public const uint Version = 58;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_world_quest_rewards.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_world_quest_rewards.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "ddon_reward_box" ADD COLUMN "is_repeat_reward" INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS "ddon_world_quest_period_first_clear"
+(
+    "character_common_id" INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
+    CONSTRAINT "pk_ddon_world_quest_period_first_clear" PRIMARY KEY ("character_common_id", "quest_schedule_id"),
+    CONSTRAINT "fk_ddon_world_quest_period_first_clear_character_common_id"
+        FOREIGN KEY ("character_common_id")
+        REFERENCES "ddon_character_common" ("character_common_id")
+        ON DELETE CASCADE
+);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -549,6 +549,7 @@ CREATE TABLE IF NOT EXISTS "ddon_reward_box"
     "random_reward1_index" INTEGER                           NOT NULL,
     "random_reward2_index" INTEGER                           NOT NULL,
     "random_reward3_index" INTEGER                           NOT NULL,
+    "is_repeat_reward"     INTEGER                           NOT NULL DEFAULT 0,
     CONSTRAINT "fk_ddon_reward_box_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS "idx_ddon_reward_box_character_common_id" ON "ddon_reward_box" ("character_common_id");
@@ -597,6 +598,14 @@ CREATE TABLE IF NOT EXISTS "ddon_mail"
     CONSTRAINT "fk_ddon_mail_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS "idx_ddon_mail_character_id" ON "ddon_mail" ("character_id");
+
+CREATE TABLE IF NOT EXISTS "ddon_world_quest_period_first_clear"
+(
+    "character_common_id" INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
+    CONSTRAINT "pk_ddon_world_quest_period_first_clear" PRIMARY KEY ("character_common_id", "quest_schedule_id"),
+    CONSTRAINT "fk_ddon_world_quest_period_first_clear_character_common_id" FOREIGN KEY ("character_common_id") REFERENCES "ddon_character_common" ("character_common_id") ON DELETE CASCADE
+);
 
 CREATE TABLE IF NOT EXISTS "ddon_system_mail"
 (

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -319,6 +319,12 @@ public interface IDatabase
     bool DeleteBoxRewardItem(uint commonId, uint uniqId, DbConnection? connectionIn = null);
     List<QuestBoxRewards> SelectBoxRewardItems(uint commonId, DbConnection? connectionIn = null);
 
+    // World Quest Period First Clear
+    bool InsertWorldQuestFirstClear(uint commonId, uint questScheduleId, DbConnection? connectionIn = null);
+    bool HasWorldQuestFirstClear(uint commonId, uint questScheduleId, DbConnection? connectionIn = null);
+    bool DeleteAllWorldQuestFirstClears(DbConnection? connectionIn = null);
+    HashSet<uint> SelectWorldQuestFirstClears(uint commonId, DbConnection? connectionIn = null);
+
     // Completed Quests
     List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
     CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -426,6 +426,10 @@ public partial class DdonSqlDb : SqlDb
                 }
             });
 
+        // World quest period first-clears: drives per-period clear count in quest list packets
+        foreach (var scheduleId in SelectWorldQuestFirstClears(character.CommonId, conn))
+            character.WorldQuestPeriodFirstClears.Add(scheduleId);
+
         // Clan membership
         character.ClanId = SelectClanMembershipByCharacterId(character.CharacterId, conn);
         character.ClanName = GetClanNameByClanId(character.ClanId);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbQuestReward.cs
@@ -9,7 +9,7 @@ public partial class DdonSqlDb : SqlDb
     protected static readonly string[] RewardBoxFields = new[]
     {
         /* uniq_reward_id */ "character_common_id", "quest_schedule_id", "num_random_rewards", "random_reward0_index", "random_reward1_index", "random_reward2_index",
-        "random_reward3_index"
+        "random_reward3_index", "is_repeat_reward"
     };
 
     private readonly int MAX_RANDOM_REWARDS = 4;
@@ -36,6 +36,8 @@ public partial class DdonSqlDb : SqlDb
                 for (i = 0; i < rewards.NumRandomRewards; i++) AddParameter(command, $"random_reward{i}_index", rewards.RandomRewardIndices[i]);
 
                 for (; i < MAX_RANDOM_REWARDS; i++) AddParameter(command, $"random_reward{i}_index", 0);
+
+                AddParameter(command, "is_repeat_reward", rewards.IsRepeatReward ? 1 : 0);
             }) == 1;
         });
     }
@@ -79,6 +81,7 @@ public partial class DdonSqlDb : SqlDb
         obj.QuestScheduleId = GetUInt32(reader, "quest_schedule_id");
 
         for (int i = 0; i < obj.NumRandomRewards; i++) obj.RandomRewardIndices.Add(GetInt32(reader, $"random_reward{i}_index"));
+        obj.IsRepeatReward = GetInt32(reader, "is_repeat_reward") != 0;
 
         return obj;
     }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbWorldQuestFirstClear.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbWorldQuestFirstClear.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core;
+
+public partial class DdonSqlDb : SqlDb
+{
+    private readonly string SqlInsertWorldQuestFirstClear =
+        "INSERT INTO \"ddon_world_quest_period_first_clear\" (\"character_common_id\", \"quest_schedule_id\") VALUES (@character_common_id, @quest_schedule_id) ON CONFLICT DO NOTHING;";
+
+    private readonly string SqlHasWorldQuestFirstClear =
+        "SELECT COUNT(*) FROM \"ddon_world_quest_period_first_clear\" WHERE \"character_common_id\" = @character_common_id AND \"quest_schedule_id\" = @quest_schedule_id;";
+
+    private readonly string SqlSelectWorldQuestFirstClears =
+        "SELECT \"quest_schedule_id\" FROM \"ddon_world_quest_period_first_clear\" WHERE \"character_common_id\" = @character_common_id;";
+
+    private readonly string SqlDeleteAllWorldQuestFirstClears =
+        "DELETE FROM \"ddon_world_quest_period_first_clear\";";
+
+    public override bool InsertWorldQuestFirstClear(uint commonId, uint questScheduleId, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            return ExecuteNonQuery(connection, SqlInsertWorldQuestFirstClear, command =>
+            {
+                AddParameter(command, "@character_common_id", commonId);
+                AddParameter(command, "@quest_schedule_id", questScheduleId);
+            }) >= 0;
+        });
+    }
+
+    public override bool HasWorldQuestFirstClear(uint commonId, uint questScheduleId, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            long count = 0;
+            ExecuteReader(connection, SqlHasWorldQuestFirstClear,
+                command =>
+                {
+                    AddParameter(command, "@character_common_id", commonId);
+                    AddParameter(command, "@quest_schedule_id", questScheduleId);
+                },
+                reader =>
+                {
+                    if (reader.Read())
+                        count = reader.GetInt64(0);
+                });
+            return count > 0;
+        });
+    }
+
+    public override bool DeleteAllWorldQuestFirstClears(DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            return ExecuteNonQuery(connection, SqlDeleteAllWorldQuestFirstClears, _ => { }) >= 0;
+        });
+    }
+
+    public override HashSet<uint> SelectWorldQuestFirstClears(uint commonId, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            var result = new HashSet<uint>();
+            ExecuteReader(connection, SqlSelectWorldQuestFirstClears,
+                command => { AddParameter(command, "@character_common_id", commonId); },
+                reader =>
+                {
+                    while (reader.Read())
+                        result.Add(GetUInt32(reader, "quest_schedule_id"));
+                });
+            return result;
+        });
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000058_WorldQuestRewardsMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000058_WorldQuestRewardsMigration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class WorldQuestRewardsMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 57;
+        public uint To => 58;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/migration_world_quest_rewards.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -495,6 +495,10 @@ public abstract class SqlDb : IDatabase
     public abstract bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards, DbConnection? connectionIn = null);
     public abstract bool DeleteBoxRewardItem(uint commonId, uint uniqId, DbConnection? connectionIn = null);
     public abstract List<QuestBoxRewards> SelectBoxRewardItems(uint commonId, DbConnection? connectionIn = null);
+    public abstract bool InsertWorldQuestFirstClear(uint commonId, uint questScheduleId, DbConnection? connectionIn = null);
+    public abstract bool HasWorldQuestFirstClear(uint commonId, uint questScheduleId, DbConnection? connectionIn = null);
+    public abstract bool DeleteAllWorldQuestFirstClears(DbConnection? connectionIn = null);
+    public abstract HashSet<uint> SelectWorldQuestFirstClears(uint commonId, DbConnection? connectionIn = null);
     public abstract List<CompletedQuest> GetCompletedQuestsByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
     public abstract CompletedQuest GetCompletedQuestsById(uint characterCommonId, QuestId questId, DbConnection? connectionIn = null);
     public abstract bool InsertCompletedQuest(uint characterCommonId, QuestId questId, QuestType questType, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/RewardManager.cs
@@ -35,6 +35,36 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards, connectionIn);
         }
 
+        public bool AddRepeatClearQuestRewards(GameClient client, Quest quest, DbConnection? connectionIn = null)
+        {
+            var rewards = quest.GenerateRepeatClearBoxRewards();
+
+            var currentRewards = GetQuestBoxRewards(client, connectionIn);
+            if (currentRewards.Count >= Server.GameSettings.GameServerSettings.RewardBoxMax)
+            {
+                return false;
+            }
+
+            return Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards, connectionIn);
+        }
+
+        public bool AddAutoRepeatClearQuestRewards(GameClient client, Quest quest, DbConnection? connectionIn = null)
+        {
+            var rewards = quest.GenerateAutoRepeatClearBoxRewards();
+            if (rewards.NumRandomRewards == 0)
+            {
+                return true;
+            }
+
+            var currentRewards = GetQuestBoxRewards(client, connectionIn);
+            if (currentRewards.Count >= Server.GameSettings.GameServerSettings.RewardBoxMax)
+            {
+                return false;
+            }
+
+            return Server.Database.InsertBoxRewardItems(client.Character.CommonId, rewards, connectionIn);
+        }
+
         public List<QuestBoxRewards> GetQuestBoxRewards(GameClient client, DbConnection? connectionIn = null)
         {
             return Server.Database.SelectBoxRewardItems(client.Character.CommonId, connectionIn);

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -83,9 +83,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
                     QuestState questState = client.Party.QuestState.GetQuestState(quest);
-                    ntc.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, questStats?.ClearCount ?? 0));
+                    uint clearCount = leaderCharacter?.WorldQuestPeriodFirstClears.Contains(quest.QuestScheduleId) == true ? 1u : 0u;
+                    ntc.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, clearCount));
                 }
 
                 foreach (var questScheduleId in client.Party.QuestState.AreaQuests(areaId))
@@ -99,8 +99,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
-                    ntc.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
+                    uint clearCount = leaderCharacter?.WorldQuestPeriodFirstClears.Contains(quest.QuestScheduleId) == true ? 1u : 0u;
+                    ntc.SetQuestList.Add(quest.ToCDataSetQuestList(0, clearCount));
 
                     if (mutating)
                     {

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -165,17 +165,42 @@ namespace Arrowgene.Ddon.GameServer.Handler
         private PacketQueue CompleteQuest(Quest quest, GameClient client, QuestStateManager questState, DbConnection? connectionIn = null)
         {
             PacketQueue packets = new();
+
+            // Snapshot repeat-clear state before DistributeQuestRewards mutates WorldQuestPeriodFirstClears.
+            bool isWorldQuest = QuestManager.IsWorldQuest(quest);
+            bool rewardSystemEnabled = Server.GameSettings.GameServerSettings.WorldQuestFirstClearRewards;
+            bool isRepeatClear = isWorldQuest && rewardSystemEnabled
+                && client.Character.WorldQuestPeriodFirstClears.Contains(quest.QuestScheduleId);
+
             packets.AddRange(questState.DistributeQuestRewards(quest.QuestScheduleId, connectionIn));
             packets.AddRange(Server.AreaRankManager.NotifyAreaRankUpOnQuestComplete(client, quest));
             questState.CompleteQuestProgress(quest.QuestScheduleId, connectionIn);
 
+            byte randomRewardNum;
+            bool isRepeatRewardFlag;
+            if (isRepeatClear)
+            {
+                isRepeatRewardFlag = true;
+                if (quest.HasRepeatClearItemRewards())
+                    randomRewardNum = quest.RepeatClearRandomRewardNum();
+                else if (quest.GetAutoRepeatPool().Count > 0)
+                    randomRewardNum = 1; // auto-repeat yields one item from the combined first-clear pool
+                else
+                    randomRewardNum = 0;
+            }
+            else
+            {
+                isRepeatRewardFlag = quest.RewardParams.IsRepeatReward;
+                randomRewardNum = quest.RandomRewardNum();
+            }
+
             S2CQuestCompleteNtc completeNtc = new S2CQuestCompleteNtc()
             {
                 QuestScheduleId = quest.QuestScheduleId,
-                RandomRewardNum = quest.RandomRewardNum(),
+                RandomRewardNum = randomRewardNum,
                 ChargeRewardNum = quest.RewardParams.ChargeRewardNum,
                 ProgressBonusNum = quest.RewardParams.ProgressBonusNum,
-                IsRepeatReward = quest.RewardParams.IsRepeatReward,
+                IsRepeatReward = isRepeatRewardFlag,
                 IsUndiscoveredReward = quest.RewardParams.IsUndiscoveredReward,
                 IsHelpReward = quest.RewardParams.IsHelpReward,
                 IsPartyBonus = quest.RewardParams.IsPartyBonus,

--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -90,6 +90,16 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 }
             }
 
+            // Repeat-clear rewards from script
+            foreach (var pointReward in questAsset.RepeatClearPointRewards)
+                quest.AddRepeatClearExpReward(pointReward.PointType, pointReward.Amount);
+
+            foreach (var walletReward in questAsset.RepeatClearRewardCurrency)
+                quest.AddRepeatClearWalletReward(walletReward.WalletType, walletReward.Amount);
+
+            foreach (var rewardItem in questAsset.RepeatClearRewardItems)
+                quest.AddRepeatClearItemReward(rewardItem);
+
             foreach (var (_, enemyGroup) in questAsset.EnemyGroups)
             {
                 quest.UniqueEnemyGroups.Add(enemyGroup.StageLayoutId);

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -4,6 +4,7 @@ using Arrowgene.Ddon.GameServer.Quests.LightQuests;
 using Arrowgene.Ddon.GameServer.Scripting.Interfaces;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
+using Arrowgene.Ddon.Server.Settings;
 using Arrowgene.Ddon.Shared.Asset;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
@@ -88,6 +89,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
         protected List<CDataQuestExp> ExpRewards { get; set; }
         protected List<QuestRewardItem> ItemRewards { get; set; }
         protected List<QuestRewardItem> SelectableRewards { get; set; }
+        // Repeat-clear reward lists: populated from InitializeRewards().
+        // When empty and WorldQuestFirstClearRewards is enabled, wallet rewards are auto-nerfed from base values.
+        protected List<CDataWalletPoint> RepeatClearWalletRewards { get; set; }
+        protected List<CDataQuestExp> RepeatClearExpRewards { get; set; }
+        protected List<QuestRewardItem> RepeatClearItemRewards { get; set; }
         public List<QuestLocation> Locations { get; protected set; }
         public List<QuestDeliveryItem> DeliveryItems { get; protected set; }
         public List<QuestEnemyHunt> EnemyHunts { get; protected set; }
@@ -171,6 +177,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
             ExpRewards = new List<CDataQuestExp>();
             ItemRewards = new List<QuestRewardItem>();
             SelectableRewards = new List<QuestRewardItem>();
+            RepeatClearWalletRewards = new List<CDataWalletPoint>();
+            RepeatClearExpRewards = new List<CDataQuestExp>();
+            RepeatClearItemRewards = new List<QuestRewardItem>();
             Locations = new List<QuestLocation>();
             DeliveryItems = new List<QuestDeliveryItem>();
             EnemyHunts = new List<QuestEnemyHunt>();
@@ -1106,6 +1115,27 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 return new List<CDataRewardBoxItem>();
             }
 
+            // Auto-repeat: one item was picked from the combined first-clear pool at completion time.
+            // The stored index is into GetAutoRepeatPool(), not into a specific random slot.
+            if (rewards.IsRepeatReward && !quest.HasRepeatClearItemRewards()
+                && rewards.NumRandomRewards > 0 && rewards.RandomRewardIndices.Count > 0)
+            {
+                var pool = quest.GetAutoRepeatPool();
+                var idx = rewards.RandomRewardIndices[0];
+                if (idx < pool.Count)
+                {
+                    var item = pool[idx];
+                    results.Add(new CDataRewardBoxItem()
+                    {
+                        ItemId = item.ItemId,
+                        Num = item.Num,
+                        Type = (byte)QuestRewardType.Repeat,
+                        UID = item.GetUID()
+                    });
+                }
+                return results;
+            }
+
             foreach (var reward in quest.SelectableRewards)
             {
                 results.AddRange(reward.AsCDataRewardBoxItems());
@@ -1191,6 +1221,160 @@ namespace Arrowgene.Ddon.GameServer.Quests
         public bool HasRewards()
         {
             return (ItemRewards.Count > 0) || (SelectableRewards.Count > 0);
+        }
+
+        public bool HasRepeatClearItemRewards()
+        {
+            return RepeatClearItemRewards.Count > 0;
+        }
+
+        public byte RepeatClearRandomRewardNum()
+        {
+            byte count = 0;
+            foreach (var reward in RepeatClearItemRewards)
+            {
+                if (reward.RewardType == QuestRewardType.Random)
+                    count++;
+            }
+            return count;
+        }
+
+        public void AddRepeatClearItemReward(QuestRewardItem reward)
+        {
+            if (reward == null) return;
+            switch (reward.RewardType)
+            {
+                case QuestRewardType.Fixed:
+                case QuestRewardType.Random:
+                    RepeatClearItemRewards.Add(reward);
+                    break;
+            }
+        }
+
+        public void AddRepeatClearWalletReward(WalletType walletType, uint amount)
+        {
+            RepeatClearWalletRewards.Add(new CDataWalletPoint() { Type = walletType, Value = amount });
+        }
+
+        public void AddRepeatClearExpReward(PointType pointType, uint amount)
+        {
+            RepeatClearExpRewards.Add(new CDataQuestExp() { Type = pointType, Reward = amount });
+        }
+
+        /// <summary>
+        /// Returns the wallet rewards to give on a repeat clear, applying server-level nerf percentages
+        /// when no custom repeat clear wallet rewards are explicitly defined.
+        /// </summary>
+        public List<CDataWalletPoint> GetRepeatClearScaledWalletRewards(GameServerSettings settings)
+        {
+            if (RepeatClearWalletRewards.Count > 0)
+            {
+                // Explicit rewards defined in the quest script, scale normally
+                var custom = new List<CDataWalletPoint>();
+                foreach (var wp in RepeatClearWalletRewards)
+                    custom.Add(new CDataWalletPoint() { Type = wp.Type, Value = Server.WalletManager.GetScaledWalletAmount(wp.Type, wp.Value) });
+                return custom;
+            }
+
+            // Auto-nerf the base wallet rewards
+            var result = new List<CDataWalletPoint>();
+            foreach (var wp in WalletRewards)
+            {
+                uint scaled = Server.WalletManager.GetScaledWalletAmount(wp.Type, wp.Value);
+                uint finalValue = wp.Type switch
+                {
+                    WalletType.Gold => (uint)(scaled * settings.WorldQuestRepeatClearGoldPct),
+                    WalletType.RiftPoints => (uint)(scaled * settings.WorldQuestRepeatClearRpPct),
+                    _ => scaled
+                };
+                result.Add(new CDataWalletPoint() { Type = wp.Type, Value = finalValue });
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Returns the EXP rewards to give on a repeat clear, applying server-level nerf percentages
+        /// when no custom repeat clear exp rewards are explicitly defined.
+        /// </summary>
+        public List<CDataQuestExp> GetRepeatClearScaledExpRewards(GameServerSettings settings)
+        {
+            if (RepeatClearExpRewards.Count > 0)
+                return RepeatClearExpRewards;
+
+            // Auto-nerf the base exp/JP rewards
+            var result = new List<CDataQuestExp>();
+            foreach (var exp in ExpRewards)
+            {
+                uint finalValue = exp.Type switch
+                {
+                    PointType.ExperiencePoints => (uint)(exp.Reward * settings.WorldQuestRepeatClearExpPct),
+                    PointType.JobPoints => (uint)(exp.Reward * settings.WorldQuestRepeatClearJpPct),
+                    _ => exp.Reward
+                };
+                result.Add(new CDataQuestExp() { Type = exp.Type, Reward = finalValue });
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Rolls random reward indices from the repeat-clear item pool.
+        /// </summary>
+        public QuestBoxRewards GenerateRepeatClearBoxRewards()
+        {
+            QuestBoxRewards obj = new QuestBoxRewards()
+            {
+                QuestScheduleId = QuestScheduleId,
+                IsRepeatReward = true,
+            };
+
+            foreach (var reward in RepeatClearItemRewards)
+            {
+                if (reward.RewardType == QuestRewardType.Random)
+                {
+                    var randomReward = (QuestRandomRewardItem)reward;
+                    obj.RandomRewardIndices.Add(randomReward.Roll());
+                }
+            }
+            obj.NumRandomRewards = obj.RandomRewardIndices.Count;
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Flat pool of all items from first-clear selectable and random reward pools.
+        /// Index into this is what gets stored as the auto-repeat reward.
+        /// </summary>
+        public List<LootPoolItem> GetAutoRepeatPool()
+        {
+            var pool = new List<LootPoolItem>();
+            foreach (var reward in SelectableRewards)
+                pool.AddRange(reward.LootPool);
+            foreach (var reward in ItemRewards)
+                if (reward.RewardType == QuestRewardType.Random)
+                    pool.AddRange(reward.LootPool);
+            return pool;
+        }
+
+        /// <summary>
+        /// Picks one item at random from the combined first-clear pool (selectable + random).
+        /// The stored index references GetAutoRepeatPool(), not any individual slot.
+        /// </summary>
+        public QuestBoxRewards GenerateAutoRepeatClearBoxRewards()
+        {
+            QuestBoxRewards obj = new QuestBoxRewards()
+            {
+                QuestScheduleId = QuestScheduleId,
+                IsRepeatReward = true,
+            };
+
+            var pool = GetAutoRepeatPool();
+            if (pool.Count > 0)
+            {
+                obj.RandomRewardIndices.Add(Random.Shared.Next(pool.Count));
+                obj.NumRandomRewards = 1;
+            }
+
+            return obj;
         }
 
         public List<CDataCharacterReleaseElement> GetContentReleaseRewards()

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -754,6 +754,69 @@ namespace Arrowgene.Ddon.GameServer.Quests
             return packets;
         }
 
+        /// <summary>
+        /// Sends reduced wallet and EXP rewards for a repeat world quest clear.
+        /// Uses quest-specific repeat rewards if defined; otherwise auto-nerfs the base rewards
+        /// per the WorldQuestRepeatClear* server settings.
+        /// </summary>
+        protected PacketQueue SendRepeatClearWalletRewards(DdonGameServer server, GameClient client, Quest quest, DbConnection? connectionIn = null)
+        {
+            PacketQueue packets = new();
+            var settings = server.GameSettings.GameServerSettings;
+
+            S2CItemUpdateCharacterItemNtc updateCharacterItemNtc = new S2CItemUpdateCharacterItemNtc()
+            {
+                UpdateType = ItemNoticeType.Quest
+            };
+
+            foreach (var walletReward in quest.GetRepeatClearScaledWalletRewards(settings))
+            {
+                updateCharacterItemNtc.UpdateWalletList.Add(server.WalletManager.AddToWallet(
+                    client.Character,
+                    walletReward.Type,
+                    walletReward.Value,
+                    connectionIn: connectionIn
+                ));
+            }
+
+            if (updateCharacterItemNtc.UpdateWalletList.Count > 0)
+            {
+                client.Enqueue(updateCharacterItemNtc, packets);
+            }
+
+            var scaledExpRewards = quest.GetRepeatClearScaledExpRewards(settings);
+            foreach (var pointReward in scaledExpRewards)
+            {
+                if (pointReward.Reward == 0)
+                    continue;
+
+                (uint BasePoints, uint BonusPoints) amount = server.ExpManager.GetAdjustedPointsForQuest(pointReward.Type, pointReward.Reward, quest.QuestType, client, client.Character);
+                switch (pointReward.Type)
+                {
+                    case PointType.ExperiencePoints:
+                        packets.AddRange(server.ExpManager.AddExp(client, client.Character, amount, RewardSource.Quest, quest.QuestType, connectionIn));
+                        break;
+                    case PointType.JobPoints:
+                        packets.AddRange(server.ExpManager.AddJp(client, client.Character, amount.BasePoints, RewardSource.Quest, quest.QuestType, connectionIn));
+                        break;
+                    case PointType.AreaPoints:
+                        var areaId = quest.QuestAreaId > 0 ? quest.QuestAreaId : (QuestAreaId)quest.LightQuestDetail.AreaId;
+                        packets.AddRange(server.AreaRankManager.AddAreaPoint(client, areaId, amount, connectionIn));
+                        break;
+                }
+            }
+
+            // Fallback AP for world quests that don't define their own AreaPoints reward on repeat clear
+            if (!scaledExpRewards.Exists(x => x.Type == PointType.AreaPoints) && QuestManager.IsWorldQuest(quest))
+            {
+                var areaId = quest.QuestAreaId;
+                var amount = server.ExpManager.GetAdjustedPointsForQuest(PointType.AreaPoints, AreaRankManager.GetAreaPointReward(quest), quest.QuestType);
+                packets.AddRange(server.AreaRankManager.AddAreaPoint(client, areaId, amount, connectionIn));
+            }
+
+            return packets;
+        }
+
         public virtual void EnforceInitialPoolEligibility() { }
 
         protected virtual Quest RollQuestVariant(QuestId questId)
@@ -975,8 +1038,8 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 if (quest == null || IsQuestActive(scheduleId) || IsCompletedWorldQuest(scheduleId))
                     continue;
 
-                CompletedQuest questStats = leaderCharacter.CompletedQuests.GetValueOrDefault(quest.QuestId);
-                questList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
+                uint clearCount = leaderCharacter.WorldQuestPeriodFirstClears.Contains(quest.QuestScheduleId) ? 1u : 0u;
+                questList.Add(quest.ToCDataSetQuestList(0, clearCount));
             }
 
             Party.SendToAll(new S2CQuestGetSetQuestListNtc
@@ -995,6 +1058,17 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         protected override Quest RollQuestVariant(QuestId questId)
         {
+            if (Server.GameSettings.GameServerSettings.WorldQuestSystem == WorldQuestSystemMode.ServerReset)
+            {
+                var pool = Server.WorldQuestManager.GetCurrentPool();
+                foreach (var scheduleId in QuestManager.GetQuestScheduleIdsForQuestId(questId))
+                {
+                    var quest = QuestManager.GetQuestByScheduleId(scheduleId);
+                    if (quest != null && pool.TryGetValue(quest.QuestAreaId, out var poolSet) && poolSet.Contains(scheduleId))
+                        return quest;
+                }
+                return null;
+            }
             return RollEligibleQuestVariant(questId, Party.Leader?.Client.Character);
         }
 
@@ -1082,6 +1156,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
             PacketQueue packets = new();
             Quest quest = GetQuest(questScheduleId);
 
+            bool isWorldQuest = QuestManager.IsWorldQuest(quest);
+            bool rewardSystemEnabled = Server.GameSettings.GameServerSettings.WorldQuestFirstClearRewards;
+
             var questState = GetQuestState(quest);
             foreach (var memberClient in Party.Clients)
             {
@@ -1103,22 +1180,47 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 // Distribute any released content from the quest to the player
                 packets.AddRange(RewardReleasedContent(memberClient, quest, connectionIn));
 
-                // Check for Item Rewards
-                if (quest.HasRewards())
+                bool isFirstClear = !isWorldQuest
+                    || !rewardSystemEnabled
+                    || !Server.Database.HasWorldQuestFirstClear(memberClient.Character.CommonId, quest.QuestScheduleId, connectionIn);
+
+                if (isWorldQuest && rewardSystemEnabled && isFirstClear)
                 {
-                    Server.RewardManager.AddQuestRewards(memberClient, quest, connectionIn);
+                    Server.Database.InsertWorldQuestFirstClear(memberClient.Character.CommonId, quest.QuestScheduleId, connectionIn);
+                    memberClient.Character.WorldQuestPeriodFirstClears.Add(quest.QuestScheduleId);
                 }
+
+                if (isFirstClear)
+                {
+                    // Full first-clear rewards: fixed items, random items, and selectables
+                    if (quest.HasRewards())
+                    {
+                        Server.RewardManager.AddQuestRewards(memberClient, quest, connectionIn);
+                    }
 
 #if false
-                if (quest.QuestId == QuestId.TheShiningGate && !memberClient.Character.HasQuestCompleted(QuestId.TheShiningGate))
-                {
-                    packets.AddRange(Server.RewardManager.UnlockEM4Skills(memberClient, connectionIn));
-                }
+                    if (quest.QuestId == QuestId.TheShiningGate && !memberClient.Character.HasQuestCompleted(QuestId.TheShiningGate))
+                    {
+                        packets.AddRange(Server.RewardManager.UnlockEM4Skills(memberClient, connectionIn));
+                    }
 #endif
 
-                // Check for Exp, Rift and Gold Rewards
-                var ntcs = SendWalletRewards(Server, memberClient, quest, connectionIn);
-                packets.AddRange(ntcs);
+                    packets.AddRange(SendWalletRewards(Server, memberClient, quest, connectionIn));
+                }
+                else
+                {
+                    // Repeat-clear: diluted item pool (if defined) and nerfed wallet rewards
+                    if (quest.HasRepeatClearItemRewards())
+                    {
+                        Server.RewardManager.AddRepeatClearQuestRewards(memberClient, quest, connectionIn);
+                    }
+                    else if (rewardSystemEnabled && quest.HasRewards())
+                    {
+                        Server.RewardManager.AddAutoRepeatClearQuestRewards(memberClient, quest, connectionIn);
+                    }
+
+                    packets.AddRange(SendRepeatClearWalletRewards(Server, memberClient, quest, connectionIn));
+                }
             }
 
             return packets;

--- a/Arrowgene.Ddon.GameServer/Quests/WorldQuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/WorldQuestManager.cs
@@ -60,30 +60,55 @@ namespace Arrowgene.Ddon.GameServer
         }
 
         /// <summary>
-        /// Performs a server-wide reset using the given seed. Called via RPC on every game server
-        /// instance (including the originating head server) when the weekly task fires.
+        /// Performs a world quest reset triggered by the weekly task.
+        /// In ServerReset mode: rotates the server-wide pool, notifies all online parties, and purges stale DB progress.
+        /// In InstanceReset mode (when WorldQuestFirstClearRewards is enabled): skips pool rotation but still resets
+        /// per-character first-clear records so the new period's rewards are available.
         /// </summary>
         public void PerformReset(long seed)
         {
-            Logger.Info($"WorldQuestManager performing reset with seed {seed}");
-            RollPool(seed);
+            var settings = _server.GameSettings.GameServerSettings;
+            bool isServerReset = settings.WorldQuestSystem == WorldQuestSystemMode.ServerReset;
 
-            foreach (var party in _server.PartyManager.GetAllParties())
+            if (isServerReset)
             {
-                if (party.QuestState is SharedQuestStateManager shared)
+                Logger.Info($"WorldQuestManager performing pool reset with seed {seed}");
+                RollPool(seed);
+
+                foreach (var party in _server.PartyManager.GetAllParties())
                 {
-                    shared.OnServerWorldQuestReset(GetCurrentPool());
+                    if (party.QuestState is SharedQuestStateManager shared)
+                    {
+                        shared.OnServerWorldQuestReset(GetCurrentPool());
+                    }
                 }
+
+                // Purge all persisted world quest progress so offline players don't reload
+                // stale quests on next login. Online players already had their in-memory
+                // state cleared above before this runs.
+                _server.Database.RemoveAllQuestProgressByType(QuestType.World);
+
+                _server.ChatManager.BroadcastMessage(
+                    LobbyChatMsgType.ManagementAlertN,
+                    "World quest pool has been refreshed for the new period.");
             }
 
-            // Purge all persisted world quest progress so offline players don't reload
-            // stale quests on next login. Online players already had their in-memory
-            // state cleared above before this runs.
-            _server.Database.RemoveAllQuestProgressByType(QuestType.World);
+            if (settings.WorldQuestFirstClearRewards)
+            {
+                Logger.Info($"WorldQuestManager clearing period first-clear reward records");
+                _server.Database.DeleteAllWorldQuestFirstClears();
 
-            _server.ChatManager.BroadcastMessage(
-                LobbyChatMsgType.ManagementAlertN,
-                "World quest pool has been refreshed for the new period.");
+                foreach (var party in _server.PartyManager.GetAllParties())
+                    foreach (var client in party.Clients)
+                        client.Character.WorldQuestPeriodFirstClears.Clear();
+
+                if (!isServerReset)
+                {
+                    _server.ChatManager.BroadcastMessage(
+                        LobbyChatMsgType.ManagementAlertN,
+                        "World quest rewards have been reset for the new period.");
+                }
+            }
         }
 
         /// <summary>

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IQuest.cs
@@ -17,6 +17,9 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
             RewardItems = new List<QuestRewardItem>();
             WalletRewards = new List<QuestWalletReward>();
             PointRewards = new List<QuestPointReward>();
+            RepeatClearRewardItems = new List<QuestRewardItem>();
+            RepeatClearWalletRewards = new List<QuestWalletReward>();
+            RepeatClearPointRewards = new List<QuestPointReward>();
             EnemyGroups = new Dictionary<uint, QuestEnemyGroup>();
             MissionParams = new QuestMissionParams();
             QuestLayoutSetInfoSetList = new List<QuestLayoutFlagSetInfo>();
@@ -76,6 +79,9 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
         protected List<QuestRewardItem> RewardItems { get; set; }
         protected List<QuestWalletReward> WalletRewards { get; set; }
         protected List<QuestPointReward> PointRewards { get; set; }
+        protected List<QuestRewardItem> RepeatClearRewardItems { get; set; }
+        protected List<QuestWalletReward> RepeatClearWalletRewards { get; set; }
+        protected List<QuestPointReward> RepeatClearPointRewards { get; set; }
         protected Dictionary<uint, QuestEnemyGroup> EnemyGroups { get; set; }
         protected List<QuestLayoutFlagSetInfo> QuestLayoutSetInfoSetList { get; set; }
         protected QuestMissionParams MissionParams { get; set; }
@@ -166,6 +172,38 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
         public void AddWalletReward(WalletType walletType, uint amount)
         {
             WalletRewards.Add(QuestWalletReward.Create(walletType, amount));
+        }
+
+        // Repeat-clear reward helpers: call these from InitializeRewards()
+        public void AddRepeatClearItemReward(QuestRewardItem reward)
+        {
+            if (reward != null)
+                RepeatClearRewardItems.Add(reward);
+        }
+
+        public void AddRepeatClearFixedItemReward(ItemId itemId, ushort amount, bool isHidden = false)
+        {
+            AddRepeatClearItemReward(QuestFixedRewardItem.Create(itemId, amount, isHidden));
+        }
+
+        public void AddRepeatClearRandomFixedItemReward(List<(ItemId ItemId, ushort Amount)> items, bool isHidden = false)
+        {
+            AddRepeatClearItemReward(QuestRandomFixedRewardItem.Create(items, isHidden));
+        }
+
+        public void AddRepeatClearRandomChanceItemReward(List<(ItemId ItemId, ushort Amount, double Chance)> items, bool isHidden = false)
+        {
+            AddRepeatClearItemReward(QuestRandomChanceRewardItem.Create(items, isHidden));
+        }
+
+        public void AddRepeatClearPointReward(PointType pointType, uint amount)
+        {
+            RepeatClearPointRewards.Add(QuestPointReward.Create(pointType, amount));
+        }
+
+        public void AddRepeatClearWalletReward(WalletType walletType, uint amount)
+        {
+            RepeatClearWalletRewards.Add(QuestWalletReward.Create(walletType, amount));
         }
 
         public void AddQuestOrderCondition(QuestOrderConditionType type, int param01 = 0, int param02 = 0)
@@ -328,6 +366,9 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
                 Processes = Processes.Values.ToList(),
                 RewardItems = RewardItems,
                 RewardCurrency = WalletRewards,
+                RepeatClearRewardItems = RepeatClearRewardItems,
+                RepeatClearRewardCurrency = RepeatClearWalletRewards,
+                RepeatClearPointRewards = RepeatClearPointRewards,
                 StageLayoutId = StageInfo.AsStageLayoutId(0, 0),
                 ResetPlayerAfterQuest = ResetPlayerAfterQuest,
                 MissionParams = MissionParams,

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/WorldQuestResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/WorldQuestResetTask.cs
@@ -17,7 +17,10 @@ namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
 
         public override bool IsEnabled(DdonGameServer server)
         {
-            return server.GameSettings.GameServerSettings.WorldQuestSystem == WorldQuestSystemMode.ServerReset;
+            var settings = server.GameSettings.GameServerSettings;
+            // Run if server-side pool rotation is needed OR if first-clear reward tracking needs periodic resets.
+            return settings.WorldQuestSystem == WorldQuestSystemMode.ServerReset
+                || settings.WorldQuestFirstClearRewards;
         }
 
         public override void RunTask(DdonGameServer server)

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1923,5 +1923,68 @@ namespace Arrowgene.Ddon.Server.Settings
             }
         }
         private const bool _WorldQuestFilterByLeaderAreaRank = false;
+
+        /// <summary>
+        /// When true, world quests use a first-clear / repeat-clear reward system per period.
+        /// First clear per period: full rewards (fixed, random, selectable).
+        /// Repeat clears: reduced random item pool (if defined per quest) plus configurable wallet reward penalties.
+        /// The WorldQuestResetTask resets first-clear records when it fires, regardless of WorldQuestSystem mode.
+        /// When false, every clear gives full rewards as if it were a first clear.
+        /// </summary>
+        [DefaultValue(_WorldQuestFirstClearRewards)]
+        public bool WorldQuestFirstClearRewards
+        {
+            set { SetSetting("WorldQuestFirstClearRewards", value); }
+            get { return TryGetSetting("WorldQuestFirstClearRewards", _WorldQuestFirstClearRewards); }
+        }
+        private const bool _WorldQuestFirstClearRewards = true;
+
+        /// <summary>
+        /// EXP reward ratio for repeat world quest clears (0.0 = none, 1.0 = full).
+        /// Only applies when WorldQuestFirstClearRewards = true.
+        /// </summary>
+        [DefaultValue(_WorldQuestRepeatClearExpPct)]
+        public double WorldQuestRepeatClearExpPct
+        {
+            set { SetSetting("WorldQuestRepeatClearExpPct", value); }
+            get { return TryGetSetting("WorldQuestRepeatClearExpPct", _WorldQuestRepeatClearExpPct); }
+        }
+        private const double _WorldQuestRepeatClearExpPct = 1.0;
+
+        /// <summary>
+        /// Rift Points reward ratio for repeat world quest clears (0.0 = none, 1.0 = full).
+        /// Only applies when WorldQuestFirstClearRewards = true.
+        /// </summary>
+        [DefaultValue(_WorldQuestRepeatClearRpPct)]
+        public double WorldQuestRepeatClearRpPct
+        {
+            set { SetSetting("WorldQuestRepeatClearRpPct", value); }
+            get { return TryGetSetting("WorldQuestRepeatClearRpPct", _WorldQuestRepeatClearRpPct); }
+        }
+        private const double _WorldQuestRepeatClearRpPct = 1.0;
+
+        /// <summary>
+        /// Gold reward ratio for repeat world quest clears (0.0 = none, 1.0 = full).
+        /// Only applies when WorldQuestFirstClearRewards = true.
+        /// </summary>
+        [DefaultValue(_WorldQuestRepeatClearGoldPct)]
+        public double WorldQuestRepeatClearGoldPct
+        {
+            set { SetSetting("WorldQuestRepeatClearGoldPct", value); }
+            get { return TryGetSetting("WorldQuestRepeatClearGoldPct", _WorldQuestRepeatClearGoldPct); }
+        }
+        private const double _WorldQuestRepeatClearGoldPct = 1.0;
+
+        /// <summary>
+        /// Job Points reward ratio for repeat world quest clears (0.0 = none, 1.0 = full).
+        /// Only applies when WorldQuestFirstClearRewards = true.
+        /// </summary>
+        [DefaultValue(_WorldQuestRepeatClearJpPct)]
+        public double WorldQuestRepeatClearJpPct
+        {
+            set { SetSetting("WorldQuestRepeatClearJpPct", value); }
+            get { return TryGetSetting("WorldQuestRepeatClearJpPct", _WorldQuestRepeatClearJpPct); }
+        }
+        private const double _WorldQuestRepeatClearJpPct = 1.0;
     }
 }

--- a/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
@@ -67,6 +67,11 @@ namespace Arrowgene.Ddon.Shared.Asset
         public bool Discoverable { get; set; }
         public List<QuestRewardItem> RewardItems;
         public List<QuestWalletReward> RewardCurrency;
+
+        // Repeat-clear rewards (used when WorldQuestFirstClearRewards is enabled and player has already cleared this period)
+        public List<QuestRewardItem> RepeatClearRewardItems;
+        public List<QuestWalletReward> RepeatClearRewardCurrency;
+        public List<QuestPointReward> RepeatClearPointRewards;
         public List<QuestOrderCondition> OrderConditions;
         public bool ResetPlayerAfterQuest { get; set; }
         public List<QuestLayoutFlag> QuestLayoutFlags { get; set; }
@@ -88,6 +93,9 @@ namespace Arrowgene.Ddon.Shared.Asset
             PointRewards = new List<QuestPointReward>();
             RewardItems = new List<QuestRewardItem>();
             RewardCurrency = new List<QuestWalletReward>();
+            RepeatClearRewardItems = new List<QuestRewardItem>();
+            RepeatClearRewardCurrency = new List<QuestWalletReward>();
+            RepeatClearPointRewards = new List<QuestPointReward>();
             QuestLayoutFlags = new List<QuestLayoutFlag>();
             QuestLayoutSetInfoFlags = new List<QuestLayoutFlagSetInfo>();
             EnemyGroups = new Dictionary<uint, QuestEnemyGroup>();

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -340,6 +340,20 @@ namespace Arrowgene.Ddon.Shared.AssetReader
                 var rewardType = reward.GetProperty("type").GetString();
                 switch (rewardType)
                 {
+                    case "repeat":
+                    {
+                        var repeatItem = new QuestRandomFixedRewardItem();
+                        foreach (var item in reward.GetProperty("loot_pool").EnumerateArray())
+                        {
+                            repeatItem.LootPool.Add(new FixedLootPoolItem()
+                            {
+                                ItemId = AssetCommonDeserializer.ParseItemId(item.GetProperty("item_id")),
+                                Num = item.GetProperty("num").GetUInt16(),
+                            });
+                        }
+                        assetData.RepeatClearRewardItems.Add(repeatItem);
+                        break;
+                    }
                     case "fixed":
                     case "random":
                     case "select":

--- a/Arrowgene.Ddon.Shared/Model/Character.cs
+++ b/Arrowgene.Ddon.Shared/Model/Character.cs
@@ -135,6 +135,7 @@ namespace Arrowgene.Ddon.Shared.Model
         public uint NextBBMStageId {  get; set; }
         public uint MaxBazaarExhibits { get; set; }
         public Dictionary<QuestId, CompletedQuest> CompletedQuests { get; set; }
+        public HashSet<uint> WorldQuestPeriodFirstClears { get; set; } = new();
         public uint LastSafeStageId { get; set; }
         public uint ClanId { get; set; }
         public ClanName ClanName { get; set; }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestRewardType.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestRewardType.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Arrowgene.Ddon.Shared.Model.Quest
 {
     public enum QuestRewardType : uint

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
@@ -269,6 +269,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         public uint QuestScheduleId { get; set; }
         public int NumRandomRewards { get; set; }
         public List<int> RandomRewardIndices { get; set; }
+        public bool IsRepeatReward { get; set; }
 
         public QuestBoxRewards()
         {

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -199,6 +199,7 @@ namespace Arrowgene.Ddon.Test.Database
         public bool DeleteAccount(int accountId) { return true; }
         public int DeleteBazaarExhibition(ulong bazaarId) { return 1; }
         public bool DeleteBoxRewardItem(uint commonId, uint uniqId, DbConnection? connectionIn = null) { return true; }
+        public bool DeleteAllWorldQuestFirstClears(DbConnection? connectionIn = null) { return true; }
         public bool DeleteCharacter(uint characterId) { return true; }
         public bool DeleteCommunicationShortcut(uint characterId, uint pageNo, uint buttonNo) { return true; }
         public bool DeleteConnection(int serverId, int accountId) { return true; }
@@ -238,6 +239,9 @@ namespace Arrowgene.Ddon.Test.Database
         public List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null) { return new List<QuestProgress>(); }
         public ulong InsertBazaarExhibition(BazaarExhibition exhibition) { return 1; }
         public bool InsertBoxRewardItems(uint commonId, QuestBoxRewards rewards, DbConnection? connectionIn = null) { return true; }
+        public bool InsertWorldQuestFirstClear(uint commonId, uint questId, DbConnection? connectionIn = null) { return true; }
+        public bool HasWorldQuestFirstClear(uint commonId, uint questId, DbConnection? connectionIn = null) { return false; }
+        public HashSet<uint> SelectWorldQuestFirstClears(uint commonId, DbConnection? connectionIn = null) { return new(); }
         public bool InsertCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut, DbConnection? connectionIn = null) { return true; }
         public bool InsertConnection(Connection connection) { return true; }
         public int InsertContact(uint requestingCharacterId, uint requestedCharacterId, ContactListStatus status, ContactListType type, bool requesterFavorite, bool requestedFavorite) { return 1; }

--- a/docs/quests/generic_quest_state_machine.md
+++ b/docs/quests/generic_quest_state_machine.md
@@ -236,6 +236,29 @@ Next we can define the rewards. The rewards have a variable format depending on 
 - If the type is `select` it will describe a reward where 1 item can be selected.
 - If the type is `random` it will describe a reward where 1 random item will be selected.
 - If the type is `fixed` it will always reward the fixed item.
+- If the type is `repeat` it defines the item pool given to players on repeat clears of the quest within the same period.
+
+When a player completes a world quest for the first time in a period, they receive the normal first-clear rewards. On every subsequent clear within that same period, they receive one item drawn at random from the `repeat` pool instead.
+
+If no `repeat` reward is defined on the quest, the server automatically constructs one by combining all items from the `select` and `random` reward pools into a single flat pool and drawing one item at random. This means most quests do not need an explicit `repeat` reward unless the designer wants a different pool from the first-clear rewards.
+
+The `repeat` reward accepts a `loot_pool` array with the same format as `fixed` and `select`. One item is chosen at random from the pool each time the reward is granted.
+
+```json
+{
+    "type": "repeat",
+    "loot_pool": [
+        {
+            "item_id": 95,
+            "num": 1
+        },
+        {
+            "item_id": 58,
+            "num": 3
+        }
+    ]
+}
+```
 
 Putting this all together, we will get a reward list which looks like
 ```json


### PR DESCRIPTION
- Added support to handle randomization of quest rewards on repeat clears.
- Added support to configure reduction of point rewards on repeat clears.
- Once the world quest task fires, full rewards will be available until first clear for that period again.

DB Migration 57 -> 58
