### PR TITLE
fixes: Server fixes from Dogma Rising Server

### DIFF
--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -99,14 +99,9 @@ public partial class DdonSqlDb : SqlDb
 
     private readonly string SqlUpdatePartnerPawnId = "UPDATE \"ddon_character\" SET \"partner_pawn_id\" = @partner_pawn_id WHERE \"character_id\" = @character_id;";
 
-    // Batch fetch: all completed quests for a character in one round-trip.
-    // Replaces the per-QuestType loop in QueryCharacterData.
     private readonly string SqlSelectAllCompletedQuests =
         $"SELECT {BuildQueryField(CompletedQuestsFields)} FROM \"ddon_completed_quests\" WHERE \"character_common_id\" = @character_common_id;";
 
-    // Local copies of field arrays from other partial files used for batch storage item loading.
-    // Cannot reference those static fields directly here due to C# static initializer ordering
-    // across partial class files — same pattern used in DdonSqlDb_CharacterCommon.cs.
     private static readonly string[] StorageItemFieldsForCharacter = new[]
     {
         "item_uid", "item_id", "safety", "color", "plus_value", "equip_points"
@@ -122,11 +117,11 @@ public partial class DdonSqlDb : SqlDb
         "item_uid", "effect_id", "unk1", "effect_type", "unk0"
     };
 
-    private static readonly string SqlSelectStorageCrestDataByUIdsBase =
-        $"SELECT {BuildQueryField(CrestFieldsForCharacter)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\"";
+    private static readonly string SqlSelectStorageCrestDataByCharacter =
+        $"SELECT {BuildQueryField(CrestFieldsForCharacter)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id;";
 
-    private static readonly string SqlSelectStorageLimitBreakByUIdsBase =
-        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsForCharacter)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\"";
+    private static readonly string SqlSelectStorageLimitBreakByCharacter =
+        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsForCharacter)} FROM \"ddon_equipment_limit_break\" WHERE \"character_id\" = @character_id;";
 
     public override bool CreateCharacter(Character character)
     {
@@ -271,7 +266,7 @@ public partial class DdonSqlDb : SqlDb
 
     private void QueryCharacterData(DbConnection conn, Character character)
     {
-        QueryCharacterCommonData(conn, character);
+        QueryCharacterCommonData(conn, character, character.CharacterId);
 
         // Shortcuts
         ExecuteReader(conn, SqlSelectShortcuts,
@@ -328,17 +323,10 @@ public partial class DdonSqlDb : SqlDb
 
         if (storageRows.Count > 0)
         {
-            string[] storageUids = storageRows.Select(r => r.Item.UId).Distinct().ToArray();
-            var (storageUidsClause, bindStorageUids) = PrepareArrayParameter("uids", storageUids);
-
             var crestMap = new Dictionary<string, List<CDataEquipElementParam>>();
             using DbConnection crestConn = OpenNewConnection();
-            ExecuteReader(crestConn, $"{SqlSelectStorageCrestDataByUIdsBase} {storageUidsClause}",
-                command =>
-                {
-                    AddParameter(command, "@character_common_id", character.CommonId);
-                    bindStorageUids(command);
-                },
+            ExecuteReader(crestConn, SqlSelectStorageCrestDataByCharacter,
+                command => { AddParameter(command, "@character_common_id", character.CommonId); },
                 reader =>
                 {
                     while (reader.Read())
@@ -352,8 +340,8 @@ public partial class DdonSqlDb : SqlDb
 
             var limitBreakMap = new Dictionary<string, List<CDataAddStatusParam>>();
             using DbConnection limitBreakConn = OpenNewConnection();
-            ExecuteReader(limitBreakConn, $"{SqlSelectStorageLimitBreakByUIdsBase} {storageUidsClause}",
-                command => { bindStorageUids(command); },
+            ExecuteReader(limitBreakConn, SqlSelectStorageLimitBreakByCharacter,
+                command => { AddParameter(command, "@character_id", character.CharacterId); },
                 reader =>
                 {
                     while (reader.Read())

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -122,13 +122,11 @@ public partial class DdonSqlDb : SqlDb
         "item_uid", "effect_id", "unk1", "effect_type", "unk0"
     };
 
-    // Batch fetch: all crests for a character's storage items in one round-trip.
-    private static readonly string SqlSelectStorageCrestDataByUIds =
-        $"SELECT {BuildQueryField(CrestFieldsForCharacter)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\" = ANY(@uids);";
+    private static readonly string SqlSelectStorageCrestDataByUIdsBase =
+        $"SELECT {BuildQueryField(CrestFieldsForCharacter)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\"";
 
-    // Batch fetch: all limit break records for a set of storage item UIDs in one round-trip.
-    private static readonly string SqlSelectStorageLimitBreakByUIds =
-        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsForCharacter)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\" = ANY(@uids);";
+    private static readonly string SqlSelectStorageLimitBreakByUIdsBase =
+        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsForCharacter)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\"";
 
     public override bool CreateCharacter(Character character)
     {
@@ -331,14 +329,15 @@ public partial class DdonSqlDb : SqlDb
         if (storageRows.Count > 0)
         {
             string[] storageUids = storageRows.Select(r => r.Item.UId).Distinct().ToArray();
+            var (storageUidsClause, bindStorageUids) = PrepareArrayParameter("uids", storageUids);
 
             var crestMap = new Dictionary<string, List<CDataEquipElementParam>>();
             using DbConnection crestConn = OpenNewConnection();
-            ExecuteReader(crestConn, SqlSelectStorageCrestDataByUIds,
+            ExecuteReader(crestConn, $"{SqlSelectStorageCrestDataByUIdsBase} {storageUidsClause}",
                 command =>
                 {
                     AddParameter(command, "@character_common_id", character.CommonId);
-                    AddParameter(command, "@uids", storageUids);
+                    bindStorageUids(command);
                 },
                 reader =>
                 {
@@ -353,8 +352,8 @@ public partial class DdonSqlDb : SqlDb
 
             var limitBreakMap = new Dictionary<string, List<CDataAddStatusParam>>();
             using DbConnection limitBreakConn = OpenNewConnection();
-            ExecuteReader(limitBreakConn, SqlSelectStorageLimitBreakByUIds,
-                command => { AddParameter(command, "@uids", storageUids); },
+            ExecuteReader(limitBreakConn, $"{SqlSelectStorageLimitBreakByUIdsBase} {storageUidsClause}",
+                command => { bindStorageUids(command); },
                 reader =>
                 {
                     while (reader.Read())

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacter.cs
@@ -99,6 +99,37 @@ public partial class DdonSqlDb : SqlDb
 
     private readonly string SqlUpdatePartnerPawnId = "UPDATE \"ddon_character\" SET \"partner_pawn_id\" = @partner_pawn_id WHERE \"character_id\" = @character_id;";
 
+    // Batch fetch: all completed quests for a character in one round-trip.
+    // Replaces the per-QuestType loop in QueryCharacterData.
+    private readonly string SqlSelectAllCompletedQuests =
+        $"SELECT {BuildQueryField(CompletedQuestsFields)} FROM \"ddon_completed_quests\" WHERE \"character_common_id\" = @character_common_id;";
+
+    // Local copies of field arrays from other partial files used for batch storage item loading.
+    // Cannot reference those static fields directly here due to C# static initializer ordering
+    // across partial class files — same pattern used in DdonSqlDb_CharacterCommon.cs.
+    private static readonly string[] StorageItemFieldsForCharacter = new[]
+    {
+        "item_uid", "item_id", "safety", "color", "plus_value", "equip_points"
+    };
+
+    private static readonly string[] CrestFieldsForCharacter = new[]
+    {
+        "character_common_id", "item_uid", "slot", "crest_id", "crest_amount"
+    };
+
+    private static readonly string[] EquipmentLimitBreakFieldsForCharacter = new[]
+    {
+        "item_uid", "effect_id", "unk1", "effect_type", "unk0"
+    };
+
+    // Batch fetch: all crests for a character's storage items in one round-trip.
+    private static readonly string SqlSelectStorageCrestDataByUIds =
+        $"SELECT {BuildQueryField(CrestFieldsForCharacter)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\" = ANY(@uids);";
+
+    // Batch fetch: all limit break records for a set of storage item UIDs in one round-trip.
+    private static readonly string SqlSelectStorageLimitBreakByUIds =
+        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsForCharacter)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\" = ANY(@uids);";
+
     public override bool CreateCharacter(Character character)
     {
         return ExecuteInTransaction(conn =>
@@ -271,44 +302,84 @@ public partial class DdonSqlDb : SqlDb
                     character.Storage.AddStorage(tuple.Item1, tuple.Item2);
                 }
             });
+
+        // Materialize storage item rows before running batch crest/limit-break queries.
+        var storageRows = new List<(StorageType StorageType, ushort Slot, uint ItemNum, Item Item)>();
         ExecuteReader(conn, SqlSelectStorageItemsByCharacter,
-            (Action<DbCommand>)(command2 => { AddParameter(command2, "@character_id", character.CharacterId); }),
-            reader2 =>
+            (Action<DbCommand>)(command => { AddParameter(command, "@character_id", character.CharacterId); }),
+            reader =>
             {
-                while (reader2.Read())
+                while (reader.Read())
                 {
-                    StorageType storageType = (StorageType)GetByte(reader2, "storage_type");
-                    ushort slot = GetUInt16(reader2, "slot_no");
-                    uint itemNum = GetUInt32(reader2, "item_num");
-                    Item item = new();
-
-                    item.UId = GetString(reader2, "item_uid");
-                    item.ItemId = GetUInt32(reader2, "item_id");
-                    item.SafetySetting = GetByte(reader2, "safety");
-                    item.Color = GetByte(reader2, "color");
-                    item.PlusValue = GetByte(reader2, "plus_value");
-                    item.EquipPoints = GetUInt32(reader2, "equip_points");
-
-                    using DbConnection connection = OpenNewConnection();
-                    ExecuteReader(connection, SqlSelectAllCrestData,
-                        command4 =>
+                    storageRows.Add((
+                        (StorageType)GetByte(reader, "storage_type"),
+                        GetUInt16(reader, "slot_no"),
+                        GetUInt32(reader, "item_num"),
+                        new Item
                         {
-                            AddParameter(command4, "character_common_id", character.CommonId);
-                            AddParameter(command4, "item_uid", item.UId);
-                        }, reader4 =>
-                        {
-                            while (reader4.Read())
-                            {
-                                Crest result = ReadCrestData(reader4);
-                                item.EquipElementParamList.Add(result.ToCDataEquipElementParam());
-                            }
-                        });
-
-                    item.AddStatusParamList = GetEquipmentLimitBreakRecord(item.UId, connection);
-
-                    character.Storage.GetStorage(storageType).SetItem(item, itemNum, slot);
+                            UId           = GetString(reader, "item_uid"),
+                            ItemId        = GetUInt32(reader, "item_id"),
+                            SafetySetting = GetByte(reader, "safety"),
+                            Color         = GetByte(reader, "color"),
+                            PlusValue     = GetByte(reader, "plus_value"),
+                            EquipPoints   = GetUInt32(reader, "equip_points")
+                        }
+                    ));
                 }
             });
+
+        if (storageRows.Count > 0)
+        {
+            string[] storageUids = storageRows.Select(r => r.Item.UId).Distinct().ToArray();
+
+            var crestMap = new Dictionary<string, List<CDataEquipElementParam>>();
+            using DbConnection crestConn = OpenNewConnection();
+            ExecuteReader(crestConn, SqlSelectStorageCrestDataByUIds,
+                command =>
+                {
+                    AddParameter(command, "@character_common_id", character.CommonId);
+                    AddParameter(command, "@uids", storageUids);
+                },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        string uid = GetString(reader, "item_uid");
+                        if (!crestMap.TryGetValue(uid, out var list))
+                            crestMap[uid] = list = new List<CDataEquipElementParam>();
+                        list.Add(ReadCrestData(reader).ToCDataEquipElementParam());
+                    }
+                });
+
+            var limitBreakMap = new Dictionary<string, List<CDataAddStatusParam>>();
+            using DbConnection limitBreakConn = OpenNewConnection();
+            ExecuteReader(limitBreakConn, SqlSelectStorageLimitBreakByUIds,
+                command => { AddParameter(command, "@uids", storageUids); },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        string uid = GetString(reader, "item_uid");
+                        if (!limitBreakMap.TryGetValue(uid, out var list))
+                            limitBreakMap[uid] = list = new List<CDataAddStatusParam>();
+                        list.Add(new CDataAddStatusParam
+                        {
+                            EnhanceId   = GetUInt16(reader, "effect_id"),
+                            Unk1        = GetUInt16(reader, "unk1"),
+                            EnhanceType = (EquipEnhanceType)GetByte(reader, "effect_type"),
+                            Unk0        = GetByte(reader, "unk0")
+                        });
+                    }
+                });
+
+            foreach (var (storageType, slot, itemNum, item) in storageRows)
+            {
+                if (crestMap.TryGetValue(item.UId, out var crests))
+                    item.EquipElementParamList.AddRange(crests);
+                item.AddStatusParamList = limitBreakMap.GetValueOrDefault(item.UId, new List<CDataAddStatusParam>());
+                character.Storage.GetStorage(storageType).SetItem(item, itemNum, slot);
+            }
+        }
 
         // Wallet Points
         ExecuteReader(conn, SqlSelectWalletPoints,
@@ -350,29 +421,25 @@ public partial class DdonSqlDb : SqlDb
                 while (reader.Read()) character.AbilityPresets.Add(ReadAbilityPreset(reader));
             });
 
-        // Quest Completion
-        foreach (QuestType questType in Enum.GetValues<QuestType>())
-            ExecuteReader(conn, SqlSelectCompletedQuestByType,
-                command =>
+        // Quest Completion - single query for all types, replaces per-QuestType loop.
+        // QuestType is read directly from the stored column, identical end result to vanilla.
+        ExecuteReader(conn, SqlSelectAllCompletedQuests,
+            command => { AddParameter(command, "@character_common_id", character.CommonId); },
+            reader =>
+            {
+                while (reader.Read())
                 {
-                    AddParameter(command, "@character_common_id", character.CommonId);
-                    AddParameter(command, "@quest_type", (uint)questType);
-                }, reader =>
-                {
-                    while (reader.Read())
+                    CompletedQuest quest = new()
                     {
-                        CompletedQuest quest = new()
-                        {
-                            QuestId = (QuestId)GetUInt32(reader, "quest_id"),
-                            QuestType = questType,
-                            ClearCount = GetUInt32(reader, "clear_count")
-                        };
+                        QuestId    = (QuestId)GetUInt32(reader, "quest_id"),
+                        QuestType  = (QuestType)GetUInt32(reader, "quest_type"),
+                        ClearCount = GetUInt32(reader, "clear_count")
+                    };
+                    character.CompletedQuests.TryAdd(quest.QuestId, quest);
+                }
+            });
 
-                        character.CompletedQuests.TryAdd(quest.QuestId, quest);
-                    }
-                });
-
-        //Clan membership
+        // Clan membership
         character.ClanId = SelectClanMembershipByCharacterId(character.CharacterId, conn);
         character.ClanName = GetClanNameByClanId(character.ClanId);
 
@@ -470,7 +537,7 @@ public partial class DdonSqlDb : SqlDb
                     continue;
 
                 // Give starter weapon for all classes
-                // If creating a character for normal mode, Wwe are only interested in slot 1 and 2
+                // If creating a character for normal mode, we are only interested in slot 1 and 2
                 for (byte i = 0; i < 2; i++)
                 {
                     Item item = jobEquipment.Value[EquipType.Performance][i];
@@ -512,7 +579,7 @@ public partial class DdonSqlDb : SqlDb
         }
     }
 
-    //Helper function to add specific items to a storage
+    // Helper function to add specific items to a storage
     public override void CreateListItems(DbConnection conn, Character character, StorageType storageType, List<(uint ItemId, uint Amount)> itemList)
     {
         Storage itemType = character.Storage.GetAllStorages()[storageType];
@@ -533,11 +600,7 @@ public partial class DdonSqlDb : SqlDb
     /// <summary>
     /// TODO: Optimize connection handling here and avoid nested loops re-using a single connection which is not supported with Npgsql.
     ///     Temporary workaround: Open a new connection for each nested read.
-    /// 
     /// </summary>
-    /// <param name="connection"></param>
-    /// <param name="characterId"></param>
-    /// <returns></returns>
     public Storages SelectAllStoragesByCharacterId(DbConnection connection, uint characterId)
     {
         Storages storages = new(new Dictionary<StorageType, ushort>());
@@ -643,8 +706,6 @@ public partial class DdonSqlDb : SqlDb
         character.MatchingProfile.PlayStyle = GetUInt32(reader, "play_style");
         character.MatchingProfile.Comment = GetString(reader, "comment");
         character.MatchingProfile.IsJoinParty = GetBoolean(reader, "is_join_party");
-
-        
 
         character.FavWarpSlotNum = GetUInt32(reader, "fav_warp_slot_num");
 

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -98,11 +98,11 @@ public partial class DdonSqlDb : SqlDb
     private static readonly string SqlSelectStorageItemsByUIdsBase =
         $"SELECT {BuildQueryField(StorageItemFieldsLocal)} FROM \"ddon_storage_item\" WHERE \"item_uid\"";
 
-    private static readonly string SqlSelectCrestDataByUIdsBase =
-        $"SELECT {BuildQueryField(CrestFieldsLocal)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\"";
+    private static readonly string SqlSelectCrestDataByCharacter =
+        $"SELECT {BuildQueryField(CrestFieldsLocal)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id;";
 
-    private static readonly string SqlSelectEquipmentLimitBreakByUIdsBase =
-        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsLocal)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\"";
+    private static readonly string SqlSelectEquipmentLimitBreakByCharacter =
+        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsLocal)} FROM \"ddon_equipment_limit_break\" WHERE \"character_id\" = @character_id;";
 
 
     public override bool UpdateCharacterCommonBaseInfo(CharacterCommon common, DbConnection? connectionIn = null)
@@ -155,7 +155,7 @@ public partial class DdonSqlDb : SqlDb
         });
     }
 
-    private void QueryCharacterCommonData(DbConnection conn, CharacterCommon common)
+    private void QueryCharacterCommonData(DbConnection conn, CharacterCommon common, uint characterId)
     {
         // Job data
         ExecuteReader(conn, SqlSelectCharacterJobDataByCharacter,
@@ -189,7 +189,7 @@ public partial class DdonSqlDb : SqlDb
             var equipItemMap = new Dictionary<string, Item>();
             using DbConnection equipItemConn = OpenNewConnection();
             ExecuteReader(equipItemConn, $"{SqlSelectStorageItemsByUIdsBase} {equipUidsClause}",
-                command => { bindEquipUids(command); },
+                bindEquipUids,
                 reader =>
                 {
                     while (reader.Read())
@@ -209,12 +209,8 @@ public partial class DdonSqlDb : SqlDb
 
             var crestMap = new Dictionary<string, List<CDataEquipElementParam>>();
             using DbConnection crestConn = OpenNewConnection();
-            ExecuteReader(crestConn, $"{SqlSelectCrestDataByUIdsBase} {equipUidsClause}",
-                command =>
-                {
-                    AddParameter(command, "@character_common_id", common.CommonId);
-                    bindEquipUids(command);
-                },
+            ExecuteReader(crestConn, SqlSelectCrestDataByCharacter,
+                command => { AddParameter(command, "@character_common_id", common.CommonId); },
                 reader =>
                 {
                     while (reader.Read())
@@ -228,8 +224,8 @@ public partial class DdonSqlDb : SqlDb
 
             var limitBreakMap = new Dictionary<string, List<CDataAddStatusParam>>();
             using DbConnection limitBreakConn = OpenNewConnection();
-            ExecuteReader(limitBreakConn, $"{SqlSelectEquipmentLimitBreakByUIdsBase} {equipUidsClause}",
-                command => { bindEquipUids(command); },
+            ExecuteReader(limitBreakConn, SqlSelectEquipmentLimitBreakByCharacter,
+                command => { AddParameter(command, "@character_id", characterId); },
                 reader =>
                 {
                     while (reader.Read())

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -95,17 +95,14 @@ public partial class DdonSqlDb : SqlDb
         "item_uid", "effect_id", "unk1", "effect_type", "unk0"
     };
 
-    // Batch fetch: all storage items for a set of UIDs in one round-trip (Postgres ANY array syntax)
-    private static readonly string SqlSelectStorageItemsByUIds =
-        $"SELECT {BuildQueryField(StorageItemFieldsLocal)} FROM \"ddon_storage_item\" WHERE \"item_uid\" = ANY(@uids);";
+    private static readonly string SqlSelectStorageItemsByUIdsBase =
+        $"SELECT {BuildQueryField(StorageItemFieldsLocal)} FROM \"ddon_storage_item\" WHERE \"item_uid\"";
 
-    // Batch fetch: all crests for a character's set of item UIDs in one round-trip
-    private static readonly string SqlSelectCrestDataByUIds =
-        $"SELECT {BuildQueryField(CrestFieldsLocal)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\" = ANY(@uids);";
+    private static readonly string SqlSelectCrestDataByUIdsBase =
+        $"SELECT {BuildQueryField(CrestFieldsLocal)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\"";
 
-    // Batch fetch: all limit break records for a set of item UIDs in one round-trip
-    private static readonly string SqlSelectEquipmentLimitBreakByUIds =
-        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsLocal)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\" = ANY(@uids);";
+    private static readonly string SqlSelectEquipmentLimitBreakByUIdsBase =
+        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsLocal)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\"";
 
 
     public override bool UpdateCharacterCommonBaseInfo(CharacterCommon common, DbConnection? connectionIn = null)
@@ -187,10 +184,12 @@ public partial class DdonSqlDb : SqlDb
         {
             string[] equipUids = equipSlots.Where(e => e.UId != null).Select(e => e.UId!).Distinct().ToArray();
 
+            var (equipUidsClause, bindEquipUids) = PrepareArrayParameter("uids", equipUids);
+
             var equipItemMap = new Dictionary<string, Item>();
             using DbConnection equipItemConn = OpenNewConnection();
-            ExecuteReader(equipItemConn, SqlSelectStorageItemsByUIds,
-                command => { AddParameter(command, "@uids", (string[])equipUids); },
+            ExecuteReader(equipItemConn, $"{SqlSelectStorageItemsByUIdsBase} {equipUidsClause}",
+                command => { bindEquipUids(command); },
                 reader =>
                 {
                     while (reader.Read())
@@ -210,11 +209,11 @@ public partial class DdonSqlDb : SqlDb
 
             var crestMap = new Dictionary<string, List<CDataEquipElementParam>>();
             using DbConnection crestConn = OpenNewConnection();
-            ExecuteReader(crestConn, SqlSelectCrestDataByUIds,
+            ExecuteReader(crestConn, $"{SqlSelectCrestDataByUIdsBase} {equipUidsClause}",
                 command =>
                 {
-                    AddParameter(command, "character_common_id", common.CommonId);
-                    AddParameter(command, "@uids", (string[])equipUids);
+                    AddParameter(command, "@character_common_id", common.CommonId);
+                    bindEquipUids(command);
                 },
                 reader =>
                 {
@@ -229,8 +228,8 @@ public partial class DdonSqlDb : SqlDb
 
             var limitBreakMap = new Dictionary<string, List<CDataAddStatusParam>>();
             using DbConnection limitBreakConn = OpenNewConnection();
-            ExecuteReader(limitBreakConn, SqlSelectEquipmentLimitBreakByUIds,
-                command => { AddParameter(command, "@uids", (string[])equipUids); },
+            ExecuteReader(limitBreakConn, $"{SqlSelectEquipmentLimitBreakByUIdsBase} {equipUidsClause}",
+                command => { bindEquipUids(command); },
                 reader =>
                 {
                     while (reader.Read())
@@ -283,11 +282,12 @@ public partial class DdonSqlDb : SqlDb
         if (jobItemSlots.Count > 0)
         {
             string[] jobUids = jobItemSlots.Where(e => e.UId != null).Select(e => e.UId!).Distinct().ToArray();
+            var (jobUidsClause, bindJobUids) = PrepareArrayParameter("uids", jobUids);
 
             var jobItemMap = new Dictionary<string, Item>();
             using DbConnection jobItemConn = OpenNewConnection();
-            ExecuteReader(jobItemConn, SqlSelectStorageItemsByUIds,
-                command => { AddParameter(command, "@uids", (string[])jobUids); },
+            ExecuteReader(jobItemConn, $"{SqlSelectStorageItemsByUIdsBase} {jobUidsClause}",
+                command => { bindJobUids(command); },
                 reader =>
                 {
                     while (reader.Read())

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -68,13 +68,44 @@ public partial class DdonSqlDb : SqlDb
         $"UPDATE \"ddon_character_common\" SET {BuildQueryUpdate(CharacterCommonFields)} WHERE \"character_common_id\" = @character_common_id;";
 
     private static readonly string SqlSelectCharacterProfile =
-    $"SELECT {BuildQueryField(CDataProfileFields)} FROM \"ddon_character_profile\" WHERE \"character_common_id\" = @character_common_id;";
+        $"SELECT {BuildQueryField(CDataProfileFields)} FROM \"ddon_character_profile\" WHERE \"character_common_id\" = @character_common_id;";
 
     private readonly string SqlInsertCharacterProfile =
         $"INSERT INTO \"ddon_character_profile\" ({BuildQueryField(CDataProfileFields)}) VALUES ({BuildQueryInsert(CDataProfileFields)});";
 
     private static readonly string SqlUpdateCharacterProfile =
         $"UPDATE \"ddon_character_profile\" SET {BuildQueryUpdate(CDataProfileFields)} WHERE \"character_common_id\" = @character_common_id;";
+
+    // Local copies of field arrays from other partial files.
+    // We cannot reference those static fields directly here because C# does not
+    // guarantee static initializer order across partial class files, which causes
+    // a type initializer exception at startup if this file initializes first.
+    private static readonly string[] StorageItemFieldsLocal = new[]
+    {
+        "item_uid", "item_id", "safety", "color", "plus_value", "equip_points"
+    };
+
+    private static readonly string[] CrestFieldsLocal = new[]
+    {
+        "character_common_id", "item_uid", "slot", "crest_id", "crest_amount"
+    };
+
+    private static readonly string[] EquipmentLimitBreakFieldsLocal = new[]
+    {
+        "item_uid", "effect_id", "unk1", "effect_type", "unk0"
+    };
+
+    // Batch fetch: all storage items for a set of UIDs in one round-trip (Postgres ANY array syntax)
+    private static readonly string SqlSelectStorageItemsByUIds =
+        $"SELECT {BuildQueryField(StorageItemFieldsLocal)} FROM \"ddon_storage_item\" WHERE \"item_uid\" = ANY(@uids);";
+
+    // Batch fetch: all crests for a character's set of item UIDs in one round-trip
+    private static readonly string SqlSelectCrestDataByUIds =
+        $"SELECT {BuildQueryField(CrestFieldsLocal)} FROM \"ddon_crests\" WHERE \"character_common_id\" = @character_common_id AND \"item_uid\" = ANY(@uids);";
+
+    // Batch fetch: all limit break records for a set of item UIDs in one round-trip
+    private static readonly string SqlSelectEquipmentLimitBreakByUIds =
+        $"SELECT {BuildQueryField(EquipmentLimitBreakFieldsLocal)} FROM \"ddon_equipment_limit_break\" WHERE \"item_uid\" = ANY(@uids);";
 
 
     public override bool UpdateCharacterCommonBaseInfo(CharacterCommon common, DbConnection? connectionIn = null)
@@ -84,7 +115,6 @@ public partial class DdonSqlDb : SqlDb
         try
         {
             int commonUpdateRowsAffected = ExecuteNonQuery(connection, SqlUpdateCharacterCommon, command => { AddParameter(command, common); });
-
             return commonUpdateRowsAffected > NoRowsAffected;
         }
         finally
@@ -102,7 +132,6 @@ public partial class DdonSqlDb : SqlDb
     public bool UpdateEditInfo(DbConnection conn, CharacterCommon common)
     {
         int commonUpdateRowsAffected = ExecuteNonQuery(conn, SqlUpdateEditInfo, command => { AddParameter(command, common); });
-
         return commonUpdateRowsAffected > NoRowsAffected;
     }
 
@@ -115,7 +144,6 @@ public partial class DdonSqlDb : SqlDb
     public bool UpdateStatusInfo(DbConnection conn, CharacterCommon common)
     {
         int commonUpdateRowsAffected = ExecuteNonQuery(conn, SqlUpdateStatusInfo, command => { AddParameter(command, common); });
-
         return commonUpdateRowsAffected > NoRowsAffected;
     }
 
@@ -134,93 +162,165 @@ public partial class DdonSqlDb : SqlDb
     {
         // Job data
         ExecuteReader(conn, SqlSelectCharacterJobDataByCharacter,
-            command => { AddParameter(command, "@character_common_id", common.CommonId); }, reader =>
+            command => { AddParameter(command, "@character_common_id", common.CommonId); },
+            reader =>
             {
                 while (reader.Read()) common.CharacterJobDataList.Add(ReadCharacterJobData(reader));
             });
 
-        // Equips
+        // Materialize equip slot records before running batch item/crest/limit-break queries.
+        var equipSlots = new List<(string? UId, JobId Job, EquipType EquipType, byte EquipSlot)>();
         ExecuteReader(conn, SqlSelectEquipItemByCharacter,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
             {
                 while (reader.Read())
-                {
-                    string UId = GetString(reader, "item_uid");
-                    JobId job = (JobId)GetByte(reader, "job");
-                    EquipType equipType = (EquipType)GetByte(reader, "equip_type");
-                    byte equipSlot = GetByte(reader, "equip_slot");
-
-                    using DbConnection connection = OpenNewConnection();
-                    ExecuteReader(connection, SqlSelectStorageItemsByUId,
-                        command2 => { AddParameter(command2, "@item_uid", UId); },
-                        reader2 =>
-                        {
-                            if (reader2.Read())
-                            {
-                                Item item = new();
-                                item.UId = GetString(reader2, "item_uid");
-                                item.ItemId = GetUInt32(reader2, "item_id");
-                                item.SafetySetting = GetByte(reader2, "safety");
-                                item.Color = GetByte(reader2, "color");
-                                item.PlusValue = GetByte(reader2, "plus_value");
-                                item.EquipPoints = GetUInt32(reader2, "equip_points");
-                                using DbConnection connection2 = OpenNewConnection();
-                                ExecuteReader(connection2, SqlSelectAllCrestData,
-                                    command3 =>
-                                    {
-                                        AddParameter(command3, "character_common_id", common.CommonId);
-                                        AddParameter(command3, "item_uid", item.UId);
-                                    }, reader4 =>
-                                    {
-                                        while (reader4.Read())
-                                        {
-                                            Crest result = ReadCrestData(reader4);
-                                            item.EquipElementParamList.Add(result.ToCDataEquipElementParam());
-                                        }
-                                    });
-
-                                using DbConnection connection3 = OpenNewConnection();
-                                item.AddStatusParamList = GetEquipmentLimitBreakRecord(item.UId, connection3);
-
-                                common.EquipmentTemplate.SetEquipItem(item, job, equipType, equipSlot);
-                            }
-                        });
-                }
+                    equipSlots.Add((
+                        GetStringNullable(reader, "item_uid"),
+                        (JobId)GetByte(reader, "job"),
+                        (EquipType)GetByte(reader, "equip_type"),
+                        GetByte(reader, "equip_slot")
+                    ));
             });
 
-        // Job Items
+        if (equipSlots.Count > 0)
+        {
+            string[] equipUids = equipSlots.Where(e => e.UId != null).Select(e => e.UId!).Distinct().ToArray();
+
+            var equipItemMap = new Dictionary<string, Item>();
+            using DbConnection equipItemConn = OpenNewConnection();
+            ExecuteReader(equipItemConn, SqlSelectStorageItemsByUIds,
+                command => { AddParameter(command, "@uids", (string[])equipUids); },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        var item = new Item
+                        {
+                            UId           = GetString(reader, "item_uid"),
+                            ItemId        = GetUInt32(reader, "item_id"),
+                            SafetySetting = GetByte(reader, "safety"),
+                            Color         = GetByte(reader, "color"),
+                            PlusValue     = GetByte(reader, "plus_value"),
+                            EquipPoints   = GetUInt32(reader, "equip_points")
+                        };
+                        equipItemMap[item.UId] = item;
+                    }
+                });
+
+            var crestMap = new Dictionary<string, List<CDataEquipElementParam>>();
+            using DbConnection crestConn = OpenNewConnection();
+            ExecuteReader(crestConn, SqlSelectCrestDataByUIds,
+                command =>
+                {
+                    AddParameter(command, "character_common_id", common.CommonId);
+                    AddParameter(command, "@uids", (string[])equipUids);
+                },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        string uid = GetString(reader, "item_uid");
+                        if (!crestMap.TryGetValue(uid, out var list))
+                            crestMap[uid] = list = new List<CDataEquipElementParam>();
+                        list.Add(ReadCrestData(reader).ToCDataEquipElementParam());
+                    }
+                });
+
+            var limitBreakMap = new Dictionary<string, List<CDataAddStatusParam>>();
+            using DbConnection limitBreakConn = OpenNewConnection();
+            ExecuteReader(limitBreakConn, SqlSelectEquipmentLimitBreakByUIds,
+                command => { AddParameter(command, "@uids", (string[])equipUids); },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        string uid = GetString(reader, "item_uid");
+                        if (!limitBreakMap.TryGetValue(uid, out var list))
+                            limitBreakMap[uid] = list = new List<CDataAddStatusParam>();
+                        list.Add(new CDataAddStatusParam
+                        {
+                            EnhanceId   = GetUInt16(reader, "effect_id"),
+                            Unk1        = GetUInt16(reader, "unk1"),
+                            EnhanceType = (EquipEnhanceType)GetByte(reader, "effect_type"),
+                            Unk0        = GetByte(reader, "unk0")
+                        });
+                    }
+                });
+
+            foreach (var (uid, job, equipType, equipSlot) in equipSlots)
+            {
+                if (string.IsNullOrEmpty(uid))
+                {
+                    common.EquipmentTemplate.SetEquipItem(null, job, equipType, equipSlot);
+                    continue;
+                }
+                if (!equipItemMap.TryGetValue(uid, out Item? item))
+                {
+                    // No storage row found — leave slot as null, same as vanilla silent failure
+                    continue;
+                }
+                if (crestMap.TryGetValue(uid, out var crests))
+                    item.EquipElementParamList.AddRange(crests);
+                item.AddStatusParamList = limitBreakMap.GetValueOrDefault(uid, new List<CDataAddStatusParam>());
+                common.EquipmentTemplate.SetEquipItem(item, job, equipType, equipSlot);
+            }
+        }
+
+        var jobItemSlots = new List<(string? UId, JobId Job, byte EquipSlot)>();
         ExecuteReader(conn, SqlSelectEquipJobItemsByCharacter,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
             {
                 while (reader.Read())
-                {
-                    string UId = GetString(reader, "item_uid");
-                    JobId job = (JobId)GetByte(reader, "job");
-                    byte equipSlot = GetByte(reader, "equip_slot");
-
-                    using DbConnection connection = OpenNewConnection();
-                    ExecuteReader(connection, SqlSelectStorageItemsByUId,
-                        command2 => { AddParameter(command2, "@item_uid", UId); },
-                        reader2 =>
-                        {
-                            if (reader2.Read())
-                            {
-                                Item item = new();
-                                item.UId = GetString(reader2, "item_uid");
-                                item.ItemId = GetUInt32(reader2, "item_id");
-                                item.SafetySetting = GetByte(reader2, "safety");
-                                item.Color = GetByte(reader2, "color");
-                                item.PlusValue = GetByte(reader2, "plus_value");
-                                item.EquipPoints = GetUInt32(reader2, "equip_points");
-                                common.EquipmentTemplate.SetJobItem(item, job, equipSlot);
-                            }
-                        });
-                }
+                    jobItemSlots.Add((
+                        GetStringNullable(reader, "item_uid"),
+                        (JobId)GetByte(reader, "job"),
+                        GetByte(reader, "equip_slot")
+                    ));
             });
 
-        // Normal Skills
+        if (jobItemSlots.Count > 0)
+        {
+            string[] jobUids = jobItemSlots.Where(e => e.UId != null).Select(e => e.UId!).Distinct().ToArray();
+
+            var jobItemMap = new Dictionary<string, Item>();
+            using DbConnection jobItemConn = OpenNewConnection();
+            ExecuteReader(jobItemConn, SqlSelectStorageItemsByUIds,
+                command => { AddParameter(command, "@uids", (string[])jobUids); },
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        var item = new Item
+                        {
+                            UId           = GetString(reader, "item_uid"),
+                            ItemId        = GetUInt32(reader, "item_id"),
+                            SafetySetting = GetByte(reader, "safety"),
+                            Color         = GetByte(reader, "color"),
+                            PlusValue     = GetByte(reader, "plus_value"),
+                            EquipPoints   = GetUInt32(reader, "equip_points")
+                        };
+                        jobItemMap[item.UId] = item;
+                    }
+                });
+
+            foreach (var (uid, job, equipSlot) in jobItemSlots)
+            {
+                if (string.IsNullOrEmpty(uid))
+                {
+                    common.EquipmentTemplate.SetJobItem(null, job, equipSlot);
+                    continue;
+                }
+                if (!jobItemMap.TryGetValue(uid, out Item? item))
+                {
+                    // No storage row found — leave slot as null, same as vanilla silent failure
+                    continue;
+                }
+                common.EquipmentTemplate.SetJobItem(item, job, equipSlot);
+            }
+        }
+
         ExecuteReader(conn, SqlSelectNormalSkillParam,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
@@ -228,13 +328,13 @@ public partial class DdonSqlDb : SqlDb
                 while (reader.Read()) common.LearnedNormalSkills.Add(ReadNormalSkillParam(reader));
             });
 
-        // Custom Skills
         ExecuteReader(conn, SqlSelectLearnedCustomSkills,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
             {
                 while (reader.Read()) common.LearnedCustomSkills.Add(ReadLearnedCustomSkill(reader));
             });
+
         ExecuteReader(conn, SqlSelectEquippedCustomSkills,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
@@ -242,10 +342,12 @@ public partial class DdonSqlDb : SqlDb
                 while (reader.Read())
                 {
                     uint skillId = GetUInt32(reader, "skill_id");
-                    JobId job = (JobId)GetByte(reader, "job");
-                    byte slotNo = GetByte(reader, "slot_no");
+                    JobId job    = (JobId)GetByte(reader, "job");
+                    byte slotNo  = GetByte(reader, "slot_no");
 
-                    CustomSkill? skill = common.LearnedCustomSkills.Where(x => x.Job == job && x.SkillId == skillId).SingleOrDefault();
+                    CustomSkill? skill = common.LearnedCustomSkills
+                        .Where(x => x.Job == job && x.SkillId == skillId)
+                        .SingleOrDefault();
 
                     if (skill is null)
                     {
@@ -257,25 +359,27 @@ public partial class DdonSqlDb : SqlDb
                 }
             });
 
-        // Abilities
         ExecuteReader(conn, SqlSelectLearnedAbilities,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
             {
                 while (reader.Read()) common.LearnedAbilities.Add(ReadLearnedAbility(reader));
             });
+
         ExecuteReader(conn, SqlSelectEquippedAbilities,
             command => { AddParameter(command, "@character_common_id", common.CommonId); },
             reader =>
             {
                 while (reader.Read())
                 {
-                    AbilityId abilityId = (AbilityId)GetUInt32(reader, "ability_id");
-                    JobId job = (JobId)GetByte(reader, "job");
-                    JobId equippedToJob = (JobId)GetByte(reader, "equipped_to_job");
-                    byte slotNo = GetByte(reader, "slot_no");
+                    AbilityId abilityId  = (AbilityId)GetUInt32(reader, "ability_id");
+                    JobId job            = (JobId)GetByte(reader, "job");
+                    JobId equippedToJob  = (JobId)GetByte(reader, "equipped_to_job");
+                    byte slotNo          = GetByte(reader, "slot_no");
 
-                    Ability? aug = common.LearnedAbilities.Where(x => x.Job == job && x.AbilityId == abilityId).SingleOrDefault();
+                    Ability? aug = common.LearnedAbilities
+                        .Where(x => x.Job == job && x.AbilityId == abilityId)
+                        .SingleOrDefault();
 
                     if (aug is null)
                     {
@@ -292,9 +396,11 @@ public partial class DdonSqlDb : SqlDb
 
     private void StoreCharacterCommonData(DbConnection conn, CharacterCommon common)
     {
-        foreach (CDataCharacterJobData characterJobData in common.CharacterJobDataList) ReplaceCharacterJobData(common.CommonId, characterJobData, conn);
+        foreach (CDataCharacterJobData characterJobData in common.CharacterJobDataList)
+            ReplaceCharacterJobData(common.CommonId, characterJobData, conn);
 
-        foreach (CDataNormalSkillParam normalSkillParam in common.LearnedNormalSkills) ReplaceNormalSkillParam(conn, common.CommonId, normalSkillParam);
+        foreach (CDataNormalSkillParam normalSkillParam in common.LearnedNormalSkills)
+            ReplaceNormalSkillParam(conn, common.CommonId, normalSkillParam);
 
         foreach (CustomSkill learnedSkills in common.LearnedCustomSkills)
             ExecuteNonQuery(conn, SqlInsertLearnedCustomSkill, command => { AddParameter(command, common.CommonId, learnedSkills); });
@@ -307,7 +413,8 @@ public partial class DdonSqlDb : SqlDb
                 if (skill != null) ReplaceEquippedCustomSkill(conn, common.CommonId, slotNo, skill);
             }
 
-        foreach (Ability ability in common.LearnedAbilities) ExecuteNonQuery(conn, SqlInsertLearnedAbility, command => { AddParameter(command, common.CommonId, ability); });
+        foreach (Ability ability in common.LearnedAbilities)
+            ExecuteNonQuery(conn, SqlInsertLearnedAbility, command => { AddParameter(command, common.CommonId, ability); });
 
         foreach (KeyValuePair<JobId, List<Ability>> jobAndAugs in common.EquippedAbilitiesDictionary)
         {
@@ -512,6 +619,5 @@ public partial class DdonSqlDb : SqlDb
         AddParameter(command, "@motion_id", common.CharacterProfile.MotionId);
         AddParameter(command, "@motion_frame_no", common.CharacterProfile.MotionFrameNo);
         AddParameter(command, "@comment", common.CharacterProfile.Comment);
-
     }
 }

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbPawn.cs
@@ -397,7 +397,7 @@ public partial class DdonSqlDb : SqlDb
 
     private void QueryPawnData(DbConnection conn, Pawn pawn)
     {
-        QueryCharacterCommonData(conn, pawn);
+        QueryCharacterCommonData(conn, pawn, pawn.CharacterId);
 
         ExecuteReader(
             conn,

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -230,9 +230,12 @@ public partial class DdonPostgresDb : DdonSqlDb
         AddTypedParameter(command, name, value);
     }
 
-    public override void AddParameter(DbCommand command, string name, string[] value)
+    public override (string SqlFragment, Action<DbCommand> Bind) PrepareArrayParameter(string paramName, string[] values)
     {
-        command.Parameters.Add(new NpgsqlParameter<string[]>(name, value));
+        return (
+            $"= ANY(@{paramName})",
+            cmd => cmd.Parameters.Add(new NpgsqlParameter<string[]>($"@{paramName}", values))
+        );
     }
 
     #endregion

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -33,7 +33,10 @@ public partial class DdonPostgresDb : DdonSqlDb
         if (_dataSource == null)
         {
             NpgsqlDataSourceBuilder dataSourceBuilder = new(_connectionString);
+
+            // Log parameter values during tracing
             dataSourceBuilder.EnableParameterLogging();
+
             _dataSource = dataSourceBuilder.Build();
         }
 
@@ -71,17 +74,22 @@ public partial class DdonPostgresDb : DdonSqlDb
             Username = user,
             Password = password,
             Database = database,
+
             MaxAutoPrepare = (int)maxAutoPrepare,
-            MinPoolSize = enablePooling ? 1 : 0,
+            MinPoolSize = enablePooling ? 2 : 0,
+            MaxPoolSize = enablePooling ? 100 : 1,
+            ConnectionIdleLifetime = 300,
             ConnectionLifetime = 0,
             ReadBufferSize = (int)bufferSize,
             WriteBufferSize = (int)bufferSize,
-            NoResetOnClose = noResetOnClose,
             SocketReceiveBufferSize = (int)bufferSize,
             SocketSendBufferSize = (int)bufferSize,
+            NoResetOnClose = noResetOnClose,
             Pooling = enablePooling,
-            IncludeErrorDetail = enableTracing
+            IncludeErrorDetail = enableTracing,
+            WriteCoalescingBufferThresholdBytes = 1000,
         };
+
         string connectionString = builder.ToString();
         Logger.Info($"Connection String: {connectionString}");
         return connectionString;
@@ -220,6 +228,11 @@ public partial class DdonPostgresDb : DdonSqlDb
     public override void AddParameter(DbCommand command, string name, bool value)
     {
         AddTypedParameter(command, name, value);
+    }
+
+    public override void AddParameter(DbCommand command, string name, string[] value)
+    {
+        command.Parameters.Add(new NpgsqlParameter<string[]>(name, value));
     }
 
     #endregion

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -210,12 +210,29 @@ public abstract class SqlDb : IDatabase
     }
 
     /// <summary>
-    /// Passes a string array as a parameter. Postgres overrides this with a typed NpgsqlParameter
-    /// for use with the ANY(@uids) batch query pattern.
+    /// Prepares an array of string values for use in a batch WHERE clause.
+    /// Returns the SQL fragment to embed (e.g. "IN (@uids_0, @uids_1)") and an action
+    /// that binds the parameters to a command. Call-site usage:
+    /// <code>
+    ///   var (clause, bind) = PrepareArrayParameter("uids", values);
+    ///   string sql = $"SELECT ... WHERE \"col\" {clause}";
+    ///   ExecuteReader(conn, sql, cmd => bind(cmd), reader => { ... });
+    /// </code>
+    /// Postgres overrides this to use the more efficient "= ANY(@uids)" array syntax.
     /// </summary>
-    public virtual void AddParameter(DbCommand command, string name, string[] value)
+    public virtual (string SqlFragment, Action<DbCommand> Bind) PrepareArrayParameter(string paramName, string[] values)
     {
-        throw new NotImplementedException("string[] parameters require a database-specific implementation (e.g. Postgres).");
+        string[] names = new string[values.Length];
+        for (int i = 0; i < values.Length; i++)
+            names[i] = $"@{paramName}_{i}";
+        return (
+            $"IN ({string.Join(", ", names)})",
+            cmd =>
+            {
+                for (int i = 0; i < values.Length; i++)
+                    AddParameter(cmd, names[i], values[i]);
+            }
+        );
     }
 
     public virtual string? GetStringNullable(DbDataReader reader, int ordinal)

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -209,6 +209,15 @@ public abstract class SqlDb : IDatabase
         AddParameter(command, name, value, DbType.Boolean);
     }
 
+    /// <summary>
+    /// Passes a string array as a parameter. Postgres overrides this with a typed NpgsqlParameter
+    /// for use with the ANY(@uids) batch query pattern.
+    /// </summary>
+    public virtual void AddParameter(DbCommand command, string name, string[] value)
+    {
+        throw new NotImplementedException("string[] parameters require a database-specific implementation (e.g. Postgres).");
+    }
+
     public virtual string? GetStringNullable(DbDataReader reader, int ordinal)
     {
         if (reader.IsDBNull(ordinal)) return null;

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -198,6 +198,16 @@ namespace Arrowgene.Ddon.GameServer
 
             client.Party?.Leave(client);
 
+            // Free reserved invite slot if this client DC'd while holding a pending invite.
+            // TryRemovePartyInvitation is atomic; concurrent timer expiry is handled safely.
+            var staleInvite = PartyManager.TryRemovePartyInvitation(client);
+            if (staleInvite != null)
+            {
+                staleInvite.CancelTimer();
+                staleInvite.Party?.Leave(client);
+                Logger.Info($"[ClientDisconnected] Freed stale invite slot PartyId:{staleInvite.Party?.Id}");
+            }
+
             EventHandler<ClientConnectionChangeArgs> connectionChangeEvent = ClientConnectionChangeEvent;
             if (connectionChangeEvent != null)
             {

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
@@ -1,8 +1,13 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.GameServer.Party;
+using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -20,20 +25,29 @@ namespace Arrowgene.Ddon.GameServer.Handler
             S2CPartyPartyChangeLeaderRes res = new S2CPartyPartyChangeLeaderRes();
             uint newLeaderCharacterId = request.CharacterId;
 
-            PartyGroup party = client.Party 
-                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_NOT_FOUNDED, "Could not leave party, does not exist");
+            PartyGroup party = client.Party
+                ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_NOT_FOUNDED, "Could not change leader, party does not exist");
 
-            var previousLeader = client.Party.Leader;
+            var previousLeader = party.Leader;
 
-            party.ChangeLeader(client, newLeaderCharacterId);
+            PlayerPartyMember newLeader = party.ChangeLeader(client, newLeaderCharacterId);
 
-            S2CPartyPartyChangeLeaderNtc ntc = new S2CPartyPartyChangeLeaderNtc();
-            ntc.CharacterId = newLeaderCharacterId;
+            // If leader didn't actually change (request ignored), do nothing
+            if (newLeader == null || previousLeader == newLeader)
+            {
+                return res;
+            }
+
+            S2CPartyPartyChangeLeaderNtc ntc = new S2CPartyPartyChangeLeaderNtc
+            {
+                CharacterId = newLeader.Client.Character.CharacterId
+            };
+
             party.SendToAll(ntc);
 
-
             PlayerPartyMember currentLeader = party.Leader;
-            if (previousLeader != null)
+
+            if (previousLeader?.Client != null)
             {
                 Server.CharacterManager.UpdateOnlineStatus(previousLeader.Client, previousLeader.Client.Character, OnlineStatus.PtMember);
                 Logger.Info(client, $"Party leader changed from {previousLeader.Client.Character.CharacterId} to {currentLeader.Client.Character.CharacterId} for PartyId:{party.Id}");
@@ -50,6 +64,39 @@ namespace Arrowgene.Ddon.GameServer.Handler
             else
             {
                 Server.CharacterManager.UpdateOnlineStatus(currentLeader.Client, currentLeader.Client.Character, OnlineStatus.PtLeader);
+            }
+
+            // Reload the new leader's quest state into shared state so priority quests resolve correctly.
+            // Leave() is not called on a manual leader change, so shared state still holds the old leader's quests.
+            try
+            {
+                foreach (var questScheduleId in party.QuestState.GetActiveQuestScheduleIds().ToList())
+                {
+                    party.QuestState.RemoveQuest(questScheduleId);
+                }
+
+                var progress = Server.Database.GetQuestProgressByType(currentLeader.Client.Character.CommonId, QuestType.All);
+                foreach (var questProgress in progress)
+                {
+                    var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
+                    if (quest is null) continue;
+                    QuestStateManager questStateManager = QuestManager.GetQuestStateManager(currentLeader.Client, quest);
+                    questStateManager.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+                }
+
+                party.SendToAll(new S2CQuestGetMainQuestNtc());
+
+                if (currentLeader.Client?.Character?.AreaId != QuestAreaId.None)
+                {
+                    var questListNtc = QuestGetSetQuestListHandler.BuildQuestListNtc(currentLeader.Client, currentLeader.Client.Character.AreaId, mutating: false);
+                    party.SendToAll(questListNtc);
+                }
+
+                Logger.Info(client, $"[ChangeLeader] Reloaded quest state for new leader {currentLeader.Client.Character.CharacterId}");
+            }
+            catch (System.Exception ex)
+            {
+                Logger.Error(client, $"[ChangeLeader] Failed to reload quest state for new leader: {ex.Message}");
             }
 
             return res;

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyInviteCharacterHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyInviteCharacterHandler.cs
@@ -1,9 +1,11 @@
+#nullable enable
+using System.Linq;
 using Arrowgene.Ddon.GameServer.Party;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
-using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -15,30 +17,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-        // When a player is invited:
-        //  PartyPartyInviteCharacterHandler
-        // 0.   C->S    The party leader sends an invite to another player, sending a C2SPartyPartyInviteCharacterReq
-        // 1.   S->C    S2CPartyPartyInviteNtc to the player, C2SPartyPartyInviteCharacterRes to the inviter with the new players info
-        //  PartyPartyInvitePrepareAcceptHandler
-        // 2.   C->S    The player accepts the invite, sending a C2SPartyPartyInvitePrepareAcceptReq
-        // 3.   S->C    S2CPartyPartyInviteAcceptNtc to the player so they move to the leader's server.
-        //              S2CPartyPartyInviteJoinMemberNtc to the leader so they know the invite was accepted.
-        //  PartyPartyLeaveHandler
-        // 4.   C->S    The player teleports to the party leader and leaves the previous party, sending a C2SPartyPartyLeaveReq
-        // 5.   S->C    S2CPartyPartyLeaveNtc to the old party members
-        //  PartyPartyJoinHandler
-        // 6.   C->S    The player requests to join the new party, sending a C2SPartyPartyJoinReq
-        // 7.   S->C    S2CPartyPartyJoinNtc to all members
-        //              S2CContextGetLobbyPlayerContextNtc to the new party member, it should maybe also be sent to all members
-        //              More stuff to determine
-        // TODO: Figure out just how much packets/data within those packets we can do without while keeping everything functioning.
         public override S2CPartyPartyInviteCharacterRes Handle(GameClient client, C2SPartyPartyInviteCharacterReq request)
         {
-
             GameClient invitedClient = Server.ClientLookup.GetClientByCharacterId(request.CharacterId)
                 ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_INVITE_FAIL_REASON_MEMBER_NOT_FOUND,
                 $"not found CharacterId:{request.CharacterId} for party invitation");
-            
+
             if (invitedClient == client)
             {
                 throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_INTERNAL_ERROR, $"can not invite (invitedClient == client)");
@@ -51,6 +35,17 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             PartyGroup party = client.Party
                 ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_NOT_FOUNDED, "can not invite (client.Party == null)");
+
+            // Reject duplicate invites to the same party - spamming the button creates ghost slots.
+            PartyInvitation? existingInvite = Server.PartyManager.GetPartyInvitation(invitedClient);
+            if (existingInvite != null && existingInvite.Party?.Id == party.Id)
+            {
+                Logger.Info(client, $"[PartyId:{party.Id}] duplicate invite ignored; {invitedClient.Identity} already has a pending invite");
+                return new S2CPartyPartyInviteCharacterRes
+                {
+                    Error = (uint)ErrorCode.ERROR_CODE_PARTY_ALREADY_INVITE
+                };
+            }
 
             PlayerPartyMember invitedMember = party.Invite(invitedClient, client);
 

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
@@ -5,6 +5,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -53,15 +54,39 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
             }
 
+            // Exclude JoinState.Prepare members and their pawns from all NTCs
+            // they have a reserved slot but haven't accepted yet.
+            var prepareOwnerIds = party.Members
+                .OfType<PlayerPartyMember>()
+                .Where(p => p.JoinState == JoinState.Prepare)
+                .Select(p => p.Client?.Character?.CharacterId ?? 0)
+                .ToHashSet();
+
             S2CPartyPartyJoinNtc ntc = new S2CPartyPartyJoinNtc();
-            ntc.HostCharacterId = party.Host.Client.Character.CharacterId;
+            uint hostCharacterId = (party.Host?.Client != null && party.Host.Client.IsAlive)
+                ? party.Host.Client.Character.CharacterId
+                : partyLeader.CharacterId;
+            ntc.HostCharacterId = hostCharacterId;
             ntc.LeaderCharacterId = partyLeader.CharacterId;
             foreach (PartyMember member in party.Members)
             {
+                if (member is PlayerPartyMember pm && prepareOwnerIds.Contains(pm.Client?.Character?.CharacterId ?? 0))
+                    continue;
+
+                if (member is PawnPartyMember pawnMember && prepareOwnerIds.Contains(pawnMember.Pawn?.CharacterId ?? 0))
+                    continue;
+
                 ntc.PartyMembers.Add(member.CDataPartyMember);
             }
 
-            party.SendToAll(ntc);
+            // Only send JoinNtc to fully joined members - Prepare members haven't accepted yet.
+            foreach (PartyMember member in party.Members)
+            {
+                if (member is PlayerPartyMember onMember && onMember.JoinState == JoinState.On)
+                {
+                    onMember.Client?.Send(ntc);
+                }
+            }
 
             S2CContextGetPartyPlayerContextNtc newMemberContext = join.GetPartyContext();
             if (partyLeader.CommonId != client.Character.CommonId)
@@ -74,28 +99,32 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if (party.Clients.Count > 0)
             {
-                // Send existing party player context NTCs to the new member
                 foreach (PartyMember member in party.Members)
                 {
                     if (member.MemberIndex == join.MemberIndex)
-                    {
-                        // Skip ourselves
                         continue;
-                    }
 
                     if (member is PlayerPartyMember playerMember)
                     {
+                        if (prepareOwnerIds.Contains(playerMember.Client?.Character?.CharacterId ?? 0))
+                            continue;
                         client.Send(playerMember.GetPartyContext());
                     }
                     else if (member is PawnPartyMember pawnPartyMember)
                     {
+                        if (prepareOwnerIds.Contains(pawnPartyMember.Pawn?.CharacterId ?? 0))
+                            continue;
                         client.Send(pawnPartyMember.GetPartyContext());
                     }
                 }
 
-                // Send new members to all existing party members
-                // client.Party.SendToAllExcept(newMemberContext, client);
-                client.Party.SendToAll(newMemberContext);
+                foreach (PartyMember member in party.Members)
+                {
+                    if (member is PlayerPartyMember onMember && onMember.JoinState == JoinState.On)
+                    {
+                        onMember.Client?.Send(newMemberContext);
+                    }
+                }
             }
 
             res.PartyId = party.Id;

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -6,7 +6,6 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -20,8 +19,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CQuestGetSetQuestListRes Handle(GameClient client, C2SQuestGetSetQuestListReq request)
         {
-            // client.Send(GameFull.Dump_132);
-
             client.Character.AreaId = request.DistributeId;
 
             S2CQuestGetSetQuestListRes res = new S2CQuestGetSetQuestListRes()
@@ -29,21 +26,55 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 DistributeId = request.DistributeId
             };
 
-            // Remove all world quests which have no progress made
+            // If shared QuestState is empty and this client is the leader, reload their quest
+            // progress from DB into shared state.
+            if (client.Party.Leader?.Client == client && client.Party.QuestState.GetActiveQuestScheduleIds().Count == 0)
+            {
+                var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
+                foreach (var questProgress in progress)
+                {
+                    var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
+                    if (quest is null) continue;
+                    QuestStateManager questStateManager = QuestManager.GetQuestStateManager(client, quest);
+                    questStateManager.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+                }
+                Logger.Info(client, $"[QuestGetSetQuestList] Reloaded quest state for promoted leader {client.Character.CharacterId}");
+            }
+
+            // Remove all world quests which have no progress made.
             client.Party.QuestState.RemoveInactiveWorldQuests();
 
-            if (QuestManager.HasWorldQuestAreaReleased(client.Character, request.DistributeId))
+            // Build the NTC, mutating path
+            S2CQuestGetSetQuestListNtc ntc = BuildQuestListNtc(client, request.DistributeId, mutating: true);
+            res.SetQuestList = ntc.SetQuestList;
+
+            // Only broadcast to all if the requesting client is the leader.
+            // Non-leader area entry should not overwrite other members' displayed quest state.
+            if (client.Party.Leader?.Client == client)
             {
-                /**
-                 * World quests get added here instead of QuestGetWorldManageQuestListHandler because
-                 * "World Manage Quests" are different from "World Quests". World manage quests appear
-                 * to control the state of the game world (doors, paths, gates, etc.). World quests
-                 * are random fetch, deliver and kill type quests.
-                 */
+                client.Party.SendToAll(ntc);
+            }
+            else
+            {
+                client.Send(ntc);
+            }
 
-                var leaderCharacter = client.Party.Leader?.Client.Character;
+            return res;
+        }
 
-                // Populate state for all quests currently in progress by the player
+        public static S2CQuestGetSetQuestListNtc BuildQuestListNtc(GameClient client, QuestAreaId areaId, bool mutating = false)
+        {
+            var leaderCharacter = client.Party.Leader?.Client?.Character;
+
+            var ntc = new S2CQuestGetSetQuestListNtc()
+            {
+                DistributeId = areaId,
+                SelectCharacterId = leaderCharacter?.CharacterId ?? client.Character.CharacterId,
+                SetQuestList = new List<CDataSetQuestList>()
+            };
+
+            if (QuestManager.HasWorldQuestAreaReleased(client.Character, areaId))
+            {
                 foreach (var questScheduleId in client.Party.QuestState.GetActiveQuestScheduleIds())
                 {
                     Quest quest = client.Party.QuestState.GetQuest(questScheduleId);
@@ -54,10 +85,10 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                     CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
                     QuestState questState = client.Party.QuestState.GetQuestState(quest);
-                    res.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, questStats?.ClearCount ?? 0));
+                    ntc.SetQuestList.Add(quest.ToCDataSetQuestList(questState?.Step ?? 0, questStats?.ClearCount ?? 0));
                 }
 
-                foreach (var questScheduleId in client.Party.QuestState.AreaQuests(request.DistributeId))
+                foreach (var questScheduleId in client.Party.QuestState.AreaQuests(areaId))
                 {
                     Quest quest = QuestManager.GetQuestByScheduleId(questScheduleId);
 
@@ -65,49 +96,40 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         || client.Party.QuestState.IsQuestActive(questScheduleId)
                         || client.Party.QuestState.IsCompletedWorldQuest(questScheduleId))
                     {
-                        // Skip quests already populated or completed
                         continue;
                     }
 
-                    if (Server.GameSettings.GameServerSettings.WorldQuestFilterByLeaderAreaRank
-                        && quest.OrderConditions.Any(c => c.Type == QuestOrderConditionType.AreaRank
-                            && (leaderCharacter == null
-                                || !leaderCharacter.AreaRanks.ContainsKey((QuestAreaId)c.Param01)
-                                || Server.AreaRankManager.GetEffectiveRank(leaderCharacter, (QuestAreaId)c.Param01) < (uint)c.Param02)))
-                    {
-                        continue;
-                    }
+                    // Area rank filtering is applied upstream in QuestStateManager.RollEligibleQuestVariant
+                    // when the world quest rotation is rolled, so quests that don't meet the leader's rank
+                    // requirement never appear in AreaQuests() at all. No handler-level check needed.
 
                     CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
-                    res.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
-                    client.Party.QuestState.AddNewQuest(quest, 0);
-                    // Enemy requests arrive before the quest list, so loaded groups may have generic enemies. Reset them.
-                    quest.ResetEnemiesForStage(client, client.Character.Stage, onlyLoaded: true);
+                    ntc.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
+
+                    if (mutating)
+                    {
+                        client.Party.QuestState.AddNewQuest(quest, 0);
+                        // Enemy requests arrive before the quest list, so loaded groups may have generic enemies. Reset them.
+                        quest.ResetEnemiesForStage(client, client.Character.Stage, onlyLoaded: true);
+                    }
                 }
             }
 
-            // Add Debug Quest
             var debugQuest = QuestManager.GetQuestByQuestId((QuestId)70000001);
-            res.SetQuestList.Add(new CDataSetQuestList()
+            if (debugQuest != null)
             {
-                Detail = new CDataSetQuestDetail()
+                ntc.SetQuestList.Add(new CDataSetQuestList()
                 {
-                    IsDiscovery = false,
-                    ClearCount = 0
-                },
-                Param = debugQuest.ToCDataQuestList(0),
-            });
+                    Detail = new CDataSetQuestDetail()
+                    {
+                        IsDiscovery = false,
+                        ClearCount = 0
+                    },
+                    Param = debugQuest.ToCDataQuestList(0),
+                });
+            }
 
-            S2CQuestGetSetQuestListNtc ntc = new S2CQuestGetSetQuestListNtc()
-            {
-                DistributeId = request.DistributeId,
-                SelectCharacterId = client.Party.Leader.Client.Character.CharacterId,
-                SetQuestList = res.SetQuestList
-            };
-
-            client.Party.SendToAll(ntc);
-
-            return res;
+            return ntc;
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -99,10 +99,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                         continue;
                     }
 
-                    // Area rank filtering is applied upstream in QuestStateManager.RollEligibleQuestVariant
-                    // when the world quest rotation is rolled, so quests that don't meet the leader's rank
-                    // requirement never appear in AreaQuests() at all. No handler-level check needed.
-
                     CompletedQuest questStats = leaderCharacter?.CompletedQuests.GetValueOrDefault(quest.QuestId);
                     ntc.SetQuestList.Add(quest.ToCDataSetQuestList(0, questStats?.ClearCount ?? 0));
 

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -1,6 +1,7 @@
 using Arrowgene.Ddon.GameServer.Context;
 using Arrowgene.Ddon.GameServer.Instance;
 using Arrowgene.Ddon.GameServer.Quests;
+using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Server.Network;
 using Arrowgene.Ddon.Shared.Entity;
@@ -20,6 +21,7 @@ namespace Arrowgene.Ddon.GameServer.Party
     {
         public const uint MaxPartyMember = 8; // TODO: Different max sizes per party type
         public const int InvalidSlotIndex = -1;
+        public uint ExmInitialPartySize { get; set; } = 0;
 
         private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PartyGroup));
 
@@ -96,7 +98,7 @@ namespace Arrowgene.Ddon.GameServer.Party
                 {
                     for (int i = 0; i < MaxSlots; i++)
                     {
-                        if (_slots[i] is PlayerPartyMember member)
+                        if (_slots[i] is PlayerPartyMember member && member.Client != null && member.Client.IsAlive)
                         {
                             clients.Add(member.Client);
                         }
@@ -177,12 +179,22 @@ namespace Arrowgene.Ddon.GameServer.Party
 
                 invitation.CancelTimer();
 
-                Leader.Client.Send(new S2CPartyPartyInviteFailNtc
+                // Guard: leader may have disconnected between the invite being sent and
+                // the invitee refusing. A NRE here would leave the slot reserved forever
+                // because FreeSlot below would never run.
+                if (Leader != null && Leader.Client != null && Leader.Client.IsAlive)
                 {
-                    ErrorCode = ErrorCode.ERROR_CODE_PARTY_INVITE_TARGET_REFUSE,
-                    ServerId = Leader.Client.Character.Server.Id,
-                    PartyId = invitation.Party.Id
-                });
+                    Leader.Client.Send(new S2CPartyPartyInviteFailNtc
+                    {
+                        ErrorCode = ErrorCode.ERROR_CODE_PARTY_INVITE_TARGET_REFUSE,
+                        ServerId = Leader.Client.Character.Server.Id,
+                        PartyId = invitation.Party.Id
+                    });
+                }
+                else
+                {
+                    Logger.Info($"[PartyId:{Id}][RefuseInvite] leader is gone, skipping InviteFail NTC");
+                }
                 
                 FreeSlot(partyMember.MemberIndex);
                 Logger.Info(client, $"[PartyId:{Id}][RefuseInvite] refused invite");
@@ -341,7 +353,18 @@ namespace Arrowgene.Ddon.GameServer.Party
 
             lock (_lock)
             {
-                if (!Clients.Contains(client))
+                // Check the slot directly (not Clients) so disconnect cleanup runs
+                // even when the socket is already dead and Clients filters it out.
+                PlayerPartyMember partyMember = GetPlayerPartyMember(client);
+                if (partyMember == null)
+                {
+                    // Not in this party at all — nothing to clean up.
+                    return;
+                }
+
+                // For a live client also verify they are in the active Clients list.
+                // Skip this check for dead/disconnected clients so cleanup always runs.
+                if (client.IsAlive && !Clients.Contains(client))
                 {
                     // TODO: Suppressing this log message for now; it spams the log and is usually not helpful.
                     // This is partly due to an order of operations problem when quitting the game.
@@ -352,13 +375,6 @@ namespace Arrowgene.Ddon.GameServer.Party
 
                 if (_isBreakup)
                 {
-                    return;
-                }
-
-                PlayerPartyMember partyMember = GetPlayerPartyMember(client);
-                if (partyMember == null)
-                {
-                    Logger.Info(client, $"[PartyId:{Id}][Leave(GameClient)] has no slot");
                     return;
                 }
 
@@ -383,6 +399,17 @@ namespace Arrowgene.Ddon.GameServer.Party
                 FreeSlot(partyMember.MemberIndex);
                 Logger.Info(client, $"[PartyId:{Id}][Leave(GameClient)] left");
 
+                // Purge dead slots so Clients.Count reflects reality and disband fires correctly.
+                for (int i = 0; i < MaxSlots; i++)
+                {
+                    if (_slots[i] is PlayerPartyMember deadMember
+                        && (deadMember.Client == null || !deadMember.Client.IsAlive))
+                    {
+                        Logger.Info($"[PartyId:{Id}][Leave] purging dead slot {i} for disconnected client");
+                        FreeSlot(i);
+                    }
+                }
+
                 if (Clients.Count <= 0)
                 {
                     Logger.Info(client, $"[PartyId:{Id}][Leave(GameClient)] was the last person, disband");
@@ -393,7 +420,93 @@ namespace Arrowgene.Ddon.GameServer.Party
                 if (partyMember.IsLeader)
                 {
                     _leader = null;
-                    Logger.Info(client, $"[PartyId:{Id}][Leave(GameClient)] leader left");
+                    partyMember.IsLeader = false;
+
+                    for (int i = 0; i < MaxSlots; i++)
+                    {
+                        if (_slots[i] is PlayerPartyMember candidate
+                            && candidate != partyMember
+                            && candidate.Client != null
+                            && candidate.Client.IsAlive)
+                        {
+                            candidate.IsLeader = true;
+                            _leader = candidate;
+                            Logger.Info(client, $"[PartyId:{Id}][Leave] auto-promoted {candidate.Client.Identity} to leader");
+
+                            SendToAll(new S2CPartyPartyChangeLeaderNtc
+                            {
+                                CharacterId = candidate.Client.Character.CharacterId
+                            });
+
+                            break;
+                        }
+                    }
+
+                    if (_leader == null)
+                    {
+                        Logger.Info(client, $"[PartyId:{Id}][Leave] leader left, no eligible candidate for promotion");
+                    }
+
+                    // Clear the old leader's quest state so stale quests aren't shown.
+                    // All entries belong to the leader - personal quests are never in shared state.
+                    // Repopulates from DB on next area entry.
+                    try
+                    {
+                        foreach (var questScheduleId in QuestState.GetActiveQuestScheduleIds().ToList())
+                        {
+                            QuestState.RemoveQuest(questScheduleId);
+                        }
+
+                        // S2CQuestGetMainQuestNtc appends rather than replaces on the client,
+                        // so send an empty list to clear the stale display.
+                        SendToAll(new S2CQuestGetMainQuestNtc());
+
+                        if (_leader != null && _leader.Client?.Character?.AreaId != QuestAreaId.None)
+                        {
+                            SendToAll(new S2CQuestGetSetQuestListNtc()
+                            {
+                                DistributeId = _leader.Client.Character.AreaId,
+                                SelectCharacterId = _leader.Client.Character.CharacterId,
+                                SetQuestList = new List<CDataSetQuestList>()
+                            });
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error($"[PartyId:{Id}][Leave] Failed to clean up quest state on promotion: {ex.Message}");
+                    }
+
+                    if (_leader?.Client != null)
+                    {
+                        try
+                        {
+                            var priorityNtc = new S2CQuestSetPriorityQuestNtc()
+                            {
+                                CharacterId = _leader.Client.Character.CharacterId
+                            };
+                            var priorityQuests = _partyManager.Server.Database
+                                .GetPriorityQuestScheduleIds(_leader.Client.Character.CommonId);
+                            foreach (var questScheduleId in priorityQuests)
+                            {
+                                if (!Arrowgene.Ddon.GameServer.Characters.QuestManager.IsQuestEnabled(questScheduleId))
+                                {
+                                    continue;
+                                }
+                                var quest = Arrowgene.Ddon.GameServer.Characters.QuestManager.GetQuestByScheduleId(questScheduleId);
+                                if (quest == null) continue;
+                                var questStateManager = Arrowgene.Ddon.GameServer.Characters.QuestManager.GetQuestStateManager(_leader.Client, quest);
+                                if (questStateManager == null) continue;
+                                var questState = questStateManager.GetQuestState(questScheduleId);
+                                if (questState == null) continue;
+                                priorityNtc.PriorityQuestList.Add(quest.ToCDataPriorityQuest(questState?.Step ?? 0));
+                            }
+                            SendToAll(priorityNtc);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error($"[PartyId:{Id}][Leave] Failed to send priority quest NTC on promotion: {ex.Message}");
+                        }
+                    }
                 }
             }
         }
@@ -606,6 +719,15 @@ namespace Arrowgene.Ddon.GameServer.Party
                 _host = null;
                 _isBreakup = true;
 
+                // FIX: Clear shared quest state on disband so disbanded members'
+                // solo parties don't inherit the leader's MSQ and world quests.
+                // Without this, QuestGetSetQuestListHandler reads stale shared state
+                // on the next area entry and re-displays the old leader's quests.
+                foreach (var questScheduleId in QuestState.GetActiveQuestScheduleIds().ToList())
+                {
+                    QuestState.RemoveQuest(questScheduleId);
+                }
+
                 return members;
             }
         }
@@ -659,7 +781,12 @@ namespace Arrowgene.Ddon.GameServer.Party
         {
             foreach (GameClient client in Clients)
             {
-                client.Send(packet);
+                // Second layer guard - Clients already filters dead sockets but
+                // this protects against any future code path that bypasses Clients.
+                if (client != null && client.IsAlive)
+                {
+                    client.Send(packet);
+                }
             }
         }
 
@@ -776,6 +903,11 @@ namespace Arrowgene.Ddon.GameServer.Party
                 {
                     if (_slots[i] is PlayerPartyMember member)
                     {
+                        if (member.Client == null)
+                        {
+                            continue;
+                        }
+
                         Character character = member.Client.Character;
                         if (character == null)
                         {
@@ -905,11 +1037,25 @@ namespace Arrowgene.Ddon.GameServer.Party
         {
             if (!Members.Any() || !Clients.Any()) return 0;
 
-            var ind = Members.FindIndex(member =>
-                member is PlayerPartyMember playerMember
-                && playerMember.Client == client
-            );
-            return ind >= 0 ? ind : ClientIndex(Clients.First());
+            // Use MemberIndex (the actual _slots position) not the index in the
+            // filtered Members list. The client was told its slot index when it
+            // joined and uses that as its identity in MasterChangeNtc. If a party
+            // member crashes and their slot is freed, Members shrinks but the
+            // remaining clients still have their original slot indices. Using
+            // Members.FindIndex would return the wrong (compressed) index.
+            lock (_lock)
+            {
+                for (int i = 0; i < MaxSlots; i++)
+                {
+                    if (_slots[i] is PlayerPartyMember playerMember && playerMember.Client == client)
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            // Fallback: client not found in slots, use first alive client's index.
+            return ClientIndex(Clients.First());
         }
 
         public bool Contains(CharacterCommon character)

--- a/Arrowgene.Ddon.GameServer/Party/PartyInvitation.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyInvitation.cs
@@ -10,15 +10,22 @@ public class PartyInvitation
     public PartyGroup Party { get; set; }
     public DateTime Date { get; set; }
     private Timer _timer;
+
     public bool IsTimerDisposed =>
-     _timer == null || !_timer.Change(Timeout.Infinite, Timeout.Infinite);
+        _timer == null || !_timer.Change(Timeout.Infinite, Timeout.Infinite);
 
     public void StartTimer(Action<PartyInvitation> onTimeout, int timeoutSec)
     {
         _timer = new Timer(state =>
         {
-            onTimeout(this);
-            _timer.Dispose();
+            try
+            {
+                onTimeout?.Invoke(this);
+            }
+            finally
+            {
+                _timer?.Dispose();
+            }
         }, null, timeoutSec * 1000, Timeout.Infinite);
     }
 
@@ -28,7 +35,7 @@ public class PartyInvitation
         {
             if (!IsTimerDisposed)
             {
-                _timer.Dispose();
+                _timer?.Dispose();
             }
         }
         catch { }

--- a/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
@@ -18,7 +18,6 @@ public class PartyManager
     public const uint InvalidPartyId = 0;
     public const ushort InvitationTimeoutSec = 30;
 
-
     private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(PartyManager));
 
     public readonly DdonGameServer Server;
@@ -42,6 +41,15 @@ public class PartyManager
 
     public bool InviteParty(GameClient invitee, GameClient host, PartyGroup party, bool createTimeout)
     {
+        // Clean up any existing invite before adding the new one (handles cross-invites and stale DC slots).
+        // TryRemove is atomic, so concurrent timer expiry is safe.
+        if (_invites.TryRemove(invitee, out PartyInvitation stale))
+        {
+            stale.CancelTimer();
+            stale.Party?.Leave(invitee);
+            Logger.Info($"[PartyId:{party.Id}][Invite] cleared stale invite for invitee {invitee.Identity} before re-inviting");
+        }
+
         PartyInvitation invitation = new PartyInvitation
         {
             Invitee = invitee,
@@ -52,7 +60,8 @@ public class PartyManager
 
         if (!_invites.TryAdd(invitee, invitation))
         {
-            throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_ALREADY_INVITE, $"[PartyId:{party.Id}][Invite] could not be invited; already has pending invite");
+            throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_ALREADY_INVITE,
+                $"[PartyId:{party.Id}][Invite] could not be invited; already has pending invite");
         }
 
         if (createTimeout)
@@ -63,22 +72,63 @@ public class PartyManager
         return true;
     }
 
-    private void RemoveExpiredInvite(PartyInvitation invitation) 
+    private void NotifyPartyInviteeClearedFromSlot(PartyInvitation invitation)
     {
-        if (_invites.ContainsKey(invitation.Invitee) && _invites.TryRemove(invitation.Invitee, out _))
+        if (invitation.Party == null || invitation.Invitee == null)
+        {
+            return;
+        }
+
+        // Capture MemberIndex before Leave() frees the slot.
+        PlayerPartyMember inviteeMember = invitation.Party.GetPlayerPartyMember(invitation.Invitee);
+        int memberIndex = inviteeMember?.MemberIndex ?? PartyGroup.InvalidSlotIndex;
+
+        Logger.Info($"[NotifyPartyInviteeClearedFromSlot] PartyId:{invitation.Party.Id} " +
+                    $"Invitee:{invitation.Invitee.Identity} MemberIndex:{memberIndex} " +
+                    $"PartyMemberCount:{invitation.Party.MemberCount()} " +
+                    $"AliveClients:{invitation.Party.Clients.Count}");
+
+        // KickNtc must be sent before Leave() — after Leave() frees the slot, SendToAll
+        // won't include the invitee and they won't see their own ghost slot removal.
+        if (memberIndex != PartyGroup.InvalidSlotIndex)
+        {
+            Logger.Info($"[NotifyPartyInviteeClearedFromSlot] Sending KickNtc MemberIndex:{memberIndex} to all {invitation.Party.Clients.Count} alive clients");
+            invitation.Party.SendToAll(new S2CPartyPartyMemberKickNtc
+            {
+                MemberIndex = (byte)memberIndex
+            });
+        }
+        else
+        {
+            Logger.Info($"[NotifyPartyInviteeClearedFromSlot] MemberIndex is InvalidSlotIndex, skipping KickNtc");
+        }
+
+        invitation.Party.Leave(invitation.Invitee);
+    }
+
+    private void RemoveExpiredInvite(PartyInvitation invitation)
+    {
+        if (invitation == null)
+        {
+            return;
+        }
+
+        // TryRemove is atomic - if DC cleanup or InviteParty already removed this entry, we stop.
+        if (_invites.TryRemove(invitation.Invitee, out _))
         {
             var ntc = new S2CPartyPartyInviteFailNtc
             {
                 ErrorCode = ErrorCode.ERROR_CODE_PARTY_INVITE_FAIL_REASON_TIMEOUT,
                 ServerId = (ushort)Server.Id,
-                PartyId = invitation.Party.Id
+                PartyId = invitation.Party?.Id ?? InvalidPartyId
             };
 
-            invitation.Invitee.Send(ntc);
-            invitation.Host.Send(ntc);
-            invitation.Party.Leave(invitation.Invitee);
+            invitation.Invitee?.Send(ntc);
+            invitation.Host?.Send(ntc);
 
-            Logger.Info(invitation.Invitee, "Invitation removed due to timeout.");
+            NotifyPartyInviteeClearedFromSlot(invitation);
+
+            Logger.Info($"Invitation removed due to timeout (Host: {invitation.Host?.Identity ?? "disconnected"}, Invitee: {invitation.Invitee?.Identity ?? "unknown"})");
         }
     }
 
@@ -90,6 +140,12 @@ public class PartyManager
             return null;
         }
 
+        return partyInvitation;
+    }
+
+    public PartyInvitation TryRemovePartyInvitation(GameClient client)
+    {
+        _invites.TryRemove(client, out PartyInvitation partyInvitation);
         return partyInvitation;
     }
 
@@ -106,9 +162,15 @@ public class PartyManager
 
     public bool CancelPartyInvitation(PartyGroup party)
     {
-        PartyInvitation invitation = _invites.Values.Where(x => x.Party == party).FirstOrDefault()
-            ?? throw new ResponseErrorException(ErrorCode.ERROR_CODE_PARTY_INVITE_FAIL_REASON_WRONG_PARTY,
-            $"Can't find invitation to cancel for party {party.Id}");
+        PartyInvitation invitation = _invites.Values
+            .Where(x => x.Party == party)
+            .FirstOrDefault();
+
+        if (invitation == null)
+        {
+            Logger.Info($"[CancelPartyInvitation] no active invitation found for PartyId:{party.Id}, already resolved");
+            return false;
+        }
 
         RemovePartyInvitation(invitation.Invitee);
 
@@ -120,9 +182,11 @@ public class PartyManager
         };
 
         invitation.CancelTimer();
-        invitation.Invitee.Send(ntc);
-        invitation.Host.Send(ntc);
-        invitation.Party.Leave(invitation.Invitee);
+
+        invitation.Invitee?.Send(ntc);
+        invitation.Host?.Send(ntc);
+
+        NotifyPartyInviteeClearedFromSlot(invitation);
 
         Logger.Info(invitation.Invitee, "Invitation removed due to cancellation.");
         return true;
@@ -180,7 +244,7 @@ public class PartyManager
         }
 
         LogPartyIdCount();
-        
+
         return party;
     }
 
@@ -194,7 +258,7 @@ public class PartyManager
         // TODO: Thread safety, logs, error handling
         foreach (KeyValuePair<uint, PartyGroup> pair in _parties)
         {
-            if(pair.Value.MemberCount() == 0)
+            if (pair.Value.MemberCount() == 0)
             {
                 _idPool.Push(pair.Key);
                 _parties.TryRemove(pair);


### PR DESCRIPTION
- Party system fixes:
  - Stale invite slot leak on disconnect
  - Cross-invite race condition
  - Invite timeout left ghost slot
  - Dead socket broadcast storm
  - Leader DC left party leaderless
  - MasterIndex returned wrong slot after member crash
  - Invite refuse NTC sent after slot freed
  - PartyInvitation timer swallowed exceptions and could leak
  - Fixed exception raised on CanelPartyInvite due to race condition
- Character load performance enhancements
- Improved performance of pawn queries

Additional Changes made during merge:
- Removed quest list handler area rank filter detection

co-authored-by: @LostMyLeg
