### PR TITLE
Phindym gathering WQs update

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
@@ -6,7 +6,7 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+    "area_id": "ElanWaterGrove",
     "rewards": [
         {
             "type": "wallet",
@@ -26,57 +26,112 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15948,
+                    "item_id": "PremiumFragrantWood",
                     "num": 3
                 },
-                {					
-                    "item_id": 9364,
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
     ],
-    "blocks": [
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",	
-            "stage_id": {
-                "id": 339,
-                "group_id": 1,
-                "layer_no": 1
-            },				
-            "npc_id": "Musel0",
-            "message_id": 10800
-        },
-        {
-            "type": "DeliverItems",
-            "stage_id": {
-                "id": 339,
-                "group_id": 1
-            },
-            "npc_id": "Musel0",
-            "announce_type": "Accept",
-            "items": [
+            "blocks": [
                 {
-                    "id": 15947,
-                    "amount": 5
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 339
+                    },
+                    "npc_id": "Musel0",
+                    "message_id": 19659
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 910},
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 22}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 19660}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 910, "Param2": 2600},
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 22}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 19661}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 19662}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 15947, "Param2": 5}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 339
+                    },
+                    "npc_id": "Musel0",
+                    "items": [
+                        {
+                            "comment": "Old Geranium",
+                            "id": 15947,
+                            "amount": 5
+                        }
+                    ],
+                    "message_id": 19663
                 }
-            ],
-            "message_id": 10737
+            ]
         },
         {
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 339,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Musel0",
-            "message_id": 11842			
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 22}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 4316},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19906}
+                    ],
+                    "check_commands": [
+                        {"type": "IngameTimeRangeEq", "Param1": 2, "Param2": 22}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 4316},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19910}
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
@@ -6,7 +6,7 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+	"area_id": "ElanWaterGrove",
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 8}],
     "rewards": [
         {
@@ -27,55 +27,112 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15961,
+                    "item_id": "StiffCrocodileSkin",
                     "num": 3
                 },
                 {					
-                    "item_id": 7555,
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
                 {				
-                    "item_id": 9364,
+                    "item_id": "SuperiorStrongGalaExtract",
                     "num": 3					
                 }
             ]
         }
     ],
-    "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 339
-      },
-      "npc_id": "Musel0",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 339,
-        "group_id": 1
-      },
-      "npc_id": "Musel0",
-      "announce_type": "Accept",
-      "items": [
+    "processes": [
         {
-          "id": 15949,
-          "amount": 5
-        }
-      ],
-      "message_id": 10737
+            "blocks": [
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 339
+                    },
+                    "npc_id": "Musel0",
+                    "message_id": 19664
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 910},
+                        {"type": "WeatherEq", "Param1": 3}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 19665}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 910, "Param2": 2600},
+                        {"type": "WeatherEq", "Param1": 3}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 19666}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 19667}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 15949, "Param2": 5}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 339
+                    },
+                    "npc_id": "Musel0",
+                    "items": [
+                        {
+                            "comment": "Elana Water",
+                            "id": 15949,
+                            "amount": 5
+                        }
+                    ],
+                    "message_id": 19668
+                }
+            ]
         },
         {
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 339,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Musel0",
-            "message_id": 11842			
-    }
-  ]
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "WeatherEq", "Param1": 3}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 4317},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19928}
+                    ],
+                    "check_commands": [
+                        {"type": "WeatherNotEq", "Param1": 3}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 4317},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19929}
+                    ]
+                }
+            ]
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
@@ -1,40 +1,41 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "Time Restriction: Daybreak Mining",
-    "quest_id": 21017005,
-    "base_level": 70,
+    "comment": "Time Restriction: Dredging at Dawn",
+    "quest_id": 21014023,
+    "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "KingalCanyon",
+    "area_id": "ElanWaterGrove",
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 5772
+            "amount": 11233
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 750
+            "amount": 1662
         },
         {
             "type": "exp",
-            "amount": 3070
+            "amount": 5470
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": "ValleySpringWater",
+                    "item_id": "AshenFlowerRock",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
                 {
                     "item_id": "SuperiorStrongGalaExtract",
-                    "num": 3
-                },
-                {
-                    "item_id": "Panacea",
                     "num": 3
                 }
             ]
@@ -46,31 +47,31 @@
                 {
                     "type": "NpcTalkAndOrder",
                     "stage_id": {
-                        "id": 377
+                        "id": 339
                     },
-                    "npc_id": "Ciaran",
-                    "message_id": 19689
+                    "npc_id": "Musel0",
+                    "message_id": 20016
                 },
                 {
                     "type": "Raw",
                     "announce_type": "Accept",
                     "check_commands": [
-                        {"type": "StageNo", "Param1": 921},
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "StageNo", "Param1": 910},
+                        {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 7}
                     ],
                     "result_commands": [
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19690}
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 20017}
                     ]
                 },
                 {
                     "type": "Raw",
                     "announce_type": "Update",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 921, "Param2": 2700},
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "TalkNpc", "Param1": 910, "Param2": 2600},
+                        {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 7}
                     ],
                     "result_commands": [
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19691}
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 20018}
                     ]
                 },
                 {
@@ -78,27 +79,27 @@
                     "announce_type": "Update",
                     "result_commands": [
                         {"type": "MyQstFlagOn", "Param1": 0},
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19692}
+                        {"type": "QstTalkChg", "Param1": 4509, "Param2": 20019}
                     ],
                     "check_commands": [
-                        {"type": "HaveItemAllBag", "Param1": 15953, "Param2": 5}
+                        {"type": "HaveItemAllBag", "Param1": 16002, "Param2": 5}
                     ]
                 },
                 {
                     "type": "DeliverItems",
                     "announce_type": "Update",
                     "stage_id": {
-                        "id": 377
+                        "id": 339
                     },
-                    "npc_id": "Ciaran",
+                    "npc_id": "Musel0",
                     "items": [
                         {
-                            "comment": "Ringing Ore",
-                            "id": 15953,
+                            "comment": "Smooth White Mud",
+                            "id": 16002,
                             "amount": 5
                         }
                     ],
-                    "message_id": 19693
+                    "message_id": 20020
                 }
             ]
         },
@@ -111,24 +112,24 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 7}
                     ]
                 },
                 {
                     "type": "Raw",
                     "result_commands": [
-                        {"type": "QstLayoutFlagOn", "Param1": 4326},
-                        {"type": "CallMessage", "Param1": 1, "Param1": 19940}
+                        {"type": "QstLayoutFlagOn", "Param1": 4684},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 20098}
                     ],
                     "check_commands": [
-                        {"type": "IngameTimeRangeNotEq", "Param1": 5, "Param2": 10}
+                        {"type": "IngameTimeRangeNotEq", "Param1": 4, "Param2": 7}
                     ]
                 },
                 {
                     "type": "Raw",
                     "result_commands": [
-                        {"type": "QstLayoutFlagOff", "Param1": 4326},
-                        {"type": "CallMessage", "Param1": 1, "Param1": 19941}
+                        {"type": "QstLayoutFlagOff", "Param1": 4684},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 20099}
                     ]
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
@@ -6,7 +6,7 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",	
+    "area_id": "FaranaPlains",
     "rewards": [
         {
             "type": "wallet",
@@ -26,57 +26,112 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15945,
+                    "item_id": "SparklingWater",
                     "num": 3
                 },
-                {					
-                    "item_id": 7555,
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
     ],
-    "blocks": [
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",	
-            "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },				
-            "npc_id": "Razanailt",
-            "message_id": 10800
-        },
-        {
-            "type": "DeliverItems",
-            "stage_id": {
-                "id": 341,
-                "group_id": 1
-            },
-            "npc_id": "Razanailt",
-            "announce_type": "Accept",
-            "items": [
+            "blocks": [
                 {
-                    "id": 15944,
-                    "amount": 5
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 341
+                    },
+                    "npc_id": "Razanailt",
+                    "message_id": 19669
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 930},
+                        {"type": "IngameTimeRangeEq", "Param1": 11, "Param2": 15}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19670}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 930, "Param2": 2600},
+                        {"type": "IngameTimeRangeEq", "Param1": 11, "Param2": 15}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19671}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19672}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 15944, "Param2": 5}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 341
+                    },
+                    "npc_id": "Razanailt",
+                    "items": [
+                        {
+                            "comment": "Farana Mint",
+                            "id": 15944,
+                            "amount": 5
+                        }
+                    ],
+                    "message_id": 19673
                 }
-            ],
-            "message_id": 10737
+            ]
         },
         {
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Razanailt",
-            "message_id": 11842			
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "IngameTimeRangeEq", "Param1": 11, "Param2": 15}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 4319},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19930}
+                    ],
+                    "check_commands": [
+                        {"type": "IngameTimeRangeNotEq", "Param1": 11, "Param2": 15}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 4319},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19931}
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
@@ -6,7 +6,7 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",
+    "area_id": "FaranaPlains",
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 9}],
     "rewards": [
         {
@@ -27,57 +27,112 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15959,
+                    "item_id": "PixieMockWing",
                     "num": 3
                 },
-                {					
-                    "item_id": 9364,
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
     ],
-    "blocks": [
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",	
-            "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },				
-            "npc_id": "Razanailt",
-            "message_id": 10800
-        },
-        {
-            "type": "DeliverItems",
-            "stage_id": {
-                "id": 341,
-                "group_id": 1
-            },
-            "npc_id": "Razanailt",
-            "announce_type": "Accept",
-            "items": [
+            "blocks": [
                 {
-                    "id": 15946,
-                    "amount": 5
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 341
+                    },
+                    "npc_id": "Razanailt",
+                    "message_id": 19674
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 930},
+                        {"type": "WeatherEq", "Param1": 2}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19675}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 930, "Param2": 2600},
+                        {"type": "WeatherEq", "Param1": 2}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19676}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19677}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 15946, "Param2": 5}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 341
+                    },
+                    "npc_id": "Razanailt",
+                    "items": [
+                        {
+                            "comment": "White Bone Rock",
+                            "id": 15946,
+                            "amount": 5
+                        }
+                    ],
+                    "message_id": 19678
                 }
-            ],
-            "message_id": 10737
+            ]
         },
         {
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Razanailt",
-            "message_id": 11842			
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "WeatherEq", "Param1": 2}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 4322},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 11932}
+                    ],
+                    "check_commands": [
+                        {"type": "WeatherNotEq", "Param1": 2}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 4322},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19933}
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
@@ -1,36 +1,37 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "Time Restriction: Daybreak Mining",
-    "quest_id": 21017005,
-    "base_level": 70,
+    "comment": "Time Restriction: Mining in the Dead of Night",
+    "quest_id": 21015023,
+    "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "area_id": "KingalCanyon",
+    "area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 11}],
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 5772
+            "amount": 11233
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 750
+            "amount": 1662
         },
         {
             "type": "exp",
-            "amount": 3070
+            "amount": 5470
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": "ValleySpringWater",
+                    "item_id": "MorrowLauanWood",
                     "num": 3
                 },
                 {
-                    "item_id": "SuperiorStrongGalaExtract",
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
                 {
@@ -46,31 +47,31 @@
                 {
                     "type": "NpcTalkAndOrder",
                     "stage_id": {
-                        "id": 377
+                        "id": 341
                     },
-                    "npc_id": "Ciaran",
-                    "message_id": 19689
+                    "npc_id": "Razanailt",
+                    "message_id": 20021
                 },
                 {
                     "type": "Raw",
                     "announce_type": "Accept",
                     "check_commands": [
-                        {"type": "StageNo", "Param1": 921},
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "StageNo", "Param1": 930},
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 23}
                     ],
                     "result_commands": [
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19690}
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 20022}
                     ]
                 },
                 {
                     "type": "Raw",
                     "announce_type": "Update",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 921, "Param2": 2700},
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "TalkNpc", "Param1": 930, "Param2": 2600},
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 23}
                     ],
                     "result_commands": [
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19691}
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 20023}
                     ]
                 },
                 {
@@ -78,27 +79,27 @@
                     "announce_type": "Update",
                     "result_commands": [
                         {"type": "MyQstFlagOn", "Param1": 0},
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19692}
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 20024}
                     ],
                     "check_commands": [
-                        {"type": "HaveItemAllBag", "Param1": 15953, "Param2": 5}
+                        {"type": "HaveItemAllBag", "Param1": 16001, "Param2": 5}
                     ]
                 },
                 {
                     "type": "DeliverItems",
                     "announce_type": "Update",
                     "stage_id": {
-                        "id": 377
+                        "id": 341
                     },
-                    "npc_id": "Ciaran",
+                    "npc_id": "Razanailt",
                     "items": [
                         {
-                            "comment": "Ringing Ore",
-                            "id": 15953,
+                            "comment": "Ashen Flower Rock",
+                            "id": 16001,
                             "amount": 5
                         }
                     ],
-                    "message_id": 19693
+                    "message_id": 20025
                 }
             ]
         },
@@ -111,24 +112,24 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 23}
                     ]
                 },
                 {
                     "type": "Raw",
                     "result_commands": [
-                        {"type": "QstLayoutFlagOn", "Param1": 4326},
-                        {"type": "CallMessage", "Param1": 1, "Param1": 19940}
+                        {"type": "QstLayoutFlagOn", "Param1": 4686},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 20102}
                     ],
                     "check_commands": [
-                        {"type": "IngameTimeRangeNotEq", "Param1": 5, "Param2": 10}
+                        {"type": "IngameTimeRangeEq", "Param1": 2, "Param2": 23}
                     ]
                 },
                 {
                     "type": "Raw",
                     "result_commands": [
-                        {"type": "QstLayoutFlagOff", "Param1": 4326},
-                        {"type": "CallMessage", "Param1": 1, "Param1": 19941}
+                        {"type": "QstLayoutFlagOff", "Param1": 4686},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 20103}
                     ]
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017006.json
@@ -6,7 +6,7 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "KingalCanyon",
+    "area_id": "KingalCanyon",
     "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 8}],
     "rewards": [
         {
@@ -27,57 +27,112 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15960,
+                    "item_id": "DemonWolfsSinewyMeat",
                     "num": 3
                 },
-                {					
-                    "item_id": 7555,
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
     ],
-    "blocks": [
+    "processes": [
         {
-            "type": "NpcTalkAndOrder",	
-            "stage_id": {
-                "id": 377,
-                "group_id": 1,
-                "layer_no": 1
-            },				
-            "npc_id": "Ciaran",
-            "message_id": 10800
-        },
-        {
-            "type": "DeliverItems",
-            "stage_id": {
-                "id": 377,
-                "group_id": 1
-            },
-            "npc_id": "Ciaran",
-            "announce_type": "Accept",
-            "items": [
+            "blocks": [
                 {
-                    "id": 15955,
-                    "amount": 5
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 377
+                    },
+                    "npc_id": "Ciaran",
+                    "message_id": 19694
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 921},
+                        {"type": "WeatherEq", "Param1": 1}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19695}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 921, "Param2": 2700},
+                        {"type": "WeatherEq", "Param1": 1}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19696}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19697}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 15955, "Param2": 5}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 377
+                    },
+                    "npc_id": "Ciaran",
+                    "items": [
+                        {
+                            "comment": "Kingalite",
+                            "id": 15955,
+                            "amount": 5
+                        }
+                    ],
+                    "message_id": 19698
                 }
-            ],
-            "message_id": 10737
+            ]
         },
         {
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 377,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Ciaran",
-            "message_id": 11842			
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "WeatherEq", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 4327},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19942}
+                    ],
+                    "check_commands": [
+                        {"type": "WeatherNotEq", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 4327},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 19943}
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017023.json
@@ -1,40 +1,41 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "Time Restriction: Daybreak Mining",
-    "quest_id": 21017005,
-    "base_level": 70,
+    "comment": "Time Restriction: Cloudy Excavation",
+    "quest_id": 21017023,
+    "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "KingalCanyon",
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 11}],
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 5772
+            "amount": 11233
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 750
+            "amount": 1662
         },
         {
             "type": "exp",
-            "amount": 3070
+            "amount": 5470
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": "ValleySpringWater",
+                    "item_id": "SmoothWhiteMud",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
                 {
                     "item_id": "SuperiorStrongGalaExtract",
-                    "num": 3
-                },
-                {
-                    "item_id": "Panacea",
                     "num": 3
                 }
             ]
@@ -49,17 +50,17 @@
                         "id": 377
                     },
                     "npc_id": "Ciaran",
-                    "message_id": 19689
+                    "message_id": 20031
                 },
                 {
                     "type": "Raw",
                     "announce_type": "Accept",
                     "check_commands": [
                         {"type": "StageNo", "Param1": 921},
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "WeatherEq", "Param1": 2}
                     ],
                     "result_commands": [
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19690}
+                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 20032}
                     ]
                 },
                 {
@@ -67,10 +68,10 @@
                     "announce_type": "Update",
                     "check_commands": [
                         {"type": "TalkNpc", "Param1": 921, "Param2": 2700},
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "WeatherEq", "Param1": 2}
                     ],
                     "result_commands": [
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19691}
+                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 20033}
                     ]
                 },
                 {
@@ -78,10 +79,10 @@
                     "announce_type": "Update",
                     "result_commands": [
                         {"type": "MyQstFlagOn", "Param1": 0},
-                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 19692}
+                        {"type": "QstTalkChg", "Param1": 2700, "Param2": 20034}
                     ],
                     "check_commands": [
-                        {"type": "HaveItemAllBag", "Param1": 15953, "Param2": 5}
+                        {"type": "HaveItemAllBag", "Param1": 16004, "Param2": 5}
                     ]
                 },
                 {
@@ -93,12 +94,12 @@
                     "npc_id": "Ciaran",
                     "items": [
                         {
-                            "comment": "Ringing Ore",
-                            "id": 15953,
+                            "comment": "Adamas Ore",
+                            "id": 16004,
                             "amount": 5
                         }
                     ],
-                    "message_id": 19693
+                    "message_id": 20035
                 }
             ]
         },
@@ -111,24 +112,24 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                        {"type": "WeatherEq", "Param1": 2}
                     ]
                 },
                 {
                     "type": "Raw",
                     "result_commands": [
-                        {"type": "QstLayoutFlagOn", "Param1": 4326},
-                        {"type": "CallMessage", "Param1": 1, "Param1": 19940}
+                        {"type": "QstLayoutFlagOn", "Param1": 4688},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 20106}
                     ],
                     "check_commands": [
-                        {"type": "IngameTimeRangeNotEq", "Param1": 5, "Param2": 10}
+                        {"type": "WeatherNotEq", "Param1": 2}
                     ]
                 },
                 {
                     "type": "Raw",
                     "result_commands": [
-                        {"type": "QstLayoutFlagOff", "Param1": 4326},
-                        {"type": "CallMessage", "Param1": 1, "Param1": 19941}
+                        {"type": "QstLayoutFlagOff", "Param1": 4688},
+                        {"type": "CallMessage", "Param1": 1, "Param1": 20107}
                     ]
                 }
             ]


### PR DESCRIPTION
Gathering world quests from Elan Water Grove, Farana Plains and Kingal Canyon now check for weather/time restrictions and turn on flag-based gathering nodes.

Additionally, three WQs were implemented:

- q21014023 (Time Restriction: Dredging at Dawn)
- q21015023 (Time Restriction: Mining in the Dead of Night)
- q21017023 (Time Restriction: Cloudy Excavation)