### PR TITLE
timer support: Add support for short quest timers

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/GenericQuest.cs
@@ -13,6 +13,7 @@ using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Arrowgene.Ddon.GameServer.Quests
 {
@@ -368,6 +369,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
 
             PatchRandomCommands(ref questProcessState, questState);
+            PatchTimerCommands(questProcessState, questState, client);
 
             return new List<CDataQuestProcessState>()
             {
@@ -409,6 +411,57 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 }
 
                 cmd.Param04 = questState.RandomSlots[slot];
+            }
+        }
+
+        // For any StartTimer result commands in the block, record the expiry time and schedule
+        // a one-shot callback that sends S2CQuestQuestProgressWorkSaveNtc so the client
+        // re-evaluates its IsEndTimer check command when the timer elapses.
+        private void PatchTimerCommands(CDataQuestProcessState processState, QuestState questState, GameClient client)
+        {
+            bool hasStartTimer = processState.ResultCommandList
+                .Any(c => c.Command == (ushort)QuestResultCommand.StartTimer);
+            if (!hasStartTimer)
+                return;
+
+            foreach (var cmd in processState.ResultCommandList)
+            {
+                if (cmd.Command != (ushort)QuestResultCommand.StartTimer)
+                    continue;
+
+                int timerNo = cmd.Param01;
+                int sec     = cmd.Param02;
+
+                // Skip if this timer was already started (re-dispatch of same block).
+                if (questState.TimerSlots.ContainsKey(timerNo))
+                    continue;
+
+                var expiry = DateTimeOffset.UtcNow.AddSeconds(sec);
+                questState.TimerSlots[timerNo] = expiry;
+
+                // Capture locals for the closure.
+                uint capturedScheduleId = QuestScheduleId;
+                bool personal = IsPersonal;
+                GameClient capturedClient = client;
+
+                int capturedTimerNo = timerNo;
+                var handle = new Timer(_ =>
+                {
+                    questState.TimerHandles.Remove(capturedTimerNo);
+
+                    var ntc = new S2CQuestTimerNtc()
+                    {
+                        QuestScheduleId = capturedScheduleId,
+                        TimerNo = (byte) capturedTimerNo
+                    };
+
+                    if (personal)
+                        capturedClient.Send(ntc);
+                    else
+                        capturedClient.Party.SendToAll(ntc);
+                }, null, TimeSpan.FromSeconds(sec), Timeout.InfiniteTimeSpan);
+
+                questState.TimerHandles[timerNo] = handle;
             }
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -53,6 +53,20 @@ namespace Arrowgene.Ddon.GameServer.Quests
         // Rolled values for SetRandom result commands, keyed by randomNo. Populated lazily
         // at block dispatch time; persists for the lifetime of this quest instance.
         public Dictionary<int, int> RandomSlots { get; set; } = [];
+        // Expiry times for StartTimer result commands, keyed by timerNo. Set at block dispatch
+        // time; used by the server-side timer callback to skip stale firings.
+        public Dictionary<int, DateTimeOffset> TimerSlots { get; set; } = [];
+        // Live System.Threading.Timer handles for active StartTimer countdowns, keyed by timerNo.
+        // Holding these references here prevents the GC from collecting (and thus cancelling) the
+        // timer before it fires. Disposed when the quest ends via DisposeTimers().
+        public Dictionary<int, System.Threading.Timer> TimerHandles { get; set; } = [];
+
+        public void DisposeTimers()
+        {
+            foreach (var t in TimerHandles.Values)
+                t.Dispose();
+            TimerHandles.Clear();
+        }
 
         public QuestState()
         {
@@ -383,6 +397,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
             var quest = GetQuest(questScheduleId);
             lock (ActiveQuests)
             {
+                if (ActiveQuests.TryGetValue(questScheduleId, out var questState))
+                    questState.DisposeTimers();
+
                 ActiveQuests.Remove(questScheduleId);
                 foreach (var location in quest.Locations)
                 {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300000.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300000.csx
@@ -39,13 +39,13 @@ public class ScriptedQuest : IQuest
             .AddCheckCmdIsTutorialQuestClear(QuestId.LivingWithThePartnerPawn);
         process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Barton, 24006);
         process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.TheWhiteDragonTemple0, NpcId.Barton, 24007);
-        process0.AddDeliverItemsBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Barton, ItemId.PineLumber, 15, 25003)
+        process0.AddDeliverItemsBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Barton, ItemId.PineLumber, 15, 25004)
             .AddCallback((param) => {
                 LibDdon.ChatMgr.SendMessageToPlayer(param.Client, LobbyChatMsgType.ManagementGuideC, "Quest menu decisions not implemented, selecting first choice");
             });
-        // TODO: Wait 3 minutes...
-        // This announce will misfire if the player logs out here
-        // Should investigate how to resume when updating this way
+        process0.AddDelayBlock(QuestAnnounceType.None, 1, 180)
+            .SetIsCheckpoint(true)
+            .AddResultCmdUpdateAnnounceDirect(7, QuestAnnounceType.Update);
         process0.AddTalkToNpcBlock(QuestAnnounceType.None, Stage.TheWhiteDragonTemple0, NpcId.Barton, 25002)
             .SetIsCheckpoint(true)
             .AddResultCmdUpdateAnnounceDirect(8, QuestAnnounceType.Update);

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -950,6 +950,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SQuestDecideDeliveryItemReq.Serializer());
             Create(new C2SQuestCancelPriorityQuestReq.Serializer());
             Create(new C2SQuestCancelNavigationQuestReq.Serializer());
+            Create(new S2CQuestTimerNtc.Serializer());
 
             Create(new C2SRankingBoardListReq.Serializer());
             Create(new C2SRankingRankListReq.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestTimerNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CQuestTimerNtc.cs
@@ -1,0 +1,34 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CQuestTimerNtc : IPacketStructure
+    {
+        public S2CQuestTimerNtc()
+        {
+        }
+
+        public PacketId Id => PacketId.S2C_QUEST_TIMER_NTC;
+        public uint QuestScheduleId { get; set; }
+        public byte TimerNo { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CQuestTimerNtc>
+        {
+
+            public override void Write(IBuffer buffer, S2CQuestTimerNtc obj)
+            {
+                WriteUInt32(buffer, obj.QuestScheduleId);
+                WriteByte(buffer, obj.TimerNo);
+            }
+
+            public override S2CQuestTimerNtc Read(IBuffer buffer)
+            {
+                S2CQuestTimerNtc obj = new S2CQuestTimerNtc();
+                obj.QuestScheduleId = ReadUInt32(buffer);
+                obj.TimerNo = ReadByte(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -781,7 +781,7 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_QUEST_11_106_16_NTC = new PacketId(11, 106, 16, "S2C_QUEST_11_106_16_NTC", ServerType.Game, PacketSource.Server); // <syslog_wm_statement_gauge_0_defeat>
         public static readonly PacketId S2C_QUEST_PLAY_INTERRUPT_RESULT_NTC = new PacketId(11, 107, 16, "S2C_QUEST_PLAY_INTERRUPT_RESULT_NTC", ServerType.Game, PacketSource.Server, "S2C_QUEST_11_107_16_NTC");
         public static readonly PacketId S2C_QUEST_11_108_16_NTC = new PacketId(11, 108, 16, "S2C_QUEST_11_108_16_NTC", ServerType.Game, PacketSource.Server); // The request to end the mission was successful (S2C_PLAY_FORCE_INTERRUPT_NOTICE?)
-        public static readonly PacketId S2C_QUEST_11_109_16_NTC = new PacketId(11, 109, 16, "S2C_QUEST_11_109_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId S2C_QUEST_TIMER_NTC = new PacketId(11, 109, 16, "S2C_QUEST_TIMER_NTC", ServerType.Game, PacketSource.Server, "S2C_QUEST_11_109_16_NTC");
         public static readonly PacketId S2C_QUEST_11_110_16_NTC = new PacketId(11, 110, 16, "S2C_QUEST_11_110_16_NTC", ServerType.Game, PacketSource.Server); // <syslog_quest_progress_failed> (S2C_FORT_DEFENSE_PLAY_START_NOTICE)
         public static readonly PacketId S2C_QUEST_11_111_16_NTC = new PacketId(11, 111, 16, "S2C_QUEST_11_111_16_NTC", ServerType.Game, PacketSource.Server); // Nothing?
         public static readonly PacketId S2C_QUEST_11_112_16_NTC = new PacketId(11, 112, 16, "S2C_QUEST_11_112_16_NTC", ServerType.Game, PacketSource.Server); // Nothing?
@@ -2713,7 +2713,7 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_QUEST_11_106_16_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_PLAY_INTERRUPT_RESULT_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_108_16_NTC);
-            AddPacketIdEntry(packetIds, S2C_QUEST_11_109_16_NTC);
+            AddPacketIdEntry(packetIds, S2C_QUEST_TIMER_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_110_16_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_111_16_NTC);
             AddPacketIdEntry(packetIds, S2C_QUEST_11_112_16_NTC);

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -388,10 +388,20 @@ PlayEmotion(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 
 ### IsEndTimer
 
+| Field | Value |
+|-------|-------|
+| Address | `0x00636BF0` |
+| Table index | 35 (check) |
+| Key callees | `FUN_0064d130(timerNo)` — Timer List A lookup at ctx+0xf0/0xfc; returns `entry+8` |
+
 ```
 /**
- * @brief
- * @param timerNo
+ * @brief Returns true when a quest instance timer (Timer List A) has expired.
+ * Walks the timer list keyed by timerNo; returns entry+8 == 0.
+ * Returns false (-1 sentinel) if timerNo is not registered.
+ * @note Pair with StartTimer(timerNo, sec). Server must schedule a QuestProgressNtc
+ *       to fire at expiry so the client re-evaluates this check.
+ * @param timerNo Timer slot identifier (set by StartTimer)
  */
 IsEndTimer(int timerNo, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -723,10 +733,19 @@ KeyItemPoint(int idx, int num, int param03 = 0, int param04 = 0);
 
 ### IsNotEndTimer
 
+| Field | Value |
+|-------|-------|
+| Address | `0x00638520` |
+| Table index | 65 (check) |
+| Key callees | `FUN_0064d130(timerNo)` — Timer List A lookup; returns `entry+8` |
+
 ```
 /**
- * @brief
- * @param timerNo
+ * @brief Returns true while a quest instance timer (Timer List A) is still running.
+ * Walks the timer list keyed by timerNo; returns 1 if entry+8 != 0 AND entry+8 != -1.
+ * Returns false if the timer has expired (entry+8==0) or is not registered (-1 sentinel).
+ * @note Logical inverse of IsEndTimer, but with an additional -1 guard.
+ * @param timerNo Timer slot identifier (set by StartTimer)
  */
 IsNotEndTimer(int timerNo, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -1078,18 +1097,37 @@ DieRaidBoss(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### CycleTimerZero
+
+| Field | Value |
+|-------|-------|
+| Address | `0x00639CD0` |
+| Table index | 99 (check) |
+| Key callees | `FUN_00be2460(this)` — reads byte flag at `this+0x649` |
+
 ```
 /**
- * @brief
+ * @brief Returns the cycle timer "reached zero" flag byte from the world quest manager.
+ * Reads a byte at cWorldQuestManager+0x649. Non-zero means the cycle timer hit zero.
+ * @note All params unused. Server evaluates from its own WorldQuestManager state.
  */
 CycleTimerZero(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### CycleTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x00639D20` |
+| Table index | 100 (check) |
+| Key callees | `FUN_00bdbbf0(this)` — returns remaining cycle time as float (`deadline - current` via `this+0x1d0`) |
+
 ```
 /**
- * @brief
- * @param timeSec
+ * @brief Returns true if the world quest cycle timer has at least timeSec seconds remaining.
+ * Computes remaining = deadline - current from the cycle timer object at this+0x1d0.
+ * Returns timeSec <= remaining.
+ * @note Server evaluates by reading WorldQuestManager's cycle timer state.
+ * @param timeSec Minimum seconds required to still be remaining
  */
 CycleTimer(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -1198,10 +1236,20 @@ IsKilledTargetEmSetGrpNoMarker(int flagNo, int param02 = 0, int param03 = 0, int
 ```
 
 ### IsLeftCycleTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x0063A6C0` |
+| Table index | 111 (check) |
+| Key callees | `FUN_00be1440(this)` — is timer running; `FUN_00bdc580()` — get elapsed time |
+
 ```
 /**
- * @brief
- * @param timeSec
+ * @brief Returns true if the cycle timer elapsed time is between a lower bound and timeSec.
+ * Guards on FUN_00be1440 (timer active check). Then: lowerBound <= elapsed <= timeSec.
+ * Used as a warning threshold: "the cycle is within timeSec seconds of completion."
+ * @note Server evaluates from WorldQuestManager elapsed state.
+ * @param timeSec Upper bound on elapsed seconds (warning threshold)
  */
 IsLeftCycleTimer(int timeSec, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -2316,10 +2364,19 @@ EndCycle(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### AddCycleTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x00638F40` |
+| Table index | 23 (result) |
+| Notes | **Client stub** — body is `return 1` only. Server controls the cycle timer. |
+
 ```
 /**
- * @brief
- * @param sec
+ * @brief Client stub. Intended to add sec seconds to the world quest cycle timer.
+ * The client does not manage the cycle timer; the server is the authority.
+ * @note Server should add sec to its WorldQuestManager cycle timer on execution.
+ * @param sec Seconds to add to the cycle timer
  */
 AddCycleTimer(int sec, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -2368,11 +2425,32 @@ PushImteToPlBag(int itemId, int itemNum, int param03 = 0, int param04 = 0);
 ```
 
 ### StartTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x00639190` |
+| Table index | 28 (result) |
+| Key callees | `FUN_009d0230(timerNo, sec)` — context validation; `FUN_0064de30(timerNo, sec)` — allocates entry in Timer List A (ctx+0xf0/0xfc), sets `entry+4=timerNo, entry+8=sec` |
+
 ```
 /**
- * @brief
- * @param timerNo
- * @param sec
+ * @brief Starts a named countdown timer in the quest instance (Timer List A).
+ * Allocates a new entry keyed by timerNo if not already present; stores sec as initial countdown.
+ * If timerNo already exists, the call is a no-op (timer is NOT reset).
+ * @note Timer List A is a dynamically resized pointer array (ctx+0xf0=count, ctx+0xf4=capacity,
+ *   ctx+0xfc=array ptr). When full it grows by 16 slots at a time (FUN_0064de30).
+ *   timerNo is a byte (u8, range 0–255) — the timer notification packet S2C_QUEST_11_109_16_NTC
+ *   carries it as a single byte, so max 256 distinct timers per quest instance.
+ *   Use small sequential values (0, 1, 2...). Because the no-op guard prevents reuse within the
+ *   same quest run, use a fresh timerNo for each logically distinct timer — there is no command
+ *   to delete or reset an instance timer.
+ * @note Server must:
+ *   1. Store (timerNo, expiryTime = now + sec) in quest state memory.
+ *   2. When the timer expires, send S2C_QUEST_11_109_16_NTC with QuestScheduleId (u32) +
+ *      timerNo (u8). Verified at FUN_007f49b0 / FUN_008185b0.
+ *   Short-lived (seconds to minutes) — memory only, no DB persistence needed.
+ * @param timerNo Timer slot identifier (u8, 0–255), referenced by IsEndTimer / IsNotEndTimer
+ * @param sec     Duration in seconds
  */
 StartTimer(int timerNo, int sec, int param03 = 0, int param04 = 0);
 ```
@@ -2682,9 +2760,20 @@ ResetTutorialFlag(int param01 = 0, int param02 = 0, int param03 = 0, int param04
 ```
 
 ### StartContentsTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x0063A760` |
+| Table index | 61 (result) |
+| Key callees | S3 season-phase guard (same as ID 246); `FUN_0064bbe0(&DAT_02189ff8)` — contents check; `FUN_0064b5a0(this)` — stores timer value at `this+8` |
+
 ```
 /**
- * @brief
+ * @brief S3-only: starts the contents-level timer if the season phase guard passes.
+ * All params are unused. The timer value is written via FUN_0064b5a0 to the contents timer object+8.
+ * Guarded by the same S3 season-phase pointer check as IsContentsModeTimerNotLess (246).
+ * @note Server should start its S3 contents timer on execution. This is a longer-lived timer
+ *       than StartTimer — may require SchedulerTask + DB persistence if it survives restarts.
  */
 StartContentsTimer(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -2748,17 +2837,35 @@ RemoveEndContentsPurpose(int announceNo, int param02 = 0, int param03 = 0, int p
 ```
 
 ### StopCycleTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x0063AA70` |
+| Table index | 68 (result) |
+| Notes | **Client stub** — body is `return 1` only. Server controls the cycle timer. |
+
 ```
 /**
- * @brief
+ * @brief Client stub. Intended to stop the world quest cycle timer.
+ * The client does not manage the cycle timer; the server is the authority.
+ * @note Server should pause its WorldQuestManager cycle timer on execution.
  */
 StopCycleTimer(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### RestartCycleTimer
+
+| Field | Value |
+|-------|-------|
+| Address | `0x0063ABA0` |
+| Table index | 69 (result) |
+| Notes | **Client stub** — body is `return 1` only. Server controls the cycle timer. |
+
 ```
 /**
- * @brief
+ * @brief Client stub. Intended to restart the world quest cycle timer.
+ * The client does not manage the cycle timer; the server is the authority.
+ * @note Server should reset/restart its WorldQuestManager cycle timer on execution.
  */
 RestartCycleTimer(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```


### PR DESCRIPTION
- Added support for short lived quest timers. Works in csx and json.
- Updated quest reference documentation with details from research.
- Added new packet S2C_QUEST_TIMER_NTC.
- Updated the quest "Extend Garden", q60300000.csx to use the new timer command since it has a sequence which waits 3 minutes.

If writing csx quests, there is a helper type AddDelayBlock.
If writing json quests need to use:
 - result command: StartTimer(timerNo, waitTimeInSeconds)
 - check command : IsEndTimer(timerNo), IsNotEndTimer(timerNo)