### PR TITLE
Personal quests

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300000.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300000.csx
@@ -9,7 +9,7 @@
 public class ScriptedQuest : IQuest
 {
     public override QuestType QuestType => QuestType.Tutorial;
-    public override QuestId QuestId => QuestId.ExtendGarden;
+    public override QuestId QuestId => QuestId.ExtendGarden; // Schedule ID: 1673527296
     public override ushort RecommendedLevel => 20;
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => true;
@@ -32,26 +32,104 @@ public class ScriptedQuest : IQuest
 
     protected override void InitializeBlocks()
     {
-        // https://www.youtube.com/watch?v=Dr2MRw2Vm1E
-
         var process0 = AddNewProcess(0);
         process0.AddRawBlock(QuestAnnounceType.None)
             .AddCheckCmdIsTutorialQuestClear(QuestId.LivingWithThePartnerPawn);
         process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Barton, 24006);
-        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.TheWhiteDragonTemple0, NpcId.Barton, 24007);
-        process0.AddDeliverItemsBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Barton, ItemId.PineLumber, 15, 25003)
-            .AddCallback((param) => {
-                LibDdon.ChatMgr.SendMessageToPlayer(param.Client, LobbyChatMsgType.ManagementGuideC, "Quest menu decisions not implemented, selecting first choice");
-            });
-        // TODO: Wait 3 minutes...
-        // This announce will misfire if the player logs out here
-        // Should investigate how to resume when updating this way
-        process0.AddTalkToNpcBlock(QuestAnnounceType.None, Stage.TheWhiteDragonTemple0, NpcId.Barton, 25002)
-            .SetIsCheckpoint(true)
-            .AddResultCmdUpdateAnnounceDirect(8, QuestAnnounceType.Update);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Barton, 24007)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(3277)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(3397)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(200, NpcId.Barton),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(0);
         process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.TheWhiteDragonTemple0)
             .AddResultCmdReleaseAnnounce(ContentsRelease.YourRoomsTerrace);
         process0.AddProcessEndBlock(true);
+
+		// Branch 1 - Deliver materials
+        var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCmdTalkNpcChoice(Stage.TheWhiteDragonTemple0, NpcId.Barton, 0);
+        process1.AddDeliverItemsBlock(QuestAnnounceType.Update, Stage.TheWhiteDragonTemple0, NpcId.Barton, ItemId.PineLumber, 15, 25004)
+            .AddResultCmdMyQstFlagOn(3277)
+			.AddResultCmdQstTalkChg(NpcId.Barton, 25003);
+        process1.AddDelayBlock(QuestAnnounceType.None, 1, 180)
+            .AddResultCmdQstLayoutFlagOn(6327)
+            .AddResultCmdQstLayoutFlagOn(6328)
+            .AddResultCmdQstLayoutFlagOn(6329)
+			.AddResultCmdQstTalkChg(NpcId.Barton, 25025)
+			.AddResultCmdQstTalkChg(NpcId.WhiteKnight0, 25022)
+			.AddResultCmdQstTalkChg(NpcId.WhiteKnight1, 25023)
+			.AddResultCmdQstTalkChg(NpcId.WhiteKnight2, 25024)
+            .AddResultCmdUpdateAnnounceDirect(7, QuestAnnounceType.Update);
+        process1.AddTalkToNpcBlock(QuestAnnounceType.None, Stage.TheWhiteDragonTemple0, NpcId.Barton, 25026)
+            .AddResultCmdUpdateAnnounceDirect(8, QuestAnnounceType.Update);
+        process1.AddProcessEndBlock(false)
+            .AddResultCmdMyQstFlagOn(0);
+
+		// Branch 2 - Gather personnel
+        var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCmdTalkNpcChoice(Stage.TheWhiteDragonTemple0, NpcId.Barton, 1);
+		process2.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdUpdateAnnounceDirect(2, QuestAnnounceType.Update)
+			.AddResultCmdQstTalkChg(NpcId.Barton, 25006)
+            .AddResultCmdMyQstFlagOn(3397)
+            .AddCheckCmdMyQstFlagOn(1)
+            .AddCheckCmdMyQstFlagOn(2)
+            .AddCheckCmdMyQstFlagOn(3);
+        process2.AddIsStageNoBlock(QuestAnnounceType.None, Stage.ArisensRoom);
+        process2.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.ArisensRoom, 0, 0, NpcId.Man510, 25009)
+            .AddResultCmdQstLayoutFlagOn(6324)
+            .AddResultCmdQstLayoutFlagOn(6325)
+            .AddResultCmdQstLayoutFlagOn(6326)
+            .AddResultCmdQstLayoutFlagOff(5675)
+            .AddResultCmdQstLayoutFlagOff(6320)
+            .AddResultCmdQstLayoutFlagOff(6321)
+			.AddResultCmdQstTalkChg(NpcId.Man511, 25011)
+			.AddResultCmdQstTalkChg(NpcId.Woman0, 25012);
+        process2.AddTalkToNpcBlock(QuestAnnounceType.Update, Stage.TheWhiteDragonTemple0, NpcId.Barton, 25002)
+			.AddResultCmdQstTalkChg(NpcId.Man510, 25010);
+        process2.AddProcessEndBlock(false)
+            .AddResultCmdMyQstFlagOn(0);
+
+		// Branch 2 - First worker
+        var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(3397);
+        process3.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.Lestania, 0, 0, NpcId.Man510, 25006)
+            .AddResultCmdQstLayoutFlagOn(5675);
+		process3.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdMyQstFlagOn(1);
+        process3.AddProcessEndBlock(false);
+
+		// Branch 2 - Second worker
+        var process4 = AddNewProcess(4);
+		process4.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(3397);
+        process4.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.Lestania, 1, 0, NpcId.Man511, 25007)
+            .AddResultCmdQstLayoutFlagOn(6320);
+		process4.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdMyQstFlagOn(2);
+        process4.AddProcessEndBlock(false);
+
+		// Branch 2 - Third worker
+        var process5 = AddNewProcess(5);
+		process5.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(3397);
+        process5.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.Lestania, 2, 0, NpcId.Woman0, 25008)
+            .AddResultCmdQstLayoutFlagOn(6321);
+		process5.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdMyQstFlagOn(3);
+        process5.AddProcessEndBlock(false);
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300010.csx
@@ -1,0 +1,109 @@
+/**
+ * @brief Mysterious Summoning Bell
+ * @cheats
+ *  /giveitem 7968 15
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60300010;
+    public override ushort RecommendedLevel => 15;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.ExtendGarden));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 7500);
+        AddWalletReward(WalletType.Gold, 7500);
+        AddWalletReward(WalletType.RiftPoints, 1500);
+        AddFixedItemReward(ItemId.ChattingBell, 1);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear(QuestId.ExtendGarden);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Barton, 26071);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Barton, 26072)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(200, NpcId.Barton, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(200, NpcId.Barton),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.ArisensRoom, 0, 0, NpcId.Sorcerer1, 60300010)
+            .AddResultCmdQstTalkChg(NpcId.Barton, 26074)
+            .AddResultCmdQstTalkChg(NpcId.Sorcerer1, 24016)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 5677);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdQstTalkChg(NpcId.Sorcerer1, 24017)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(1)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.NewTalkNpc(211, 0, 0, 60300010),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(3278)
+			]);
+        process0.AddDelayBlock(QuestAnnounceType.Update, 1, 180)
+            .AddResultCmdQstTalkChg(NpcId.Sorcerer1, 25028);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.ArisensRoom, 0, 0, NpcId.Sorcerer1, 60300010)
+            .AddResultCmdQstTalkChg(NpcId.Sorcerer1, 25029)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3282);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdPlayMessage(26120, 544)
+            .AddResultCmdTutorialDialog(TutorialId.PawnTacticsTraining);
+
+		var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(211, NpcId.Sorcerer1, 0)
+			]);
+		process1.AddNewDeliverItemsBlock(QuestAnnounceType.None, Stage.ArisensRoom, 0, 0, NpcId.Sorcerer1, ItemId.Amethyst, 10, 25014)
+            .AddResultCmdQstTalkChg(NpcId.Sorcerer1, 25015)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3278);
+
+		var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(211, NpcId.Sorcerer1, 1)
+			]);
+		process2.AddNewDeliverItemsBlock(QuestAnnounceType.None, Stage.ArisensRoom, 0, 0, NpcId.Sorcerer1, ItemId.PhantomOre, 5, 25016)
+            .AddResultCmdQstTalkChg(NpcId.Sorcerer1, 25017)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 1);
+		process2.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3278);
+
+		var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.StageNo(211),
+				QuestManager.CheckCommand.MyQstFlagOn(3282)
+			]);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.PlayMessage(25029, 544)
+			]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300104.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300104.csx
@@ -1,0 +1,72 @@
+/**
+ * @brief Adventure Spot Guide: Feryana Wilderness I
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60300104;
+    public override ushort RecommendedLevel => 85;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.MephiteTravelersInn;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.FeryanaWilderness, 2));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+        AddFixedItemReward(ItemId.GiantHusk, 3);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10; 
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter, Stage.ShrineoftheEternalBlaze, 16, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Goremanticore, 85, 215384, 0)
+                .SetIsAreaBoss(true)
+				.SetIsBoss(true)
+                .SetEnemyTargetTypesId(TargetTypesId.AreaBoss),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.MephiteTravelersInn, NpcId.Shekel, 25824);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.Accept, EnemyGroupId.Encounter)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 25825)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEnemyFoundForOrder(1093, 16, 0)
+			]);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(1093, 0) // Chest room
+			]);
+        process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 25826)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(635, NpcId.Shekel) 
+			]);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300105.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300105.csx
@@ -1,0 +1,82 @@
+/**
+ * @brief Adventure Spot Guide: Feryana Wilderness II
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60300105;
+    public override ushort RecommendedLevel => 88;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.MephiteTravelersInn;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.FeryanaWilderness, 5));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+        AddFixedItemReward(ItemId.ScorpionTailsHusk, 1);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10; 
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter, Stage.FalseRemains, 22, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyOgreLightArmor, 88, 218181, 0)
+                .SetIsAreaBoss(true)
+				.SetIsBoss(true)
+                .SetEnemyTargetTypesId(TargetTypesId.AreaBoss),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 88, 5454, 1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 5454, 2)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 5454, 3)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 5454, 4)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 5454, 5)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.MephiteTravelersInn, NpcId.Shekel, 25827);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.Accept, EnemyGroupId.Encounter)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 25828)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEnemyFoundForOrder(1061, 22, -1)
+			]);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(1061, 0) // Chest room
+			]);
+        process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 25829)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(635, NpcId.Shekel) 
+			]);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300106.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300106.csx
@@ -1,0 +1,88 @@
+/**
+ * @brief Adventure Spot Guide: Feryana Wilderness III
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60300106;
+    public override ushort RecommendedLevel => 88;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.MephiteTravelersInn;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.FeryanaWilderness, 8));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+        AddFixedItemReward(ItemId.RedHotSmeltedOre, 1);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10; 
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter, Stage.RestlessWaterChannel, 19, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 0)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 2)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 3)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonCyclops, 90, 110000, 4)
+                .SetIsAreaBoss(true)
+				.SetIsBoss(true)
+                .SetEnemyTargetTypesId(TargetTypesId.AreaBoss),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 5)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 6)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 7)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonWarg, 90, 4827, 8)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.MephiteTravelersInn, NpcId.Shekel, 25830);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.Accept, EnemyGroupId.Encounter)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 25831)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEnemyFoundForOrder(1024, 19, -1)
+			]);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(1024, 0) // Chest room
+			]);
+        process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 25832)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(635, NpcId.Shekel) 
+			]);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318001.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318001.csx
@@ -1,0 +1,149 @@
+/**
+ * @brief Rathnite Foothills Rescue Request
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60318001; // Schedule ID: 1676935296
+    public override ushort RecommendedLevel => 81;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.RathniteFoothills;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+        public const uint Encounter1 = 11;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.RathniteFoothills, 2));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.GustyWindsStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.RathniteFoothills, 8, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 81, 4200, 4),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 81, 4200, 5),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 81, 4200, 6),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 81, 4200, 8),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter1, Stage.RathniteFoothills, 65, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 81, 4200, 4)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 81, 4200, 5)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 81, 4200, 7)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdCheckAreaRank(QuestAreaId.RathniteFoothills, 2);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.RathniteFoothills, 1, 0, NpcId.Guy, 60318001)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 5679)
+            .AddResultCmdQstTalkChg(NpcId.Guy, 24049);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Guy, 24050),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Fran, 23643)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(130, NpcId.Fran),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Fran, 23647)
+			]);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0, resetGroup: false)
+			.AddResultCommands([
+				QuestManager.ResultCommand.StartTimer(1, 20)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.RathniteFoothills, 1, 0, NpcId.Guy, 60318001)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(2962),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Guy, 24026)
+			]);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(130, NpcId.Fran, 0)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEndTimer(2),
+				QuestManager.CheckCommand.MyQstFlagOff(2962)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5565),
+				QuestManager.ResultCommand.CallGeneralAnnounce(1, 100216)
+			]);
+
+        var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(130, NpcId.Fran, 1)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEndTimer(2),
+				QuestManager.CheckCommand.MyQstFlagOff(2962)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5699),
+				QuestManager.ResultCommand.CallGeneralAnnounce(1, 100216)
+			]);
+
+        var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(10)
+			]);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEndTimer(1),
+				QuestManager.CheckCommand.MyQstFlagOff(2962)
+			]);
+        process3.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter1)
+			.AddResultCommands([
+				QuestManager.ResultCommand.StartTimer(2, 30),
+				QuestManager.ResultCommand.CallGeneralAnnounce(1, 100217)
+			]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318002.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318002.csx
@@ -1,0 +1,149 @@
+/**
+ * @brief Rathnite Foothills Liberation Army Support
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60318002; // Schedule ID: 1676935424
+    public override ushort RecommendedLevel => 81;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.RathniteFoothills;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+        public const uint Encounter1 = 11;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.RathniteFoothills, 2));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.AnimalHunterStoneShard, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.RathniteFoothills, 9, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 81, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.Behemoth0, 81, 105000, 1)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 81, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 81, 4200, 3),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 81, 4200, 6),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter1, Stage.CaveofHellsDescent, 19, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Gorecyclops0, 78, 51692, 3)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.Saurian, 78, 5168, 4)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.Saurian, 78, 5168, 5)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.Saurian, 78, 5168, 6)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.Saurian, 78, 5168, 7)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdCheckAreaRank(QuestAreaId.RathniteFoothills, 2);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.RathniteFoothills, 0, 0, NpcId.Derek, 60318002)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 5680)
+            .AddResultCmdQstTalkChg(NpcId.Derek, 23648);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Derek, 23650)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(1)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.NewTalkNpc(130, 0, 0, 60318002),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+        process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(2)
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter0)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(5, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Derek, 24331)
+			]);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter0, resetGroup: false)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(6, 3)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.RathniteFoothills, 0, 0, NpcId.Derek, 60318002)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(7, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Derek, 23652)
+			]);
+        process0.AddProcessEndBlock(true);
+
+		// Branch 1 - Procure supplies
+        var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(130, NpcId.Derek, 0)
+			]);
+		process1.AddNewDeliverItemsBlock(QuestAnnounceType.None, Stage.RathniteFoothills, 0, 0, NpcId.Derek, ItemId.PlanktonLiquid, 5, 24326)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(0),
+				QuestManager.ResultCommand.UpdateAnnounceDirect(1, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Derek, 23649)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(2)
+			]);
+
+		//Branch 2 - Survey spots
+        var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(130, NpcId.Derek, 1)
+			]);
+        process2.AddDiscoverGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter1)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(1),
+				QuestManager.ResultCommand.UpdateAnnounceDirect(2, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Derek, 23651)
+			]);
+        process2.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter1, resetGroup: false)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(3, 3)
+			]);
+        process2.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.RathniteFoothills, 0, 0, NpcId.Derek, 60318002)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(4, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Derek, 24323)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(2)
+			]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318003.csx
@@ -1,0 +1,173 @@
+/**
+ * @brief Rathnite Foothills Trial: Rathnite Foothills Pursue and Defeat Enemies
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60318003; // Schedule ID: 1676935552
+    public override ushort RecommendedLevel => 83;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.RathniteFoothills;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.RathniteFoothills, 5));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.DemihumanCutterStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.RathniteFoothillsLakeside0, 31, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BlackGriffin0, 83, 105000, 0),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 83, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 83, 4200, 2),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdCheckAreaRank(QuestAreaId.RathniteFoothills, 5);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.RathniteFoothills, 0, 0, NpcId.Dana, 60318003)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 5681)
+            .AddResultCmdQstTalkChg(NpcId.Dana, 23653);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Dana, 23654)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(130, NpcId.Dana, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.NewTalkNpc(130, 0, 0, 60318003),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Dana, 23655),
+				QuestManager.ResultCommand.SetRandom(1, 1, 2, 1)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6205)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6206)
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddResultCommands([
+				QuestManager.ResultCommand.SetRandom(2, 1, 2, 1)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(0)
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.RathniteFoothills, 0, 0, NpcId.Dana, 60318003)
+            .AddResultCmdQstTalkChg(NpcId.Dana, 23656);
+        process0.AddProcessEndBlock(true);
+
+		var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.RandomEq(1, 1)
+			]);
+        process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(6203)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 0, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 1, 0, 0)
+			]);
+        process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6203),
+				QuestManager.ResultCommand.QstLayoutFlagOn(6205)
+			]);
+
+		var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.RandomEq(1, 2)
+			]);
+        process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(6204)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 0, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 1, 0, 0)
+			]);
+        process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6204),
+				QuestManager.ResultCommand.QstLayoutFlagOn(6206)
+			]);
+
+		var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.RandomEq(2, 1)
+			]);
+        process3.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(6205)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 2, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 3, 0, 0)
+			]);
+        process3.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6205),
+				QuestManager.ResultCommand.MyQstFlagOn(0)
+			]);
+
+		var process4 = AddNewProcess(4);
+		process4.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.RandomEq(2, 2)
+			]);
+        process4.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(6206)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 2, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(131, 3, 0, 0)
+			]);
+        process4.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6206),
+				QuestManager.ResultCommand.MyQstFlagOn(0)
+			]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318004.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60318004.csx
@@ -1,0 +1,126 @@
+/**
+ * @brief Rathnite Foothills: Prevent Enemy Attack
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60318004; // Schedule ID: 1676935680
+    public override ushort RecommendedLevel => 83;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.RathniteFoothills;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.RathniteFoothills, 5));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.DemihumanCutterStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.RathniteFoothills, 19, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 83, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 83, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 83, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.Gorechimera0, 83, 105000, 3)
+				.SetIsBoss(true),
+        });
+    }
+
+    protected override void InitializeBlocks() // flag 5682 dudley 6266 shenay 6267 versa 6268 keik 5568 anna
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdCheckAreaRank(QuestAreaId.RathniteFoothills, 5);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.RathniteFoothills, 0, 0, NpcId.Dudley, 60318004)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 5682)
+            .AddResultCmdQstTalkChg(NpcId.Dudley, 23658);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Dudley, 23659)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6266)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6267)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6268)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.NewTalkNpc(130, 0, 0, 60318004),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.QuestTalkNpcRadius(131, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.QuestTalkNpcRadius(131, 1, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.QuestTalkNpcRadius(131, 2, 0)
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.RathniteFoothills, 0, 0, NpcId.Dudley, 23662);
+        process0.AddProcessEndBlock(true);
+
+		// Branch 1 - Shenay
+		var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCmdTalkNpcChoice(Stage.RathniteFoothills, NpcId.Dudley, 0);
+		process1.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6266)
+			.AddResultCmdQstTalkChgFsm(NpcId.Shenai, 23660)
+			.AddResultCmdQstTalkChgFsm(NpcId.Dudley, 24441)
+			.AddCheckCmdIsMyquestLayoutFlagOn(10);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCmdQstTalkChgFsm(NpcId.Shenai, 23661);
+
+
+		// Branch 2 - Versa
+		var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCmdTalkNpcChoice(Stage.RathniteFoothills, NpcId.Dudley, 1);
+		process2.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6267)
+			.AddResultCmdQstTalkChgFsm(NpcId.Versa, 24437)
+			.AddResultCmdQstTalkChgFsm(NpcId.Dudley, 24442)
+			.AddCheckCmdIsMyquestLayoutFlagOn(10);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCmdQstTalkChgFsm(NpcId.Versa, 24439);
+
+		//Branch 3 - Keik
+		var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCmdTalkNpcChoice(Stage.RathniteFoothills, NpcId.Dudley, 2);
+		process3.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6268)
+			.AddResultCmdQstTalkChgFsm(NpcId.Keiku, 24438)
+			.AddResultCmdQstTalkChgFsm(NpcId.Dudley, 24436)
+			.AddCheckCmdIsMyquestLayoutFlagOn(10);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCmdQstTalkChgFsm(NpcId.Keiku, 24440);
+
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319000.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319000.csx
@@ -7,7 +7,7 @@
 public class ScriptedQuest : IQuest
 {
     public override QuestType QuestType => QuestType.Tutorial;
-    public override QuestId QuestId => (QuestId)60319000;
+    public override QuestId QuestId => (QuestId)60319000; // Schedule ID: 1677099008
     public override ushort RecommendedLevel => 86;
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => false;
@@ -61,7 +61,7 @@ public class ScriptedQuest : IQuest
 			.AddCheckCommands([
 				QuestManager.CheckCommand.MyQstFlagOn(3249)
 			]);
-        process0.AddTalkToNpcBlock(QuestAnnounceType.Checkpoint, Stage.MephiteTravelersInn, NpcId.Nayajiku, 23871);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.None, Stage.MephiteTravelersInn, NpcId.Nayajiku, 23871);
         process0.AddProcessEndBlock(true);
 
 		// Branch 1 - Drew

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319010.csx
@@ -7,7 +7,7 @@
 public class ScriptedQuest : IQuest
 {
     public override QuestType QuestType => QuestType.Tutorial;
-    public override QuestId QuestId => (QuestId)60319010;
+    public override QuestId QuestId => (QuestId)60319010; // Schedule ID: 1677100288
     public override ushort RecommendedLevel => 88;
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => false;
@@ -58,11 +58,14 @@ public class ScriptedQuest : IQuest
 			.AddCheckCommands([
 				QuestManager.CheckCommand.MyQstFlagOn(1)
 			]);
-        process0.AddTalkToNpcBlock(QuestAnnounceType.Checkpoint, Stage.LookoutCastle1, NpcId.Nayajiku, 25704)
+        process0.AddTalkToNpcBlock(QuestAnnounceType.None, Stage.LookoutCastle1, NpcId.Nayajiku, 25704)
 			.AddResultCommands([
 				QuestManager.ResultCommand.UpdateAnnounceDirect(9, 3)
 			]);
-        process0.AddProcessEndBlock(true);
+        process0.AddProcessEndBlock(true)
+			.AddResultCommands([
+				QuestManager.ResultCommand.WorldManageLayoutFlagOn(1216, 70000001)
+			]);
 
 		// Branch 1 - Gerald
 		var process1 = AddNewProcess(1);
@@ -110,34 +113,45 @@ public class ScriptedQuest : IQuest
 				QuestManager.ResultCommand.MyQstFlagOn(0),
 				QuestManager.ResultCommand.QstTalkChg(NpcId.Shekel, 23896)
 			]);
+        process2.AddDelayBlock(QuestAnnounceType.None, 1, 180)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5612),
+				QuestManager.ResultCommand.UpdateAnnounceDirect(4, 3)
+			]);
 		process2.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.UpdateAnnounceDirect(5, 3),
-				QuestManager.ResultCommand.WorldManageLayoutFlagOff(1216, 70000001)
+				QuestManager.ResultCommand.UpdateAnnounceDirect(5, 3)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.StageNo(635)
 			]);
-        process2.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.MephiteTravelersInn, 0, 0, NpcId.Klaus0, 60319010) // No timer implementation so just talk to him
+        process2.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.MephiteTravelersInn, 0, 0, NpcId.Klaus0, 60319010)
 			.AddResultCommands([
 				QuestManager.ResultCommand.MyQstFlagOn(3366),
-				QuestManager.ResultCommand.QstLayoutFlagOn(5612),
 				QuestManager.ResultCommand.QstTalkChg(NpcId.Klaus0, 25696)
 			]);
 		process2.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(3420),
 				QuestManager.ResultCommand.MyQstFlagOn(1),
 				QuestManager.ResultCommand.QstTalkChg(NpcId.Klaus0, 25697)
-			])
+			]);
+
+		var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
 			.AddCheckCommands([
-				QuestManager.CheckCommand.StageNo(451)
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(5612)
 			]);
-		process2.AddRawBlock(QuestAnnounceType.None)
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.StageNoNotEq(201)
+			]);
+		process3.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.QstLayoutFlagOff(5612),
-				QuestManager.ResultCommand.QstTalkDel(NpcId.Klaus0),
-				QuestManager.ResultCommand.WorldManageLayoutFlagOn(1216, 70000001)
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Klaus0, 25695),
+				QuestManager.ResultCommand.WorldManageLayoutFlagOff(1216, 70000001)
 			]);
+
     }
 }
 return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319011.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319011.csx
@@ -7,7 +7,7 @@
 public class ScriptedQuest : IQuest
 {
     public override QuestType QuestType => QuestType.Tutorial;
-    public override QuestId QuestId => (QuestId)60319011;
+    public override QuestId QuestId => (QuestId)60319011; // Schedule ID: 1677100416
     public override ushort RecommendedLevel => 88;
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => false;
@@ -289,6 +289,7 @@ public class ScriptedQuest : IQuest
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LookoutCastle1, NpcId.Nayajiku, 25737)
 			.AddResultCommands([
 				QuestManager.ResultCommand.MyQstFlagOn(3377),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6407),
 				QuestManager.ResultCommand.QstTalkChg(NpcId.Guy, 23906)
 			]);
         process0.AddProcessEndBlock(true);

--- a/Arrowgene.Ddon.Scripts/scripts/quests/world_manage/q79000003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/world_manage/q79000003.csx
@@ -18,6 +18,28 @@ public class ScriptedQuest : IQuest
         process0.AddNoProgressBlock();
         process0.AddNoProgressBlock();
         process0.AddProcessEndBlock(false);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsTutorialQuestClear(60318011)
+			]);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.WorldManageQuest, QuestFlagAction.Set, 3284, (QuestId)70030001)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+
+        var process2 = AddNewProcess(2);
+        process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsTutorialQuestClear(60319011)
+			]);
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagType.WorldManageQuest, QuestFlagAction.Set, 3286, (QuestId)70031001)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
     }
 }
 


### PR DESCRIPTION
The following quests have been added:

- q60300010 (Mysterious Summoning Bell)
- q60318001 (Rathnite Foothills: Rescue Request)
- q60318002 (Rathnite Foothills: Liberation Army Support)
- q60318003 (Rathnite Foothills: Pursue and Defeat Enemies)
- q60318004 (Rathnite Foothills: Prevent Enemy Attack)

The following quests have been changed:

- q60300000 (Extend Garden): Both branches are now fully functional.
- q60319000 (Feryana Wilderness Trial: Supply Unit Support): Removed a checkpoint at the end due to issues.
- q60319010 (Feryana Wilderness Trial: Investigate Sealed Evil): Klaus timer step was implemented. Klaus now only vanishes from the Audience Chamber when you leave the stage. Removed a checkpoint at the end due to issues.
- q60319011 (Into the Ancient Darkness): Disabled a flag near the end to avoid an issue with the final checkpoint.
- q79000003: Now holds flags from q60318011 and q60319011 so you can reaccess these areas after you complete the trials.