### PR TITLE
More personal quests

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000014.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000014.csx
@@ -55,8 +55,8 @@ public class ScriptedQuest : IQuest
             .AddResultCmdTutorialDialog(TutorialId.RewardMissions)
             .AddResultCmdReleaseAnnounce(ContentsRelease.GrandMissions, flagInfo: QuestFlags.NpcFunctions.GrandMission)
             // TODO: Issac, Dooris, Endale and Nayajiku might be unlocked at different points
-            .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.SenekaExm)
-            .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.IsaacExm)
+            //.AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.SenekaExm)
+            //.AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.IsaacExm)
             .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.DorisExm)
             .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.EndaleExm)
             .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.NayajikuExm);

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000100.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000100.csx
@@ -1,0 +1,43 @@
+/**
+ * @brief Further Signs of Misfortune
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60000100; // Schedule ID: 1610629120
+    public override ushort RecommendedLevel => 60;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 0);
+        AddWalletReward(WalletType.Gold, 0);
+        AddWalletReward(WalletType.RiftPoints, 0);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.ExtremeMissionCleared((QuestId)50000003));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.BeForevermoreWhiteDragon);
+        process0.AddNpcTouchAndOrderBlock(Stage.AudienceChamber, NpcId.TheWhiteDragon, 0);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.AudienceChamber, 105, 2);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.AudienceChamber, NpcId.Joseph, 16094)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 13026);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000101.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000101.csx
@@ -1,0 +1,48 @@
+/**
+ * @brief Whirls of Dragon Force
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60000101; // Schedule ID: 1610629248
+    public override ushort RecommendedLevel => 55;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 0);
+        AddWalletReward(WalletType.Gold, 0);
+        AddWalletReward(WalletType.RiftPoints, 0);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.BeForevermoreWhiteDragon));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.BeForevermoreWhiteDragon);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Seneka0, 16732);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddCheckCmdTouchActToNpc(Stage.AudienceChamber, NpcId.Joseph)
+            .AddResultCmdQstTalkChg(NpcId.Seneka0, 16906);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.AudienceChamber, 103, 6);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Seneka0, 16717)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 16909);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdTutorialDialog(TutorialId.ExtremeMissions)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.SenekaExm);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200002.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200002.csx
@@ -1,0 +1,52 @@
+/**
+ * @brief Dangerous Footsteps
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200002; // Schedule ID: 1652556032
+    public override ushort RecommendedLevel => 57;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 3600);
+        AddWalletReward(WalletType.Gold, 900);
+        AddWalletReward(WalletType.RiftPoints, 120);
+
+        AddFixedItemReward(ItemId.CorruptionCure, 1);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheFateOfLestania));
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60000101));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.TheFateOfLestania);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 18044)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 3737);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddCheckCmdTouchActToNpc(Stage.AudienceChamber, NpcId.ArisenCorpsRegimentalSoldier8);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.BloodbaneIsle1, 0, 0, QuestJumpType.Before, Stage.AudienceChamber);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.AudienceChamber, 160, 6, QuestJumpType.Before, Stage.BloodbaneIsle1);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18046)
+			.AddResultCmdQstTalkChg(NpcId.Joseph, 18045)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 3737);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.IsaacExm);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200003.csx
@@ -1,0 +1,49 @@
+/**
+ * @brief Signs of Chaos
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200003; // Schedule ID: 1652556160
+    public override ushort RecommendedLevel => 65;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 1970);
+        AddWalletReward(WalletType.Gold, 1072);
+        AddWalletReward(WalletType.RiftPoints, 137);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheEntrustedOne));
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60200002));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.TheEntrustedOne);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 18047)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 3751);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddCheckCmdTouchActToNpc(Stage.AudienceChamber, NpcId.ArisenCorpsRegimentalSoldier9);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.Lestania, 150, 159, QuestJumpType.Before, Stage.AudienceChamber);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.AudienceChamber, 165, 6, QuestJumpType.Before, Stage.Lestania);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18049)
+			.AddResultCmdQstTalkChg(NpcId.Joseph, 18048)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 3751);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200004.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200004.csx
@@ -1,0 +1,43 @@
+/**
+ * @brief Supreme Radiance
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200004; // Schedule ID: 1652556288
+    public override ushort RecommendedLevel => 70;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.RoadToMastery));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 15350);
+        AddWalletReward(WalletType.Gold, 4618);
+        AddWalletReward(WalletType.RiftPoints, 600);
+        AddFixedItemReward(ItemId.SupremeMeritMedal, 1);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear(QuestId.RoadToMastery);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Renton0, 24394);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.CraftRoom, NpcId.Sonia, 24396)
+			.AddResultCmdQstTalkChg(NpcId.Renton0, 24395);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdPlayMessage(24397, 1026);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200006.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200006.csx
@@ -1,0 +1,49 @@
+/**
+ * @brief The Treasure Lying in the Frontier 1
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200006; // Schedule ID: 1652556544
+    public override ushort RecommendedLevel => 60;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60200012));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 1891);
+        AddWalletReward(WalletType.Gold, 990);
+        AddWalletReward(WalletType.RiftPoints, 125);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18056);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Isaac, 18057)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(802, 0) // Cesspool of Filth
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(804, 0) // Statuary Hollow
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(821, 0) // Frigid Ancient Passage
+			]);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18058);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200007.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200007.csx
@@ -1,0 +1,55 @@
+/**
+ * @brief The Treasure Lying in the Frontier 2
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200007; // Schedule ID: 1652556672
+    public override ushort RecommendedLevel => 65;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60200006));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 1992);
+        AddWalletReward(WalletType.Gold, 1022);
+        AddWalletReward(WalletType.RiftPoints, 130);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18059);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Isaac, 18060)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(809, 0) // Scorching Blockade
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(822, 0) // Crypt of Murmurs
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(842, 0) // Towerside Dry Well
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(850, 0) // Misty Illusion Terrace
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(871, 0) // Penitentiary
+			]);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18061);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200008.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200008.csx
@@ -1,0 +1,51 @@
+/**
+ * @brief The Treasure Lying in the Frontier 3
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200008; // Schedule ID: 1652556800
+    public override ushort RecommendedLevel => 65;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60200003));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 1970);
+        AddWalletReward(WalletType.Gold, 1072);
+        AddWalletReward(WalletType.RiftPoints, 137);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear((QuestId)60200003);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18062);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Isaac, 18063)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(807, 0) // Bridgeside Tunnel
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(825, 0) // Gardnox Sewers
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(872, 0) // Mysterious Mausoleum
+			]);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18064);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200009.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200009.csx
@@ -1,0 +1,57 @@
+/**
+ * @brief The Treasure Lying in the Frontier 4
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200009; // Schedule ID: 1652556928
+    public override ushort RecommendedLevel => 65;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60200008));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 1970);
+        AddWalletReward(WalletType.Gold, 1072);
+        AddWalletReward(WalletType.RiftPoints, 137);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear((QuestId)60200008);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18125);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Isaac, 18127)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(803, 0) // Echo Cascade Cavern
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(806, 0) // Fungal Colony Caves
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(841, 0) // Forsaken Well
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(843, 0) // Hidden Observatory
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.SceHitIn(851, 0) // Soaring Sky Terrace
+			]);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18129);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200012.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60200012.csx
@@ -1,0 +1,46 @@
+/**
+ * @brief The Treasure Sleeping in the Ark
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60200012; // Schedule ID: 1652557312
+    public override ushort RecommendedLevel => 57;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60200002));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 3600);
+        AddWalletReward(WalletType.Gold, 990);
+        AddWalletReward(WalletType.RiftPoints, 120);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18374);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.BlackGrapeInn, NpcId.Alfred, 18376)
+            .AddResultCmdQstTalkChg(NpcId.Isaac, 18375);
+        process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
+            .AddResultCmdQstTalkChg(NpcId.Alfred, 18377)
+			.AddCheckCmdIsStageNo(Stage.TheArksLowerLevel);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdQstTalkChg(NpcId.Isaac, 18378)
+			.AddCheckCmdSceHitIn(Stage.TheArksLowerLevel, 0);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Isaac, 18379);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50101020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50101020.json
@@ -15,7 +15,7 @@
         "phase_groups": []
     },
     "order_conditions": [
-        {"type": "MainQuestCompleted", "Param1": 30}
+        {"type": "ClearPersonalQuest", "Param1": 60000101}
     ],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50104000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50104000.json
@@ -15,7 +15,7 @@
         "phase_groups": []
     },
     "order_conditions": [
-        {"type": "ClearExtremeMission", "Param1": 50103020}
+        {"type": "ClearPersonalQuest", "Param1": 60000100}
     ],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50201000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50201000.json
@@ -15,7 +15,7 @@
         "phase_groups": []
     },
     "order_conditions": [
-        {"type": "ClearExtremeMission", "Param1": 50104000}
+        {"type": "ClearPersonalQuest", "Param1": 60200002}
     ],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50202000.json
@@ -15,7 +15,7 @@
         "phase_groups": []
     },
     "order_conditions": [
-        {"type": "ClearExtremeMission", "Param1": 50201000}
+        {"type": "ClearPersonalQuest", "Param1": 60200003}
     ],
     "rewards": [
         {


### PR DESCRIPTION
The following quests have been added:

- q60000100 (Further Signs of Misfortune)
- q60000101 (Whirls of Dragon Force) - Unlocks Seneka EXMs
- q60200002 (Dangerous Footsteps) - Unlocks Isaac EXMs
- q60200003 (Signs of Chaos)
- q60200004 (Supreme Radiance)
- q60200006 (The Treasure Lying in the Frontier 1)
- q60200007 (The Treasure Lying in the Frontier 2)
- q60200008 (The Treasure Lying in the Frontier 3)
- q60200009 (The Treasure Lying in the Frontier 4)
- q60200012 (The Treasure Sleeping in the Ark)

Additionally, the following changes to existing quests have been made:

- Reliable Source of Information: No longer unlocks Seneka's or Isaac's Extreme Missions.
- EM1 (Call of the Catacombs): Now requires Whirls of Dragon Force.
- EM4 (The Shining Gate): Now requires Further Signs of Misfortune.
- EM5 (Agent of Corruption): Now requires Dangerous Footseps.
- EM6 (Phantasmic Great Dragon): Now requires Signs of Chaos.
