### PR TITLE
fix: Fix stale world prioirty quest

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestCancelHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestCancelHandler.cs
@@ -18,37 +18,31 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
             var quest = QuestManager.GetQuestByScheduleId(packet.QuestScheduleId);
             var questStateManager = QuestManager.GetQuestStateManager(client, quest);
-            Server.Database.RemoveQuestProgress(client.Character.CommonId, quest.QuestScheduleId, quest.QuestType);
-            
             bool isPriority = Server.Database.DeletePriorityQuest(client.Character.CommonId, quest.QuestScheduleId);
+            Server.Database.RemoveQuestProgress(client.Character.CommonId, quest.QuestScheduleId, quest.QuestType);
 
-            if (quest.IsPersonal)
+            bool isLeaderOrSolo = client.Party.IsSolo || client.Party.Leader?.Client == client;
+            if (quest.IsPersonal || isLeaderOrSolo)
             {
                 questStateManager.CancelQuest(quest.QuestScheduleId);
 
-                if (isPriority && (client.Party.IsSolo || client.Party.Leader?.Client == client))
+                S2CQuestQuestCancelNtc cancelNtc = new S2CQuestQuestCancelNtc()
                 {
-                    client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client).Send();
+                    QuestId = (uint)quest.QuestId,
+                    QuestScheduleId = quest.QuestScheduleId
+                };
+                client.Send(cancelNtc);
+
+                if (!quest.IsPersonal && !client.Party.IsSolo)
+                {
+                    client.Party.SendToAllExcept(cancelNtc, client);
                 }
             }
-            else
+
+            if (isPriority && isLeaderOrSolo)
             {
-                if (client.Party.Leader?.Client == client) //Only the leader should be able to inform the party quest state.
-                {
-                    questStateManager.CancelQuest(quest.QuestScheduleId);
-
-                    S2CQuestQuestCancelNtc cancelNtc = new S2CQuestQuestCancelNtc()
-                    {
-                        QuestId = (uint)quest.QuestId,
-                        QuestScheduleId = quest.QuestScheduleId
-                    };
-                    client.Party.SendToAllExcept(cancelNtc, client);
-
-                    if (isPriority)
-                    {
-                        client.Party.QuestState.UpdatePriorityQuestList(client).Send();
-                    }
-                }
+                var leaderClient = client.Party.Leader?.Client ?? client;
+                client.Party.QuestState.UpdatePriorityQuestList(leaderClient).Send();
             }
             
             return new S2CQuestQuestCancelRes()

--- a/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/StageAreaChangeHandler.cs
@@ -113,12 +113,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
                                     Type = LobbyChatMsgType.ManagementAlertC,
                                     Message = "A quest has been canceled because the\ndelivery time period has ended."
                                 }, queue);
-
-                                if (member.Party.IsSolo || member.Party.Leader?.Client == member)
-                                {
-                                    queue.AddRange(member.Party.QuestState.UpdatePriorityQuestList(member.Party.Leader.Client, connection));
-                                }
                             }
+                        }
+
+                        if (client.Party.IsSolo || client.Party.Leader?.Client == client)
+                        {
+                            queue.AddRange(client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client, connection));
                         }
                     });
                 }

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -443,6 +443,15 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             var quest = GetQuest(questScheduleId);
             RemoveQuest(questScheduleId);
+
+            if (QuestManager.IsWorldQuest(quest))
+            {
+                lock (ActiveQuests)
+                {
+                    CompletedWorldQuests.Add(quest.QuestId);
+                    RolledInstanceWorldQuests[quest.QuestAreaId].Remove(questScheduleId);
+                }
+            }
         }
 
         public void CompleteQuest(uint questScheduleId)
@@ -1119,12 +1128,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             PacketQueue packets = new();
 
-            if (Party.Leader is null || requestingClient != Party.Leader.Client)
+            var leaderClient = Party.Leader?.Client ?? (Party.IsSolo ? requestingClient : null);
+            if (leaderClient is null || requestingClient != leaderClient)
             {
                 return packets;
             }
-
-            var leaderClient = Party.Leader.Client;
 
             S2CQuestSetPriorityQuestNtc prioNtc = new S2CQuestSetPriorityQuestNtc()
             {


### PR DESCRIPTION
- Fixed an issue where canceled world quests show back to being tracked on instance reset.
- Fixed an issue where the cancel NTC was not sent properly when playing solo
- Fixed an issue where the priority number was not calculated correctly when accepting new quests
