### PR TITLE
fix: Add a server config for IANA ID

### DIFF
--- a/Arrowgene.Ddon.GameServer/Quests/WorldQuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/WorldQuestManager.cs
@@ -38,8 +38,9 @@ namespace Arrowgene.Ddon.GameServer
                 return;
 
             var settings = _server.GameSettings.GameServerSettings;
-            long seed = ComputeCurrentPeriodSeed(settings.WorldQuestResetDay, settings.WorldQuestResetHour, settings.WorldQuestResetMinute);
-            Logger.Info($"WorldQuestManager initializing with seed {seed} (period starting {DateTimeOffset.FromUnixTimeSeconds(seed):u})");
+            long seed = ComputeCurrentPeriodSeed(settings.WorldQuestResetDay, settings.WorldQuestResetHour, settings.WorldQuestResetMinute, settings.GetEffectiveUtcOffset());
+            var periodStart = TimeZoneInfo.ConvertTime(DateTimeOffset.FromUnixTimeSeconds(seed), settings.ServerTimeZone);
+            Logger.Info($"WorldQuestManager initializing with seed {seed} (period starting {periodStart:yyyy-MM-dd HH:mm:ss zzz})");
             RollPool(seed);
         }
 
@@ -87,17 +88,19 @@ namespace Arrowgene.Ddon.GameServer
 
         /// <summary>
         /// Computes the Unix timestamp of the most recent past occurrence of the configured
-        /// reset day and hour (UTC). All server instances independently arrive at the same seed,
-        /// making the pool deterministic without a DB round-trip.
+        /// reset day and hour. All server instances independently arrive at the same seed as long
+        /// as they are configured with the same utcOffset, making the pool deterministic
+        /// without a DB round-trip.
         /// </summary>
-        public static long ComputeCurrentPeriodSeed(DayOfWeek resetDay, uint resetHour, uint resetMinute = 0)
+        public static long ComputeCurrentPeriodSeed(DayOfWeek resetDay, uint resetHour, uint resetMinute = 0, TimeSpan? utcOffset = null)
         {
-            var now = DateTimeOffset.UtcNow;
+            var offset = utcOffset ?? TimeSpan.Zero;
+            var now = DateTimeOffset.UtcNow.ToOffset(offset);
             int dayDiff = ((int)now.DayOfWeek - (int)resetDay + 7) % 7;
-            var resetDate = now.UtcDateTime.Date.AddDays(-dayDiff);
+            var resetDate = now.AddDays(-dayDiff);
             var resetTime = new DateTimeOffset(
                 resetDate.Year, resetDate.Month, resetDate.Day,
-                (int)resetHour, (int)resetMinute, 0, TimeSpan.Zero);
+                (int)resetHour, (int)resetMinute, 0, offset);
 
             // If the reset time for today hasn't happened yet, go back one full week
             if (resetTime > now)

--- a/Arrowgene.Ddon.GameServer/ScheduleManager.cs
+++ b/Arrowgene.Ddon.GameServer/ScheduleManager.cs
@@ -47,6 +47,10 @@ namespace Arrowgene.Ddon.GameServer
                 new GroupChatPruningTask(0, 0),
                 new StampResetTask(5, 0),
             ];
+
+            var settings = server.GameSettings.GameServerSettings;
+            foreach (var task in Tasks)
+                task.GetOffset = () => settings.GetEffectiveUtcOffset();
         }
 
         private int GetTimerTick(ScheduleInterval interval)

--- a/Arrowgene.Ddon.GameServer/Tasks/DailyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/DailyTask.cs
@@ -16,8 +16,9 @@ namespace Arrowgene.Ddon.GameServer.Tasks
 
         public override long NextTimestamp()
         {
-            var tomorrow = DateTime.Today.AddDays(1);
-            return new DateTimeOffset(new DateTime(tomorrow.Year, tomorrow.Month, tomorrow.Day, (int)Hour, (int)Minute, 0)).ToUnixTimeSeconds();
+            var now = DateTimeOffset.UtcNow.ToOffset(Offset);
+            var tomorrow = now.AddDays(1).Date;
+            return new DateTimeOffset(tomorrow.Year, tomorrow.Month, tomorrow.Day, (int)Hour, (int)Minute, 0, Offset).ToUnixTimeSeconds();
         }
 
         public override string TaskTypeName()

--- a/Arrowgene.Ddon.GameServer/Tasks/HourlyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/HourlyTask.cs
@@ -5,20 +5,16 @@ namespace Arrowgene.Ddon.GameServer.Tasks
 {
     public abstract class HourlyTask : SchedulerTask
     {
-        /// <summary>
-        /// Task which is always scheduled to run on the hour in the timezone of the server currently running.
-        /// </summary>
-        /// <param name="type">The task type associated with this task</param>
         public HourlyTask(TaskType type) : base(ScheduleInterval.Hourly, type)
         {
         }
 
         public override long NextTimestamp()
         {
-            var now = DateTime.Now;
+            var now = DateTimeOffset.UtcNow.ToOffset(Offset);
             var next = now.AddHours(1);
-            var nextTime = new DateTime(next.Year, next.Month, next.Day, next.Hour, 0, 0);
-            return new DateTimeOffset(now.Add(nextTime - now)).ToUnixTimeSeconds();
+            var nextTime = new DateTimeOffset(next.Year, next.Month, next.Day, next.Hour, 0, 0, Offset);
+            return nextTime.ToUnixTimeSeconds();
         }
 
         public override string TaskTypeName()

--- a/Arrowgene.Ddon.GameServer/Tasks/Implementations/WorldQuestResetTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/Implementations/WorldQuestResetTask.cs
@@ -23,7 +23,7 @@ namespace Arrowgene.Ddon.GameServer.Tasks.Implementations
         public override void RunTask(DdonGameServer server)
         {
             var settings = server.GameSettings.GameServerSettings;
-            long seed = WorldQuestManager.ComputeCurrentPeriodSeed(settings.WorldQuestResetDay, settings.WorldQuestResetHour, settings.WorldQuestResetMinute);
+            long seed = WorldQuestManager.ComputeCurrentPeriodSeed(settings.WorldQuestResetDay, settings.WorldQuestResetHour, settings.WorldQuestResetMinute, settings.GetEffectiveUtcOffset());
             Logger.Info($"Triggering server-wide world quest reset with seed {seed}");
             server.RpcManager.AnnounceAll("internal/command", RpcInternalCommand.WorldQuestReset, seed);
         }

--- a/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/SchedulerTask.cs
@@ -1,4 +1,5 @@
 using Arrowgene.Ddon.Shared.Model.Scheduler;
+using System;
 
 namespace Arrowgene.Ddon.GameServer.Tasks
 {
@@ -8,8 +9,18 @@ namespace Arrowgene.Ddon.GameServer.Tasks
         public ScheduleInterval Interval { get; }
 
         /// <summary>
-        /// Constructor for SchedulerTask.
+        /// Returns the UTC offset to use when computing the next fire time. Evaluated fresh on
+        /// every NextTimestamp() call so DST transitions are picked up automatically when a
+        /// ServerTimeZoneId is configured.
         /// </summary>
+        public TimeSpan Offset => GetOffset();
+
+        /// <summary>
+        /// Delegate that produces the current UTC offset. Set by ScheduleManager using the
+        /// server's ServerTimeZoneId / ServerUtcOffset settings.
+        /// </summary>
+        public Func<TimeSpan> GetOffset { get; set; } = () => TimeSpan.Zero;
+
         /// <param name="interval">Hint for the type of interval this task is expected to occur at.</param>
         /// <param name="type">
         ///     The task type which is stored in the DB and used to resume the scheduler

--- a/Arrowgene.Ddon.GameServer/Tasks/WeeklyTask.cs
+++ b/Arrowgene.Ddon.GameServer/Tasks/WeeklyTask.cs
@@ -10,13 +10,6 @@ namespace Arrowgene.Ddon.GameServer.Tasks
         public uint Hour { get; }
         public uint Minute { get; }
 
-        /// <summary>
-        /// Creates a task which runs on a weekly cadence.
-        /// Uses the timezone of the head server when calculating times.
-        /// </summary>
-        /// <param name="scheduleType">The type of event this is associated with</param>
-        /// <param name="day">The day during the week the reset should occur.</param>
-        /// <param name="hour">The hour the reset should occur in a 24 hour format</param>
         public WeeklyTask(TaskType scheduleType, DayOfWeek day, uint hour, uint minute) : base(ScheduleInterval.Weekly, scheduleType)
         {
             Day = day;
@@ -24,14 +17,11 @@ namespace Arrowgene.Ddon.GameServer.Tasks
             Minute = minute;
         }
 
-        /// <summary>
-        /// Calculates the next timestamp for this task in unix seconds
-        /// </summary>
-        /// <returns>Returns the next timestamp in unix seconds</returns>
         public override long NextTimestamp()
         {
-            var nextDate = DateUtils.GetNextWeekday(DateTime.Today.AddDays(1), Day);
-            return new DateTimeOffset(new DateTime(nextDate.Year, nextDate.Month, nextDate.Day, (int)Hour, (int)Minute, 0)).ToUnixTimeSeconds();
+            var now = DateTimeOffset.UtcNow.ToOffset(Offset);
+            var nextDate = DateUtils.GetNextWeekday(now.AddDays(1).Date, Day);
+            return new DateTimeOffset(nextDate.Year, nextDate.Month, nextDate.Day, (int)Hour, (int)Minute, 0, Offset).ToUnixTimeSeconds();
         }
 
         public override string TaskTypeName()

--- a/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
+++ b/Arrowgene.Ddon.Server/Scripting/modules/GameServerSettingsModule.cs
@@ -76,6 +76,7 @@ namespace Arrowgene.Ddon.Server.Scripting.modules
                 .AddReferences(MetadataReference.CreateFromFile(typeof(LibUtils).Assembly.Location))
                 .AddImports("System", "System.Collections", "System.Collections.Generic")
                 .AddImports("Arrowgene.Ddon.Server.Scripting")
+                .AddImports("Arrowgene.Ddon.Server.Settings")
                 .AddImports("Arrowgene.Ddon.Shared.Model")
                 .AddImports("Arrowgene.Ddon.Shared.Model.Quest");
         }

--- a/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
+++ b/Arrowgene.Ddon.Server/Settings/GameServerSettings.cs
@@ -1806,7 +1806,8 @@ namespace Arrowgene.Ddon.Server.Settings
         private const WorldQuestSystemMode _WorldQuestSystem = WorldQuestSystemMode.ServerReset;
 
         /// <summary>
-        /// Day of the week (UTC) on which the server-wide world quest pool resets.
+        /// Day of the week (in the timezone defined by ServerTimeZone) on which the
+        /// server-wide world quest pool resets.
         /// Only used when WorldQuestSystem = WorldQuestSystemMode.ServerReset.
         /// </summary>
         [DefaultValue("DayOfWeek.Thursday")]
@@ -1824,7 +1825,8 @@ namespace Arrowgene.Ddon.Server.Settings
         private const DayOfWeek _WorldQuestResetDay = DayOfWeek.Thursday;
 
         /// <summary>
-        /// Hour of the day (0-23, UTC) at which the server-wide world quest pool resets.
+        /// Hour of the day (0-23, in the timezone defined by ServerTimeZone) at which
+        /// the server-wide world quest pool resets.
         /// Only used when WorldQuestSystem = WorldQuestSystemMode.ServerReset.
         /// </summary>
         [DefaultValue(_WorldQuestResetHour)]
@@ -1842,7 +1844,8 @@ namespace Arrowgene.Ddon.Server.Settings
         private const uint _WorldQuestResetHour = 10;
 
         /// <summary>
-        /// Minute of the hour (0-59, UTC) at which the server-wide world quest pool resets.
+        /// Minute of the hour (0-59, in the timezone defined by ServerTimeZone) at which
+        /// the server-wide world quest pool resets.
         /// Only used when WorldQuestSystem = WorldQuestSystemMode.ServerReset.
         /// </summary>
         [DefaultValue(_WorldQuestResetMinute)]
@@ -1858,6 +1861,48 @@ namespace Arrowgene.Ddon.Server.Settings
             }
         }
         private const uint _WorldQuestResetMinute = 0;
+
+        /// <summary>
+        /// Timezone used for all calendar-aligned task scheduler resets (daily, weekly) and world
+        /// quest seed computation. Set this to the same value on every shard.
+        ///
+        /// Use the named constants in <see cref="TimeZoneId"/> - they cover both DST-observing and fixed-offset
+        /// timezones, so no manual update is ever needed when clocks change:
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneId.Japan;          // Japan (JST) - original game timezone
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneId.CentralEurope;  // Germany, France, Spain, etc. (CET/CEST auto)
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneId.EasternEurope;  // Finland, Greece, Romania, etc. (EET/EEST auto)
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneId.UKIreland;      // UK/Ireland (GMT/BST auto)
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneId.Eastern;        // US/Canada Eastern (EST/EDT auto)
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneId.UTC;            // UTC
+        ///
+        /// For a timezone not listed in <see cref="TimeZoneId"/>, use FindSystemTimeZoneById with any IANA ID:
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneInfo.FindSystemTimeZoneById("America/Indiana/Knox");
+        ///
+        /// Full list of IANA timezone IDs:
+        ///   https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+        ///
+        /// For a fully custom fixed offset with no IANA ID:
+        ///   TimeZoneInfo ServerTimeZone = TimeZoneInfo.CreateCustomTimeZone("custom", TimeSpan.FromHours(5.5), "UTC+5:30", "UTC+5:30");
+        /// </summary>
+        [DefaultValue("TimeZoneId.Japan")]
+        public TimeZoneInfo ServerTimeZone
+        {
+            set
+            {
+                SetSetting("ServerTimeZone", value);
+            }
+            get
+            {
+                return TryGetSetting("ServerTimeZone", _ServerTimeZone);
+            }
+        }
+        private static readonly TimeZoneInfo _ServerTimeZone =
+            TimeZoneInfo.TryFindSystemTimeZoneById("Asia/Tokyo", out var _jst) ? _jst : TimeZoneInfo.Utc;
+
+        /// <summary>
+        /// Returns the UTC offset for the configured ServerTimeZone at the current moment.
+        /// </summary>
+        public TimeSpan GetEffectiveUtcOffset() => ServerTimeZone.GetUtcOffset(DateTimeOffset.UtcNow);
 
         /// <summary>
         /// When true, world quests that the party leader does not meet the area rank requirement for

--- a/Arrowgene.Ddon.Server/Settings/SettingsTemplate.cs
+++ b/Arrowgene.Ddon.Server/Settings/SettingsTemplate.cs
@@ -147,10 +147,8 @@ namespace Arrowgene.Ddon.Server.Settings
         {
             StringBuilder sb = new StringBuilder();
 
-            // Split the summary text into lines based on newlines preserved in XML
-            string[] lines = summaryNode.InnerText.Trim().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
-           
-            // Multi-line summary
+            string[] lines = ExtractText(summaryNode).Trim().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
             sb.AppendLine("/// <summary>");
             foreach (string line in lines)
             {
@@ -159,6 +157,35 @@ namespace Arrowgene.Ddon.Server.Settings
             sb.AppendLine("/// </summary>");
 
             return sb.ToString().TrimEnd();
+        }
+
+        // Walks an XML node tree and extracts readable text, resolving <see cref="T:Ns.Name"/>
+        // to just "Name" instead of silently dropping it as InnerText would.
+        private static string ExtractText(XmlNode node)
+        {
+            var sb = new StringBuilder();
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.NodeType == XmlNodeType.Text)
+                {
+                    sb.Append(child.Value);
+                }
+                else if (child.Name is "see" or "seealso")
+                {
+                    var cref = child.Attributes?["cref"]?.Value;
+                    if (cref != null)
+                    {
+                        // cref format: "T:Namespace.TypeName" or bare "TypeName"
+                        var typePath = cref.Contains(':') ? cref[(cref.IndexOf(':') + 1)..] : cref;
+                        sb.Append(typePath.Contains('.') ? typePath[(typePath.LastIndexOf('.') + 1)..] : typePath);
+                    }
+                }
+                else
+                {
+                    sb.Append(ExtractText(child));
+                }
+            }
+            return sb.ToString();
         }
     }
 }

--- a/Arrowgene.Ddon.Server/Settings/TimeZoneId.cs
+++ b/Arrowgene.Ddon.Server/Settings/TimeZoneId.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace Arrowgene.Ddon.Server.Settings
+{
+    /// <summary>
+    /// Named timezone constants for use with ServerTimeZone.
+    /// Each constant returns a TimeZoneInfo that covers both DST-observing and fixed-offset
+    /// timezones — no manual update is needed when clocks change.
+    ///
+    /// If your timezone is not listed, use FindSystemTimeZoneById with any IANA ID:
+    ///   settings.ServerTimeZone = TimeZoneInfo.FindSystemTimeZoneById("America/Indiana/Knox");
+    ///
+    /// For a fully custom offset with no IANA ID:
+    ///   settings.ServerTimeZone = TimeZoneInfo.CreateCustomTimeZone("custom", TimeSpan.FromHours(5.5), "UTC+5:30", "UTC+5:30");
+    ///
+    /// A full list of IANA timezone IDs: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    /// </summary>
+    public static class TimeZoneId
+    {
+        // ── Universal ─────────────────────────────────────────────────────────
+        public static TimeZoneInfo UTC              => TimeZoneInfo.FindSystemTimeZoneById("UTC");
+
+        // ── Europe — DST-observing ────────────────────────────────────────────
+        public static TimeZoneInfo UKIreland        => TimeZoneInfo.FindSystemTimeZoneById("Europe/London");    // UK, Ireland              (GMT/BST)
+        public static TimeZoneInfo PortugalMainland => TimeZoneInfo.FindSystemTimeZoneById("Europe/Lisbon");    // Portugal mainland         (WET/WEST)
+        public static TimeZoneInfo CentralEurope    => TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");    // Germany, France, Spain, Italy, Netherlands,
+                                                                                                                // Belgium, Austria, Switzerland, Poland, Czech Republic,
+                                                                                                                // Slovakia, Hungary, Croatia, Slovenia, Denmark,
+                                                                                                                // Norway, Sweden, Luxembourg, and more (CET/CEST)
+        public static TimeZoneInfo EasternEurope    => TimeZoneInfo.FindSystemTimeZoneById("Europe/Helsinki"); // Finland, Estonia, Latvia, Lithuania (EET/EEST)
+        public static TimeZoneInfo SoutheastEurope  => TimeZoneInfo.FindSystemTimeZoneById("Europe/Athens");   // Greece, Romania, Bulgaria, Cyprus  (EET/EEST)
+        public static TimeZoneInfo Ukraine          => TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");     // Ukraine                   (EET/EEST)
+
+        // ── Europe — fixed offset (no DST) ───────────────────────────────────
+        public static TimeZoneInfo Iceland          => TimeZoneInfo.FindSystemTimeZoneById("Atlantic/Reykjavik"); // Iceland                (UTC+0)
+        public static TimeZoneInfo Moscow           => TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow");   // Russia (Moscow zone)       (UTC+3, no DST since 2014)
+        public static TimeZoneInfo Turkey           => TimeZoneInfo.FindSystemTimeZoneById("Europe/Istanbul"); // Turkey                    (UTC+3, no DST since 2016)
+
+        // ── Americas — DST-observing ──────────────────────────────────────────
+        public static TimeZoneInfo Eastern          => TimeZoneInfo.FindSystemTimeZoneById("America/New_York");    // US/Canada Eastern      (EST/EDT)
+        public static TimeZoneInfo Central          => TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");     // US/Canada Central      (CST/CDT)
+        public static TimeZoneInfo Mountain         => TimeZoneInfo.FindSystemTimeZoneById("America/Denver");      // US Mountain            (MST/MDT)
+        public static TimeZoneInfo Pacific          => TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"); // US/Canada Pacific      (PST/PDT)
+        public static TimeZoneInfo Alaska           => TimeZoneInfo.FindSystemTimeZoneById("America/Anchorage");   // Alaska                 (AKST/AKDT)
+        public static TimeZoneInfo Brazil           => TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo");   // Brazil (Brasília)      (BRT/BRST)
+
+        // ── Americas — fixed offset (no DST) ─────────────────────────────────
+        public static TimeZoneInfo Arizona          => TimeZoneInfo.FindSystemTimeZoneById("America/Phoenix");     // Arizona                (MST, no DST)
+        public static TimeZoneInfo Hawaii           => TimeZoneInfo.FindSystemTimeZoneById("Pacific/Honolulu");    // Hawaii                 (HST, no DST)
+
+        // ── Asia — fixed offset (no DST) ─────────────────────────────────────
+        public static TimeZoneInfo Japan            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");          // Japan                  (JST, UTC+9)
+        public static TimeZoneInfo Korea            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Seoul");          // South Korea            (KST, UTC+9)
+        public static TimeZoneInfo China            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Shanghai");       // China                  (CST, UTC+8)
+        public static TimeZoneInfo Singapore        => TimeZoneInfo.FindSystemTimeZoneById("Asia/Singapore");      // Singapore              (SGT, UTC+8)
+        public static TimeZoneInfo HongKong         => TimeZoneInfo.FindSystemTimeZoneById("Asia/Hong_Kong");      // Hong Kong              (HKT, UTC+8)
+        public static TimeZoneInfo Indochina        => TimeZoneInfo.FindSystemTimeZoneById("Asia/Bangkok");        // Thailand, Vietnam, etc.(ICT, UTC+7)
+        public static TimeZoneInfo WesternIndonesia => TimeZoneInfo.FindSystemTimeZoneById("Asia/Jakarta");        // Western Indonesia      (WIB, UTC+7)
+        public static TimeZoneInfo India            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Kolkata");        // India                  (IST, UTC+5:30)
+        public static TimeZoneInfo Nepal            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Kathmandu");      // Nepal                  (NPT, UTC+5:45)
+        public static TimeZoneInfo Pakistan         => TimeZoneInfo.FindSystemTimeZoneById("Asia/Karachi");        // Pakistan               (PKT, UTC+5)
+        public static TimeZoneInfo Iran             => TimeZoneInfo.FindSystemTimeZoneById("Asia/Tehran");         // Iran                   (IRST/IRDT, observes DST)
+
+        // ── Pacific / Oceania ─────────────────────────────────────────────────
+        public static TimeZoneInfo AustraliaCentral => TimeZoneInfo.FindSystemTimeZoneById("Australia/Darwin");    // Australia Central      (ACST, UTC+9:30, no DST)
+        public static TimeZoneInfo AustraliaEastern => TimeZoneInfo.FindSystemTimeZoneById("Australia/Sydney");    // Australia Eastern      (AEST/AEDT, observes DST)
+        public static TimeZoneInfo NewZealand       => TimeZoneInfo.FindSystemTimeZoneById("Pacific/Auckland");    // New Zealand            (NZST/NZDT, observes DST)
+    }
+}


### PR DESCRIPTION
Some timers are running off local server time, while others are using UTC 0. Added a a new setting ServerTimeZone which uses an IANA ID. It is used by the task scheduler and and other calendar aware timing events. By default it is set to "TimeZoneId.Japan" (JST +9). A helper class named TimeZoneId.cs exists so a admin can use a named constant instead of magic numbers. Using the IANA ID allows the server to select the right time for regions which observe DST as well as regions which do not. The setting ServerTimeZone should be configured the same on all channels used by the server.
