### PR TITLE
Bloodbane Island WQs update

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000001.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 13 } ],
+  "news_image": 551,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 13}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000002.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BreyaCoast",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 11 } ],
+  "news_image": 501,
+  "order_conditions": [{"type": "AreaRank", "Param1": 2, "Param2": 11}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000003.json
@@ -7,7 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BreyaCoast",
-  "news_image": 526,
+  "news_image": 592,
   "order_conditions": [{"type": "AreaRank", "Param1": 2, "Param2": 13}],
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000006.json
@@ -6,7 +6,8 @@
     "base_level": 56,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 245,
     "rewards": [
         {
             "type": "wallet",
@@ -26,16 +27,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7877,
+                    "item_id": "GoldIngot",
                     "num": 2
                 },
-                {					
-                    "item_id": 7853,
+                {
+                    "item_id": "IronOreFragment",
                     "num": 5
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
@@ -44,58 +45,89 @@
         {
             "stage_id": {
                 "id": 316,
-                "group_id": 10
+                "group_id": 6
             },
+            "starting_index": 5,
             "enemies": [
                 {
+                    "comment": "Infected Hobgoblin - Severe",
                     "enemy_id": "0x010160",
-                    "level": 57,
-                    "exp": 2000,
-                    "is_boss": false
-    },
-    {
+                    "infection_type": 2,
+                    "level": 56,
+                    "exp": 324
+                },
+                {
+                    "comment": "Infected Hobgoblin - Severe",
+                    "enemy_id": "0x010160",
+                    "infection_type": 2,
+                    "level": 56,
+                    "exp": 324
+                },
+                {
+                    "comment": "Infected Hobgoblin Fighter - Severe",
                     "enemy_id": "0x010161",
-                    "level": 57,
-                    "exp": 2000,
-                    "is_boss": false
-    },
-    {
+                    "infection_type": 2,
+                    "level": 56,
+                    "exp": 324
+                },
+                {
+                    "comment": "Infected Hobgoblin Fighter - Severe",
+                    "enemy_id": "0x010161",
+                    "infection_type": 2,
+                    "level": 56,
+                    "exp": 324
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger",
                     "enemy_id": "0x010162",
-                    "level": 57,
-                    "exp": 2000,
-                    "is_boss": false					
+                    "level": 56,
+                    "exp": 324
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger",
+                    "enemy_id": "0x010162",
+                    "level": 56,
+                    "exp": 324
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger",
+                    "enemy_id": "0x010162",
+                    "level": 56,
+                    "exp": 324
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Rolf",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 317,
-        "group_id": 1
-      },
-      "npc_id": "Rolf",
-      "announce_type": "Accept",
-      "items": [
         {
-          "id": 11759,
-          "amount": 2
-        }
-      ],
-      "message_id": 10737
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Rolf",
+            "message_id": 17124
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Rolf",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17125, "comment": "Extra dialogue - Rolf"}
+            ],
+            "items": [
+                {"id": 11759, "amount": 2, "comment": "Unappraised Moon Trinket - Soldier"}
+            ],
+            "message_id": 17126
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17127, "comment": "Extra dialogue 2 - Rolf"}
+            ],
             "groups": [0]
         },
         {
@@ -104,16 +136,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Rolf",
-            "message_id": 11842			
+            "message_id": 17128
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000007.json
@@ -6,7 +6,8 @@
     "base_level": 60,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 583,
     "rewards": [
         {
             "type": "wallet",
@@ -26,16 +27,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7885,
+                    "item_id": "BlueSteelIngot",
                     "num": 2
                 },
-                {					
-                    "item_id": 7967,
+                {
+                    "item_id": "CedarWood",
                     "num": 2
                 },
-                {				
-                    "item_id": 9364,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
@@ -48,32 +49,43 @@
             },
             "enemies": [
                 {
+                    "comment": "Infected Griffin",
                     "enemy_id": "0x015306",
                     "level": 60,
-                    "exp": 40000,
+                    "exp": 8500,
                     "is_boss": true,
-                    "infection_type": 2				
+                    "infection_type": 2
+                },
+                {
+                    "comment": "Infected Hobgoblin",
+                    "enemy_id": "0x010161",
+                    "level": 60,
+                    "exp": 340
+                },
+                {
+                    "comment": "Infected Hobgoblin",
+                    "enemy_id": "0x010161",
+                    "level": 60,
+                    "exp": 340
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 3757, "comment": "Spawns Something??"}				
-            ],	  
-      "stage_id": {
-        "id": 317,
-		"group_id": 1,
-		"layer_no": 1		
-      },
-      "npc_id": "Clarissa",
-      "message_id": 10800
-    },
-    {
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Clarissa",
+            "message_id": 17129
+        },
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2400, "Param2": 17130, "comment": "Extra dialogue - Clarissa"}
+            ],
             "groups": [0]
         },
         {
@@ -82,16 +94,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Clarissa",
-            "message_id": 11842	
-    }
-  ]
+            "message_id": 17131
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000008.json
@@ -6,7 +6,8 @@
     "base_level": 57,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 245,
     "rewards": [
         {
             "type": "wallet",
@@ -26,16 +27,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7880,
+                    "item_id": "MithrilIngot",
                     "num": 2
                 },
-                {					
-                    "item_id": 7981,
+                {
+                    "item_id": "Moonglow",
                     "num": 5
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
@@ -44,36 +45,36 @@
         {
             "stage_id": {
                 "id": 316,
-                "group_id": 3
+                "group_id": 11
             },
+            "starting_index": 1,
             "enemies": [
                 {
+                    "comment": "Infected Gorecyclops - Slight",
                     "enemy_id": "0x015012",
-                    "level": 60,
-                    "exp": 40000,
-                    "is_boss": true,
-                    "infection_type": 2					
+                    "infection_type": 1,
+                    "level": 57,
+                    "exp": 6560,
+                    "is_boss": true
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 3757, "comment": "Spawns Something??"}				
-            ],	  
-      "stage_id": {
-        "id": 317,
-		"group_id": 1,
-		"layer_no": 1		
-      },
-      "npc_id": "Clarissa",
-      "message_id": 10800
-    },
-    {
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Clarissa",
+            "message_id": 17133
+        },
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2400, "Param2": 17134, "comment": "Extra dialogue - Clarissa"}
+            ],
             "groups": [0]
         },
         {
@@ -82,16 +83,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Clarissa",
-            "message_id": 11842	
-    }
-  ]
+            "message_id": 17135
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000009.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BloodbaneIsle",
+  "news_image": 538,
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000010.json
@@ -6,7 +6,8 @@
     "base_level": 55,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 15,
     "rewards": [
         {
             "type": "wallet",
@@ -26,44 +27,44 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7942,
+                    "item_id": "BlowResistantCloth",
                     "num": 2
                 },
-                {					
-                    "item_id": 8018,
+                {
+                    "item_id": "LargeScallopShell",
                     "num": 5
                 },
-                {				
-                    "item_id": 9364,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
     ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Gunther",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 2,
-        "group_id": 1
-      },
-      "npc_id": "Sally",
-      "announce_type": "Accept",
-      "items": [
         {
-          "id": 11508,
-          "amount": 6
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Gunther",
+            "message_id": 17137
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 2
+            },
+            "npc_id": "Sally",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2401, "Param2": 17138, "comment": "Extra dialogue - Gunther"},
+                {"type": "QstTalkChg", "Param1": 4709, "Param2": 17139, "comment": "Extra dialogue - Sally"}
+            ],
+            "items": [
+                {"id": 11508, "amount": 6, "comment": "Saltpetre Chunk"}
+            ],
+            "message_id": 17140
         }
-      ],
-      "message_id": 10737
-    }
-  ]
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000011.json
@@ -6,7 +6,8 @@
     "base_level": 63,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 522,
     "rewards": [
         {
             "type": "exp",
@@ -26,16 +27,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11778,
+                    "item_id": "FrostMetal",
                     "num": 1
                 },
                 {
-                    "item_id": 7853,
+                    "item_id": "IronOreFragment",
                     "num": 5
                 },
                 {
-                    "item_id": 7555,
-                    "num": 3					
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
                 }
             ]
         }
@@ -48,10 +49,41 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x015505",
+                    "comment": "Ghoul",
+                    "enemy_id": "0x015503",
                     "level": 63,
-                    "exp": 42000,
-					"is_boss": true
+                    "exp": 3876,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 63,
+                    "exp": 788
                 }
             ]
         },
@@ -60,26 +92,49 @@
                 "id": 330,
                 "group_id": 1
             },
+            "starting_index": 3,
             "enemies": [
                 {
+                    "comment": "Frost Skeleton",
                     "enemy_id": "0x010315",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 788
                 },
                 {
+                    "comment": "Frost Skeleton",
                     "enemy_id": "0x010315",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 788
                 },
                 {
+                    "comment": "Frost Skeleton",
                     "enemy_id": "0x010315",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 788
                 },
                 {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
                     "enemy_id": "0x010509",
                     "level": 63,
-                    "exp": 2200					
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
                 }
             ]
         },
@@ -88,76 +143,150 @@
                 "id": 330,
                 "group_id": 4
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x010400",
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 3876,
+                    "is_boss": true,
+                    "index": 0
                 },
                 {
-                    "enemy_id": "0x010400",
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 3876,
+                    "is_boss": true,
+                    "index": 5
                 },
                 {
+                    "comment": "Frost Corpse Punisher",
+                    "enemy_id": "0x010511",
+                    "level": 63,
+                    "exp": 788,
+                    "index": 7
+                },
+                {
+                    "comment": "Frost Corpse Punisher",
+                    "enemy_id": "0x010511",
+                    "level": 63,
+                    "exp": 788,
+                    "index": 8
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 63,
+                    "exp": 788,
+                    "index": 9
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 63,
+                    "exp": 788,
+                    "index": 10
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 63,
+                    "exp": 788,
+                    "index": 11
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 63,
+                    "exp": 788,
+                    "index": 12
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 330,
+                "group_id": 5
+            },
+            "enemies": [
+                {
+                    "comment": "Frost Machina",
                     "enemy_id": "0x015851",
-                    "level": 64,
-                    "exp": 44000,
-					"is_boss": true
+                    "level": 63,
+                    "exp": 19380,
+                    "is_boss": true
                 },
                 {
-                    "enemy_id": "0x010509",
+                    "comment": "Saurian",
+                    "enemy_id": "0x010400",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 788
                 },
                 {
+                    "comment": "Saurian",
+                    "enemy_id": "0x010400",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Saurian",
+                    "enemy_id": "0x010400",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
                     "enemy_id": "0x010509",
                     "level": 63,
-                    "exp": 3200
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
+                },
+                {
+                    "comment": "Mudman",
+                    "enemy_id": "0x010509",
+                    "level": 63,
+                    "exp": 788
                 }
             ]
         }
     ],
     "processes": [
         {
-            "comment": "Process 0",
             "blocks": [
                 {
                     "type": "NpcTalkAndOrder",
                     "stage_id": {
                         "id": 317
                     },
-                    "npc_id": "549",
-                    "message_id": 11372
+                    "npc_id": "Bertrand",
+                    "message_id": 17141
                 },
                 {
-                    "type": "MyQstFlags",
+                    "type": "SeekOutEnemiesAtMarkedLocation",
                     "announce_type": "Accept",
-                    "set_flags": [1],
-                    "check_flags": [2, 3, 4]
-                },
-                {
-                    "type": "TalkToNpc",
-                    "stage_id": {
-                        "id": 317
-                    },
-                    "announce_type": "Update",
-                    "npc_id": "549",
-                    "message_id": 11842
-                }
-            ]
-        },
-        {
-            "comment": "Process1 (Demon Group 1)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-				},
-				{
-					"type": "SeekOutEnemiesAtMarkedLocation",
-					"announce_type": "Update",
-					"groups": [0]
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 549, "Param2": 17142, "comment": "Extra dialogue - Bertrand"}
+                    ],
+                    "groups": [0]
                 },
                 {
                     "type": "KillGroup",
@@ -167,12 +296,26 @@
                 },
                 {
                     "type": "MyQstFlags",
-                    "set_flags": [2]
+                    "announce_type": "Update",
+                    "set_flags": [1],
+                    "check_flags": [2]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "check_flags": [3, 4, 5]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 317
+                    },
+                    "npc_id": "Bertrand",
+                    "message_id": 17143
                 }
             ]
         },
         {
-            "comment": "Process2 (Demons Group 2)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
@@ -184,18 +327,20 @@
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2}
+                    ],
                     "groups": [1]
                 },
                 {
                     "type": "MyQstFlags",
+                    "announce_type": "Update",
                     "set_flags": [3]
                 }
             ]
         },
         {
-            "comment": "Process3 (Demons Group 3)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
@@ -207,13 +352,41 @@
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2}
+                    ],
                     "groups": [2]
                 },
                 {
                     "type": "MyQstFlags",
+                    "announce_type": "Update",
                     "set_flags": [4]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [1]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "groups": [3]
+                },
+                {
+                    "type": "KillGroup",
+                    "reset_group": false,
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2}
+                    ],
+                    "groups": [3]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "set_flags": [5]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000012.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 11 } ],
+  "news_image": 9,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 11}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000014.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BreyaCoast",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 11 } ],
+  "news_image": 24,
+  "order_conditions": [{"type": "AreaRank", "Param1": 2, "Param2": 11}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000022.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000022.json
@@ -1,0 +1,156 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Knight's Pride on the Line",
+  "quest_id": 21000022,
+  "base_level": 60,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BloodbaneIsle",
+  "news_image": 902,
+  "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 2}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 17023
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 3960
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 500
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 335,
+        "group_id": 1
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Bounty Behemoth",
+          "enemy_id": "0x015709",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 26481,
+          "is_boss": true
+        },
+        {
+          "comment": "Bounty Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Bolt Skeleton Brute",
+          "enemy_id": "0x010322",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Gargoyle",
+          "enemy_id": "0x010603",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Gargoyle",
+          "enemy_id": "0x010603",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Gargoyle",
+          "enemy_id": "0x010603",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Gargoyle",
+          "enemy_id": "0x010603",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Gargoyle",
+          "enemy_id": "0x010603",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        },
+        {
+          "comment": "Bounty Gargoyle",
+          "enemy_id": "0x010603",
+          "named_enemy_params_id": 458,
+          "level": 60,
+          "exp": 340
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 317
+      },
+      "npc_id": "Sven",
+      "message_id": 17144
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 2403, "Param2": 17145, "comment": "Extra dialogue - Sven"}
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 317
+      },
+      "announce_type": "Update",
+      "npc_id": "Sven",
+      "message_id": 17146
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000023.json
@@ -6,7 +6,7 @@
     "base_level": 60,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
     "rewards": [
         {
             "type": "wallet",
@@ -26,16 +26,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11504,
+                    "item_id": "IceCubeFragment",
                     "num": 3
                 },
-                {					
-                    "item_id": 7901,
+                {
+                    "item_id": "Crystal",
                     "num": 5
                 },
-                {				
-                    "item_id": 7555,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
                 }
             ]
         }
@@ -46,62 +46,90 @@
                 "id": 330,
                 "group_id": 3
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x010315",
-                    "level": 60,
-                    "exp": 3500,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010315",
-                    "level": 60,
-                    "exp": 3500,
-                    "is_boss": false
-    },
-    {
+                    "comment": "Frost Skeleton Brute",
                     "enemy_id": "0x010511",
                     "level": 60,
-                    "exp": 4500,
-                    "is_boss": false
-    },
-    {
+                    "exp": 756,
+                    "index": 1
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
                     "enemy_id": "0x010511",
                     "level": 60,
-                    "exp": 4500,
-                    "is_boss": false					
+                    "exp": 756,
+                    "index": 2
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010511",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 3
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010511",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 4
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010511",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 5
+                },
+                {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 8
+                },
+                {
+                    "comment": "Frost Skeleton",
+                    "enemy_id": "0x010315",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 9
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Rolf",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 317,
-        "group_id": 1
-      },
-      "npc_id": "Rolf",
-      "announce_type": "Accept",
-      "items": [
         {
-          "id": 7958,
-          "amount": 2
-        }
-      ],
-      "message_id": 10737
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Rolf",
+            "message_id": 17148
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Rolf",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17149, "comment": "Extra dialogue - Rolf"}
+            ],
+            "items": [
+                {"id": 7958, "amount": 2, "comment": "Drómi"}
+            ],
+            "message_id": 17150
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17151, "comment": "Extra dialogue 2 - Rolf"}
+            ],
             "groups": [0]
         },
         {
@@ -110,16 +138,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Rolf",
-            "message_id": 11842			
-    }
-  ]
+            "message_id": 17152
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000024.json
@@ -6,7 +6,8 @@
     "base_level": 60,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",
+    "area_id": "BloodbaneIsle",
+    "news_image": 581,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 2}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11508,
+                    "item_id": "SaltpetreChunk",
                     "num": 2
                 },
                 {
-                    "item_id": 7994,
+                    "item_id": "QualityGalaMushroom",
                     "num": 7
                 },
                 {
-                    "item_id": 9364,
-                    "num": 3					
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
@@ -47,12 +48,44 @@
                 "id": 335,
                 "group_id": 4
             },
+            "starting_index": 1,
             "enemies": [
                 {
+                    "comment": "Ogre",
                     "enemy_id": "0x015500",
                     "level": 60,
-                    "exp": 40000,
-					"is_boss": true
+                    "exp": 3783,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Acid Blob",
+                    "enemy_id": "0x010911",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Acid Blob",
+                    "enemy_id": "0x010911",
+                    "level": 60,
+                    "exp": 756
                 }
             ]
         },
@@ -63,27 +96,46 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x010400",
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
                     "level": 60,
-                    "exp": 3000
-                }
-            ]
-        },
-        {
-            "stage_id": {
-                "id": 318,
-                "group_id": 7
-            },
-            "enemies": [
-                {
-                    "enemy_id": "0x010400",
-                    "level": 60,
-                    "exp": 3000
+                    "exp": 756
                 },
                 {
-                    "enemy_id": "0x010400",
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
                     "level": 60,
-                    "exp": 3000
+                    "exp": 756
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 60,
+                    "exp": 756
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 60,
+                    "exp": 756
                 }
             ]
         },
@@ -92,31 +144,55 @@
                 "id": 318,
                 "group_id": 2
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 60,
-                    "exp": 3000
+                    "exp": 756,
+                    "index": 4
                 },
                 {
+                    "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 60,
-                    "exp": 3000
+                    "exp": 756,
+                    "index": 5
                 },
                 {
+                    "comment": "Bolt Skeleton Brute",
                     "enemy_id": "0x010307",
                     "level": 60,
-                    "exp": 3000
+                    "exp": 756,
+                    "index": 6
                 },
                 {
-                    "enemy_id": "0x010307",
+                    "comment": "Infected Snow Harpy - Severe",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "infection_type": 2,
                     "level": 60,
-                    "exp": 3000
+                    "exp": 756,
+                    "index": 9
                 },
                 {
-                    "enemy_id": "0x010600",
+                    "comment": "Infected Snow Harpy - Severe",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "infection_type": 2,
                     "level": 60,
-                    "exp": 3000					
+                    "exp": 756,
+                    "index": 10
+                },
+                {
+                    "comment": "Infected Snow Harpy - Severe",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "infection_type": 2,
+                    "level": 60,
+                    "exp": 756,
+                    "index": 11
                 }
             ]
         },
@@ -125,67 +201,76 @@
                 "id": 318,
                 "group_id": 6
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x010400",
-                    "level": 60,
-                    "exp": 3000
-                },
-                {
-                    "enemy_id": "0x010400",
-                    "level": 60,
-                    "exp": 3000
-                },
-                {
+                    "comment": "Infected Gorecyclops - Slight",
                     "enemy_id": "0x015012",
                     "level": 60,
-                    "exp": 40000,
-					"is_boss": true,
-					"infected_type": 2
+                    "exp": 18915,
+                    "is_boss": true,
+                    "infected_type": 1,
+                    "index": 5
+                },
+                {
+                    "comment": "Infected Snow Harpy",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "level": 60,
+                    "exp": 756,
+                    "index": 7
+                },
+                {
+                    "comment": "Infected Snow Harpy",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "level": 60,
+                    "exp": 756,
+                    "index": 8
+                },
+                {
+                    "comment": "Infected Snow Harpy",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "level": 60,
+                    "exp": 756,
+                    "index": 9
+                },
+                {
+                    "comment": "Hobgoblin Leader",
+                    "enemy_id": "0x010113",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 11
+                },
+                {
+                    "comment": "Hobgoblin Leader",
+                    "enemy_id": "0x010113",
+                    "level": 60,
+                    "exp": 756,
+                    "index": 12
                 }
             ]
         }
     ],
     "processes": [
         {
-            "comment": "Process 0",
             "blocks": [
                 {
                     "type": "NpcTalkAndOrder",
                     "stage_id": {
                         "id": 317
                     },
-                    "npc_id": "549",
-                    "message_id": 11372
+                    "npc_id": "Bertrand",
+                    "message_id": 17153
                 },
                 {
-                    "type": "MyQstFlags",
+                    "type": "SeekOutEnemiesAtMarkedLocation",
                     "announce_type": "Accept",
-                    "set_flags": [1],
-                    "check_flags": [2, 3, 4, 5, 6]
-                },
-                {
-                    "type": "TalkToNpc",
-                    "stage_id": {
-                        "id": 317
-                    },
-                    "announce_type": "Update",
-                    "npc_id": "549",
-                    "message_id": 11842
-                }
-            ]
-        },
-        {
-            "comment": "Process1 (Demon Group 1)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-				},
-				{
-					"type": "SeekOutEnemiesAtMarkedLocation",
-					"announce_type": "Update",
-					"groups": [0]
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 549, "Param2": 17154, "comment": "Extra dialogue - Bertrand"}
+                    ],
+                    "groups": [0]
                 },
                 {
                     "type": "KillGroup",
@@ -195,99 +280,97 @@
                 },
                 {
                     "type": "MyQstFlags",
-                    "set_flags": [2]
+                    "announce_type": "Update",
+                    "set_flags": [1],
+                    "check_flags": [2]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "check_flags": [3, 4, 5]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 317
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Bertrand",
+                    "message_id": 17155
                 }
             ]
         },
         {
-            "comment": "Process2 (Demons Group 2)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
                     "check_flags": [1]
                 },
                 {
-                    "type": "DiscoverEnemy",					
+                    "type": "DiscoverEnemy",
                     "groups": [1]
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2}
+                    ],
                     "groups": [1]
                 },
                 {
                     "type": "MyQstFlags",
+                    "announce_type": "Update",
                     "set_flags": [3]
                 }
             ]
         },
         {
-            "comment": "Process3 (Demons Group 3)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
                     "check_flags": [1]
                 },
                 {
-                    "type": "DiscoverEnemy",					
+                    "type": "DiscoverEnemy",
                     "groups": [2]
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2}
+                    ],
                     "groups": [2]
                 },
                 {
                     "type": "MyQstFlags",
+                    "announce_type": "Update",
                     "set_flags": [4]
                 }
             ]
         },
         {
-            "comment": "Process3 (Demons Group 4)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
                     "check_flags": [1]
                 },
                 {
-                    "type": "DiscoverEnemy",				
+                    "type": "DiscoverEnemy",
                     "groups": [3]
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2}
+                    ],
                     "groups": [3]
                 },
                 {
                     "type": "MyQstFlags",
                     "set_flags": [5]
-                }
-            ]
-        },
-        {
-            "comment": "Process3 (Demons Group 5)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-                },
-                {
-                    "type": "DiscoverEnemy",					
-                    "groups": [4]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [4]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [6]						
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000025.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000025.json
@@ -8,6 +8,7 @@
     "discoverable": true,
     "area_id": "BloodbaneIsle",
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 2}],
+    "news_image": 521,
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000026.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000026.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "HidellPlains",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 1, "Param2": 13 } ],
+  "news_image": 553,
+  "order_conditions": [{"type": "AreaRank", "Param1": 1, "Param2": 13}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000027.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BreyaCoast",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 2, "Param2": 13 } ],
+  "news_image": 593,
+  "order_conditions": [{"type": "AreaRank", "Param1": 2, "Param2": 13}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000035.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000035.json
@@ -6,7 +6,8 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",
+    "area_id": "BloodbaneIsle",
+    "news_image": 900,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 4}],
     "rewards": [
         {
@@ -27,16 +28,19 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Crest of Sanctity - Decreased Holy Resist",
                     "item_id": 16064,
                     "num": 2
                 },
                 {
-                    "item_id": 25690,
+                    "comment": "Crest of Sanctity",
+                    "item_id": 9264,
                     "num": 2
                 },
                 {
+                    "comment": "Crest of Diminished Holy Resist",
                     "item_id": 9274,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         }
@@ -45,39 +49,112 @@
         {
             "stage_id": {
                 "id": 335,
-                "group_id": 4
+                "group_id": 10
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Troll",
                     "enemy_id": "0x015040",
                     "level": 63,
-                    "exp": 42000,
-					"is_boss": true				
+                    "exp": 3875,
+                    "is_boss": true,
+                    "index": 0
+                },
+                {
+                    "comment": "Hobgoblin",
+                    "enemy_id": "0x010110",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 3
+                },
+                {
+                    "comment": "Hobgoblin",
+                    "enemy_id": "0x010110",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 4
+                },
+                {
+                    "comment": "Hobgoblin",
+                    "enemy_id": "0x010110",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 5
+                },
+                {
+                    "comment": "Hobgoblin Leader",
+                    "enemy_id": "0x010113",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 7
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 331,
-                "group_id": 2
+                "group_id": 1
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Infected Gorecyclops - Slight",
                     "enemy_id": "0x015012",
+                    "infection_type": 1,
                     "level": 61,
-                    "exp": 40000,
-					"is_boss": true,
-					"infected_type": 2
+                    "exp": 3810,
+                    "is_boss": true,
+                    "index": 0
                 },
                 {
-                    "enemy_id": "0x010307",
-                    "level": 60,
-                    "exp": 3000
+                    "comment": "Lux Skeleton Brute",
+                    "enemy_id": "0x010323",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 3
                 },
                 {
-                    "enemy_id": "0x010317",
-                    "level": 60,
-                    "exp": 3000
+                    "comment": "Lux Skeleton Brute",
+                    "enemy_id": "0x010323",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 4
+                },
+                {
+                    "comment": "Lux Skeleton Brute",
+                    "enemy_id": "0x010323",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 5
+                },
+                {
+                    "comment": "Dim Slime",
+                    "enemy_id": "0x010909",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 6
+                },
+                {
+                    "comment": "Dim Slime",
+                    "enemy_id": "0x010909",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 7
+                },
+                {
+                    "comment": "Dim Slime",
+                    "enemy_id": "0x010909",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 8
+                },
+                {
+                    "comment": "Dim Slime",
+                    "enemy_id": "0x010909",
+                    "level": 63,
+                    "exp": 775,
+                    "index": 9
                 }
             ]
         },
@@ -86,22 +163,53 @@
                 "id": 331,
                 "group_id": 3
             },
+            "starting_index": 1,
             "enemies": [
                 {
+                    "comment": "Chimera",
                     "enemy_id": "0x015200",
-                    "level": 61,
-                    "exp": 41000,
-					"is_boss": true
-                },
-                {
-                    "enemy_id": "0x010162",
                     "level": 60,
-                    "exp": 3000
+                    "exp": 3870,
+                    "is_boss": true
                 },
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
-                    "level": 60,
-                    "exp": 3000
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger - Severe",
+                    "enemy_id": "0x010162",
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger - Severe",
+                    "enemy_id": "0x010162",
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger - Severe",
+                    "enemy_id": "0x010162",
+                    "infection_type": 2,
+                    "level": 63,
+                    "exp": 775
                 }
             ]
         },
@@ -110,62 +218,92 @@
                 "id": 331,
                 "group_id": 7
             },
+            "starting_index": 1,
             "enemies": [
                 {
+                    "comment": "Infected Griffin - Slight",
                     "enemy_id": "0x015306",
+                    "infection_type": 1,
                     "level": 62,
-                    "exp": 43000,
-					"is_boss": true,
-					"infected_type": 2
+                    "exp": 19200,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 331,
+                "group_id": 9
+            },
+            "enemies": [
+                {
+                    "comment": "Skeleton Mage",
+                    "enemy_id": "0x010308",
+                    "start_think_tbl_no": 2,
+                    "level": 63,
+                    "exp": 775
                 },
                 {
-                    "enemy_id": "0x010430",
-                    "level": 60,
-                    "exp": 3000
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Skeleton Mage",
+                    "enemy_id": "0x010308",
+                    "start_think_tbl_no": 2,
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Skeleton Mage",
+                    "enemy_id": "0x010308",
+                    "start_think_tbl_no": 2,
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Bolt Skeleton",
+                    "enemy_id": "0x010316",
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Skeleton Mage",
+                    "enemy_id": "0x010308",
+                    "start_think_tbl_no": 2,
+                    "level": 63,
+                    "exp": 775
+                },
+                {
+                    "comment": "Skeleton Mage",
+                    "enemy_id": "0x010308",
+                    "start_think_tbl_no": 2,
+                    "level": 63,
+                    "exp": 775
                 }
             ]
         }
     ],
     "processes": [
         {
-            "comment": "Process 0",
             "blocks": [
                 {
                     "type": "NpcTalkAndOrder",
                     "stage_id": {
                         "id": 317
                     },
-                    "npc_id": "549",
-                    "message_id": 11372
+                    "npc_id": "Bertrand",
+                    "message_id": 17176
                 },
                 {
-                    "type": "MyQstFlags",
+                    "type": "SeekOutEnemiesAtMarkedLocation",
                     "announce_type": "Accept",
-                    "set_flags": [1],
-                    "check_flags": [2, 3, 4, 5]
-                },
-                {
-                    "type": "TalkToNpc",
-                    "stage_id": {
-                        "id": 317
-                    },
-                    "announce_type": "Update",
-                    "npc_id": "549",
-                    "message_id": 11842
-                }
-            ]
-        },
-        {
-            "comment": "Process1 (Demon Group 1)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-				},
-				{
-					"type": "SeekOutEnemiesAtMarkedLocation",
-					"announce_type": "Update",
-					"groups": [0]
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 549, "Param2": 17177, "comment": "Extra dialogue - Bertrand"}
+                    ],
+                    "groups": [0]
                 },
                 {
                     "type": "KillGroup",
@@ -175,12 +313,45 @@
                 },
                 {
                     "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "set_flags": [1],
+                    "check_flags": [2, 3, 4]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 317
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Bertrand",
+                    "message_id": 17178
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [1]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "groups": [1]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "reset_group": false,
+                    "groups": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
                     "set_flags": [2]
                 }
             ]
         },
         {
-            "comment": "Process2 (Demons Group 2)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
@@ -188,22 +359,21 @@
                 },
                 {
                     "type": "DiscoverEnemy",
-                    "groups": [1]
+                    "groups": [2]
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
-                    "groups": [1]
+                    "groups": [2]
                 },
                 {
                     "type": "MyQstFlags",
+                    "announce_type": "Update",
                     "set_flags": [3]
                 }
             ]
         },
         {
-            "comment": "Process3 (Demons Group 3)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
@@ -211,13 +381,12 @@
                 },
                 {
                     "type": "DiscoverEnemy",
-                    "groups": [2]
+                    "groups": [3]
                 },
                 {
                     "type": "KillGroup",
-                    "announce_type": "Update",
                     "reset_group": false,
-                    "groups": [2]
+                    "groups": [3, 4]
                 },
                 {
                     "type": "MyQstFlags",
@@ -226,25 +395,14 @@
             ]
         },
         {
-            "comment": "Process3 (Demons Group 4)",
             "blocks": [
                 {
                     "type": "MyQstFlags",
                     "check_flags": [1]
                 },
                 {
-                    "type": "DiscoverEnemy",
-                    "groups": [3]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [3]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [5]						
+                    "type": "SpawnGroup",
+                    "groups": [4]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000036.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000036.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "BloodbaneIsle",
+    "news_image": 582,
     "rewards": [
         {
             "type": "wallet",
@@ -26,15 +27,15 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11777,
+                    "item_id": "DiscoloredHardHorn",
                     "num": 1
                 },
                 {
-                    "item_id": 7967,
+                    "item_id": "CedarWood",
                     "num": 2
                 },
                 {
-                    "item_id": 41,
+                    "item_id": "Panacea",
                     "num": 3
                 }
             ]
@@ -48,11 +49,12 @@
             },
             "enemies": [
                 {
+                    "comment": "Infected Behemoth - Slight",
                     "enemy_id": "0x015712",
                     "level": 65,
-                    "exp": 50000,
+                    "exp": 3940,
                     "is_boss": true,
-                    "infection_type": 2
+                    "infection_type": 1
                 }
             ]
         }
@@ -60,20 +62,18 @@
     "blocks": [
         {
             "type": "NpcTalkAndOrder",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 3765, "comment": "Spawns Something??"}
-            ],
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "npc_id": "Sven",
-            "message_id": 10800
+            "message_id": 17168
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2403, "Param2": 17169, "comment": "Extra dialogue - Sven"}
+            ],
             "groups": [0]
         },
         {
@@ -85,13 +85,11 @@
         {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Sven",
-            "message_id": 11842
+            "message_id": 17170
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000037.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000037.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BloodbaneIsle",
+  "news_image": 242,
   "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 4}],
   "rewards": [
     {
@@ -50,12 +51,13 @@
         "id": 335,
         "group_id": 1
       },
-      "starting_index": 2,
+      "starting_index": 1,
       "enemies": [
         {
           "comment": "Infected Griffin (Slight)",
           "enemy_id": "0x015306",
           "infection_type": 1,
+		  "set_type": 3,
           "level": 63,
           "exp": 8800,
           "is_boss": true
@@ -67,6 +69,12 @@
           "exp": 352,
           "repop_count": 1,
           "repop_wait_second": 10
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 63,
+          "exp": 352
         },
         {
           "comment": "Infected Hobgoblin Fighter",
@@ -161,7 +169,7 @@
         {
           "comment": "Group 0 boss HP check",
           "type": "Raw",
-          "check_commands": [{"type": "EmHpLess", "Param1": 110, "Param2": 1, "Param3": 2, "Param4": 40}]
+          "check_commands": [{"type": "EmHpLess", "Param1": 110, "Param2": 1, "Param3": 1, "Param4": 40}]
         },
         {
           "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000046.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000046.json
@@ -6,7 +6,8 @@
     "base_level": 63,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 92,
     "rewards": [
         {
             "type": "wallet",
@@ -26,20 +27,20 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7948,
+                    "item_id": "CursedCloth",
                     "num": 2
                 },
-                {					
-                    "item_id": 7848,
+                {
+                    "item_id": "BlueAlluvialGold",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
-    ],	
+    ],
     "blocks": [
     {
       "type": "NpcTalkAndOrder",
@@ -47,23 +48,23 @@
         "id": 317
       },
       "npc_id": "Gunther",
-      "message_id": 10800
+      "message_id": 17164
     },
     {
       "type": "DeliverItems",
       "stage_id": {
-        "id": 44,
-        "group_id": 1
+        "id": 44
       },
       "npc_id": "Kennec",
       "announce_type": "Accept",
-      "items": [
-        {
-          "id": 11770,
-          "amount": 6
-        }
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 2401, "Param2": 17165, "comment": "Extra dialogue - Gunther"},
+        {"type": "QstTalkChg", "Param1": 1605, "Param2": 17166, "comment": "Extra dialogue - Kennec"}
       ],
-      "message_id": 10737		
+      "items": [
+        {"id": 11770, "amount": 6, "comment": "Volden Quality Coal"}
+      ],
+      "message_id": 17167
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000048.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000048.json
@@ -6,8 +6,9 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "area_id": "BloodbaneIsle",
+    "news_image": 532,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 8}],
-	"area_id": "BloodbaneIsle",	
     "rewards": [
         {
             "type": "wallet",
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11775,
+                    "item_id": "StalactiteTip",
                     "num": 3
                 },
-                {					
-                    "item_id": 7848,
+                {
+                    "item_id": "BlueAlluvialGold",
                     "num": 3
                 },
-                {				
-                    "item_id": 9364,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
@@ -47,68 +48,84 @@
                 "id": 321,
                 "group_id": 2
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Golem",
                     "enemy_id": "0x015100",
                     "level": 65,
-                    "exp": 50000,
-                    "is_boss": true
-    },
-    {
+                    "exp": 3940,
+                    "is_boss": true,
+                    "index": 1
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger",
                     "enemy_id": "0x010162",
                     "level": 65,
-                    "exp": 3500,
-                    "is_boss": false
-    },
-    {
+                    "exp": 788,
+                    "index": 2
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger",
                     "enemy_id": "0x010162",
                     "level": 65,
-                    "exp": 3500,
-                    "is_boss": false
-    },
-    {
+                    "exp": 788,
+                    "index": 3
+                },
+                {
+                    "comment": "Infected Hobgoblin Slinger",
+                    "enemy_id": "0x010162",
+                    "level": 65,
+                    "exp": 788,
+                    "index": 4
+                },
+                {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 65,
-                    "exp": 3500,
-                    "is_boss": false	
-    },
-    {
+                    "exp": 788,
+                    "index": 7
+                },
+                {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 65,
-                    "exp": 3500,
-                    "is_boss": false						
+                    "exp": 788,
+                    "index": 9
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Rolf",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 317,
-        "group_id": 1
-      },
-      "npc_id": "Rolf",
-      "announce_type": "Accept",
-      "items": [
         {
-          "id": 7956,
-          "amount": 2
-        }
-      ],
-      "message_id": 10737
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Rolf",
+            "message_id": 17156
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Rolf",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17157, "comment": "Extra dialogue - Rolf"}
+            ],
+            "items": [
+                {"id": 7956, "amount": 2, "comment": "Strong Thread"}
+            ],
+            "message_id": 17158
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17159, "comment": "Extra dialogue 2 - Rolf"}
+            ],
             "groups": [0]
         },
         {
@@ -117,16 +134,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Rolf",
-            "message_id": 11842			
+            "message_id": 17160
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000049.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000049.json
@@ -7,7 +7,8 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 8}],
-    "area_id": "BloodbaneIsle", 
+    "area_id": "BloodbaneIsle",
+    "news_image": 244,
     "rewards": [
         {
             "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000059.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000059.json
@@ -6,8 +6,9 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
+    "area_id": "BloodbaneIsle",
+    "news_image": 148,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
-	"area_id": "BloodbaneIsle",	
     "rewards": [
         {
             "type": "wallet",
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11789,
+                    "item_id": "PebbleBud",
                     "num": 3
                 },
-                {					
-                    "item_id": 7555,
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
@@ -48,23 +49,23 @@
                 "id": 317
             },
             "npc_id": "Rolf",
-            "message_id": 10800
+            "message_id": 17445
         },
         {
             "type": "DeliverItems",
             "stage_id": {
-                "id": 317,
-                "group_id": 1
+                "id": 53
             },
-            "npc_id": "Rolf",
+            "npc_id": "Augusto",
             "announce_type": "Accept",
-            "items": [
-                {
-                    "id": 11793,
-                    "amount": 6
-                }
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2402, "Param2": 17446, "comment": "Extra dialogue - Rolf"},
+                {"type": "QstTalkChg", "Param1": 1708, "Param2": 17447, "comment": "Extra dialogue - Augusto"}
             ],
-            "message_id": 10737
+            "items": [
+                {"id": 11793, "amount": 6, "comment": "Ancient Beast Pelt"}
+            ],
+            "message_id": 17448
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000060.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000060.json
@@ -1,0 +1,164 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "As a Knight",
+    "quest_id": 21000060,
+    "base_level": 70,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "BloodbaneIsle",
+    "news_image": 244,
+    "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 14}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 2309
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "exp",
+            "amount": 13814
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "DioriteSteelIngot",
+                    "num": 1
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 337,
+                "group_id": 1
+            },
+            "starting_index": 2,
+            "enemies": [
+                {
+                    "comment": "Infected Behemoth - Critical",
+                    "enemy_id": "0x015712",
+                    "infection_type": 3,
+                    "level": 70,
+                    "exp": 11400,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Flame Corpse Torturer",
+                    "enemy_id": "0x010517",
+                    "level": 70,
+                    "exp": 494,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Flame Corpse Torturer",
+                    "enemy_id": "0x010517",
+                    "level": 70,
+                    "exp": 494,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Flame Corpse Torturer",
+                    "enemy_id": "0x010517",
+                    "level": 70,
+                    "exp": 494,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Flame Corpse Torturer",
+                    "enemy_id": "0x010517",
+                    "level": 70,
+                    "exp": 494,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Flame Corpse Torturer",
+                    "enemy_id": "0x010517",
+                    "level": 70,
+                    "exp": 494,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Infected Snow Harpy",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "level": 70,
+                    "exp": 456,
+                    "repop_count": 2,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Infected Snow Harpy",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "level": 70,
+                    "exp": 456,
+                    "repop_count": 2,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Infected Snow Harpy",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "level": 70,
+                    "exp": 456,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Sven",
+            "message_id": 17449
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2403, "Param2": 17450, "comment": "Extra dialogue - Sven"}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 317
+            },
+            "announce_type": "Update",
+            "npc_id": "Sven",
+            "message_id": 17451
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000061.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000061.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BloodbaneIsle",
+  "news_image": 902,
   "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 11}],
   "rewards": [
     {
@@ -57,7 +58,7 @@
           "enemy_id": "0x015851",
           "named_enemy_params_id": 458,
           "level": 65,
-          "exp": 55167,
+          "exp": 27584,
           "is_boss": true
         },
         {
@@ -66,7 +67,7 @@
           "named_enemy_params_id": 458,
           "infection_type": 2,
           "level": 65,
-          "exp": 720
+          "exp": 360
         },
         {
           "comment": "Bounty Infected Direwolf (Severe)",
@@ -74,7 +75,7 @@
           "named_enemy_params_id": 458,
           "infection_type": 2,
           "level": 65,
-          "exp": 720
+          "exp": 360
         }
       ]
     },
@@ -90,7 +91,7 @@
           "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
           "level": 65,
-          "exp": 792
+          "exp": 396
         },
         {
           "comment": "Bounty Flame Skeleton",
@@ -98,7 +99,7 @@
           "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
           "level": 65,
-          "exp": 792
+          "exp": 396
         },
         {
           "comment": "Bounty Flame Skeleton",
@@ -106,7 +107,7 @@
           "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
           "level": 65,
-          "exp": 792
+          "exp": 396
         },
         {
           "comment": "Bounty Flame Skeleton",
@@ -114,7 +115,7 @@
           "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
           "level": 65,
-          "exp": 792
+          "exp": 396
         },
         {
           "comment": "Bounty Flame Skeleton",
@@ -122,7 +123,7 @@
           "named_enemy_params_id": 458,
           "start_think_tbl_no": 2,
           "level": 65,
-          "exp": 792
+          "exp": 396
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000062.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000062.json
@@ -6,8 +6,9 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
-    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "area_id": "BloodbaneIsle",
+    "news_image": 583,
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "rewards": [
         {
             "type": "wallet",
@@ -27,15 +28,15 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7886,
+                    "item_id": "MagickGoldIngot",
                     "num": 1
                 },
                 {
-                    "item_id": 9364,
+                    "item_id": "SuperiorStrongGalaExtract",
                     "num": 3
                 },
                 {
-                    "item_id": 41,
+                    "item_id": "Panacea",
                     "num": 3
                 }
             ]
@@ -47,24 +48,26 @@
                 "id": 409,
                 "group_id": 3
             },
+            "starting_index": 6,
             "enemies": [
                 {
+                    "comment": "Chimera",
                     "enemy_id": "0x015200",
                     "level": 65,
-                    "exp": 50000,
+                    "exp": 5100,
                     "is_boss": true
                 },
                 {
+                    "comment": "Flame Skeleton Brute",
                     "enemy_id": "0x010320",
                     "level": 65,
-                    "exp": 4000,
-                    "is_boss": false
+                    "exp": 540
                 },
                 {
+                    "comment": "Flame Skeleton Brute",
                     "enemy_id": "0x010320",
                     "level": 65,
-                    "exp": 4000,
-                    "is_boss": false
+                    "exp": 540
                 }
             ]
         }
@@ -76,27 +79,29 @@
                 "id": 317
             },
             "npc_id": "Clarissa",
-            "message_id": 10800
+            "message_id": 17453
         },
         {
             "type": "DeliverItems",
             "stage_id": {
-                "id": 317,
-                "group_id": 1
+                "id": 317
             },
             "npc_id": "Clarissa",
             "announce_type": "Accept",
-            "items": [
-                {
-                    "id": 8011,
-                    "amount": 2
-                }
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2400, "Param2": 17454, "comment": "Extra dialogue - Clarissa"}
             ],
-            "message_id": 10737
+            "items": [
+                {"id": 8011, "amount": 2, "comment": "Scroll of Fire"}
+            ],
+            "message_id": 17455
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2400, "Param2": 17456, "comment": "Extra dialogue 2 - Clarissa"}
+            ],
             "groups": [0]
         },
         {
@@ -108,13 +113,11 @@
         {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Clarissa",
-            "message_id": 11842
+            "message_id": 17457
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000073.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000073.json
@@ -6,7 +6,8 @@
     "base_level": 65,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",
+    "area_id": "BloodbaneIsle",
+    "news_image": 249,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7743,
+                    "item_id": "GoldThread",
                     "num": 1
                 },
-                {					
-                    "item_id": 7555,
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
-                {				
-                    "item_id": 9364,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
@@ -44,48 +45,73 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 335,
+                "id": 336,
                 "group_id": 5
             },
+            "starting_index": 6,
             "enemies": [
                 {
+                    "comment": "Ghoul",
                     "enemy_id": "0x015503",
                     "level": 65,
-                    "exp": 4000,
-                    "is_boss": false
-        },
-        {
+                    "exp": 4900,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Ghoul",
                     "enemy_id": "0x015503",
                     "level": 65,
-                    "exp": 4000,
-                    "is_boss": false
-        },
-        {
-                    "enemy_id": "0x010512",
+                    "exp": 4900,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Dark Corpse Torturer",
+                    "enemy_id": "0x010520",
                     "level": 65,
-                    "exp": 4000,
-                    "is_boss": false					
+                    "exp": 468
+                },
+                {
+                    "comment": "Dark Corpse Torturer",
+                    "enemy_id": "0x010520",
+                    "level": 65,
+                    "exp": 468
+                },
+                {
+                    "comment": "Dark Corpse Torturer",
+                    "enemy_id": "0x010520",
+                    "level": 65,
+                    "exp": 468
+                },
+                {
+                    "comment": "Dark Corpse Torturer",
+                    "enemy_id": "0x010520",
+                    "level": 65,
+                    "exp": 468
+                },
+                {
+                    "comment": "Dark Corpse Torturer",
+                    "enemy_id": "0x010520",
+                    "level": 65,
+                    "exp": 468
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 3757, "comment": "Spawns Something??"}				
-            ],	  
-      "stage_id": {
-        "id": 317,
-		"group_id": 1,
-		"layer_no": 1	
-      },
-      "npc_id": "Clarissa",
-      "message_id": 10800
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Clarissa",
+            "message_id": 17461
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2400, "Param2": 17462, "comment": "Extra dialogue - Clarissa"}
+            ],
             "groups": [0]
         },
         {
@@ -94,16 +120,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Clarissa",
-            "message_id": 11842	
-    }
-  ]
+            "message_id": 17463
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000075.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000075.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "BloodbaneIsle",
+  "news_image": 532,
   "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 13}],
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000085.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000085.json
@@ -6,7 +6,8 @@
     "base_level": 68,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",
+    "area_id": "BloodbaneIsle",
+    "news_image": 533,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 12}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11795,
+                    "item_id": "PhytonLiquid",
                     "num": 3
                 },
-                {					
-                    "item_id": 9364,
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
@@ -47,62 +48,73 @@
                 "id": 319,
                 "group_id": 1
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x015600",
-                    "level": 68,
-                    "exp": 70000,
-                    "is_boss": true
-    },
-    {
-                    "enemy_id": "0x015600",
-                    "level": 68,
-                    "exp": 70000,
-                    "is_boss": true
-    },
-    {
-                    "enemy_id": "0x015600",
-                    "level": 68,
-                    "exp": 70000,
-                    "is_boss": true	
-    },
-    {
+                    "comment": "Shadow Chimera",
                     "enemy_id": "0x015203",
-                    "level": 68,
-                    "exp": 70000,
-                    "is_boss": true						
+                    "level": 66,
+                    "exp": 3940,
+                    "is_boss": true,
+                    "index": 9
+                },
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 65,
+                    "exp": 3876,
+                    "is_boss": true,
+                    "index": 12
+                },
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 65,
+                    "exp": 3876,
+                    "is_boss": true,
+                    "index": 13
+                },
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 65,
+                    "exp": 3876,
+                    "is_boss": true,
+                    "index": 14
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Gunther",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 317,
-        "group_id": 1
-      },
-      "npc_id": "Gunther",
-      "announce_type": "Accept",
-      "items": [
         {
-          "id": 7808,
-          "amount": 2
-        }
-      ],
-      "message_id": 10737
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Gunther",
+            "message_id": 17469
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Gunther",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2401, "Param2": 17470, "comment": "Extra dialogue - Gunther"}
+            ],
+            "items": [
+                {"id": 7808, "amount": 2, "comment": "Witch's Grimoire"}
+            ],
+            "message_id": 17471
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2401, "Param2": 17472, "comment": "Extra dialogue 2 - Gunther"}
+            ],
             "groups": [0]
         },
         {
@@ -111,16 +123,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Gunther",
-            "message_id": 11842			
-    }
-  ]
+            "message_id": 17473
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000087.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000087.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "BloodbaneIsle",
+    "news_image": 582,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 11}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000096.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000096.json
@@ -6,7 +6,8 @@
     "base_level": 68,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",	
+    "area_id": "BloodbaneIsle",
+    "news_image": 249,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 9446,
+                    "item_id": "WindTwine",
                     "num": 1
                 },
-                {					
-                    "item_id": 7555,
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
@@ -44,61 +45,78 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 335,
+                "id": 336,
                 "group_id": 5
             },
+            "starting_index": 5,
             "enemies": [
                 {
-                    "enemy_id": "0x010461",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false	
-    },
-    {
-                    "enemy_id": "0x010461",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010461",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010461",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010508",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false					
-    },
-    {
+                    "comment": "Golem",
                     "enemy_id": "0x015100",
                     "level": 68,
-                    "exp": 70000,
-                    "is_boss": true						
+                    "exp": 5925,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Eliminator",
+                    "enemy_id": "0x010508",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Eliminator",
+                    "enemy_id": "0x010508",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 68,
+                    "exp": 1185
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Clarissa",
-      "message_id": 10800
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Clarissa",
+            "message_id": 17477
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2400, "Param2": 17478, "comment": "Extra dialogue - Clarissa"}
+            ],
             "groups": [0]
         },
         {
@@ -107,16 +125,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Clarissa",
-            "message_id": 11842			
-    }
-  ]
+            "message_id": 17479
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000097.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000097.json
@@ -6,7 +6,8 @@
     "base_level": 68,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "BloodbaneIsle",
+    "area_id": "BloodbaneIsle",
+    "news_image": 533,
     "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 13}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 11795,
+                    "item_id": "PhytonLiquid",
                     "num": 3
                 },
-                {					
-                    "item_id": 7555,
+                {
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 },
-                {				
-                    "item_id": 9364,
-                    "num": 3					
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
                 }
             ]
         }
@@ -47,62 +48,78 @@
                 "id": 319,
                 "group_id": 1
             },
+            "starting_index": 9,
             "enemies": [
                 {
-                    "enemy_id": "0x011130",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false	
-    },
-    {
-                    "enemy_id": "0x011130",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false	
-    },
-    {
-                    "enemy_id": "0x011130",
-                    "level": 68,
-                    "exp": 3000,
-                    "is_boss": false	
-    },
-    {
+                    "comment": "Shadow Chimera",
                     "enemy_id": "0x015203",
                     "level": 68,
-                    "exp": 70000,
-                    "is_boss": true						
+                    "exp": 5925,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Shadow Goblin Leader",
+                    "enemy_id": "0x011160",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Shadow Goblin Leader",
+                    "enemy_id": "0x011160",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "level": 68,
+                    "exp": 1185
+                },
+                {
+                    "comment": "Shadow Goblin Fighter",
+                    "enemy_id": "0x011131",
+                    "level": 68,
+                    "exp": 1185
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 317
-      },
-      "npc_id": "Gunther",
-      "message_id": 10800
-    },
-    {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 317,
-        "group_id": 1
-      },
-      "npc_id": "Gunther",
-      "announce_type": "Accept",
-      "items": [
         {
-          "id": 8033,
-          "amount": 2
-        }
-      ],
-      "message_id": 10737
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Gunther",
+            "message_id": 17481
+        },
+        {
+            "type": "DeliverItems",
+            "stage_id": {
+                "id": 317
+            },
+            "npc_id": "Gunther",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2401, "Param2": 17482, "comment": "Extra dialogue - Gunther"}
+            ],
+            "items": [
+                {"id": 8033, "amount": 2, "comment": "Aliment Extractant"}
+            ],
+            "message_id": 17483
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2401, "Param2": 17484, "comment": "Extra dialogue 2 - Gunther"}
+            ],
             "groups": [0]
         },
         {
@@ -111,16 +128,14 @@
             "reset_group": false,
             "groups": [0]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 317,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 317
             },
             "announce_type": "Update",
             "npc_id": "Gunther",
-            "message_id": 11842			
-    }
-  ]
+            "message_id": 17485
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000099.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000099.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "BloodbaneIsle",
+    "news_image": 247,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20100}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014000.json
@@ -6,8 +6,13 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",	
+    "area_id": "ElanWaterGrove",
+    "news_image": 282,
     "rewards": [
+        {
+            "type": "exp",
+            "amount": 9210
+        },
         {
             "type": "wallet",
             "wallet_type": "Gold",
@@ -19,57 +24,54 @@
             "amount": 300
         },
         {
-            "type": "exp",
-            "amount": 9210
-        },
-        {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7937,
+                    "item_id": "HardLeatherCloth",
                     "num": 3
                 },
-                {					
-                    "item_id": 9364,
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
                     "num": 3
                 },
-                {				
-                    "item_id": 41,
-                    "num": 3					
+                {
+                    "item_id": "Panacea",
+                    "num": 3
                 }
             ]
         }
     ],
-    "enemy_groups" : [
+    "enemy_groups": [
         {
             "stage_id": {
                 "id": 372,
-                "group_id": 27
+                "group_id": 23
             },
+            "starting_index": 5,
             "enemies": [
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535
                 },
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535
                 },
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535
                 },
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535
                 }
             ]
         },
@@ -78,21 +80,43 @@
                 "id": 372,
                 "group_id": 24
             },
+            "starting_index": 4,
             "enemies": [
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Giant Sulfur Saurian",
+                    "enemy_id": "0x010411",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535
                 },
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Giant Sulfur Saurian",
+                    "enemy_id": "0x010411",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535
                 },
                 {
-                    "enemy_id": "0x010430",
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
                     "level": 70,
-                    "exp": 3000			
+                    "exp": 1535
+                },
+                {
+                    "comment": "Giant Sulfur Saurian",
+                    "enemy_id": "0x010411",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "level": 70,
+                    "exp": 1535
                 }
             ]
         },
@@ -101,77 +125,106 @@
                 "id": 372,
                 "group_id": 27
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535,
+                    "index": 4
                 },
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535,
+                    "index": 5
                 },
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 70,
-                    "exp": 3000					
+                    "exp": 1535,
+                    "index": 6
+                },
+                {
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 7
+                },
+                {
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 8
+                },
+                {
+                    "comment": "Sulfur Saurian",
+                    "enemy_id": "0x010410",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 10
                 }
             ]
         }
     ],
-  "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 339
-      },
-      "npc_id": "Dirith1",
-      "message_id": 10800
-    },
-    {
-      "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Accept",
-      "groups": [ 0 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [ 0 ]
-    },
-    {
-      "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Update",
-      "groups": [ 1 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [ 1 ]
-    },
-    {
-      "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Update",
-      "groups": [ 2 ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [ 2 ]
-    },
-    {
-      "type": "TalkToNpc",
-      "stage_id": {
-        "id": 339,
-        "group_id": 1,
-        "layer_no": 1
-      },
-      "announce_type": "Update",
-      "npc_id": "Dirith1",
-      "message_id": 11842
-    }
-  ]
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 339
+            },
+            "npc_id": "Dirith1",
+            "message_id": 19249
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 559, "Param2": 19250}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 339
+            },
+            "announce_type": "Update",
+            "npc_id": "Dirith1",
+            "message_id": 19251
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014001.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
 	"area_id": "ElanWaterGrove",
+    "news_image": 531,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
     "rewards": [
         {
@@ -27,15 +28,15 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15928,
+                    "item_id": "RainbowColoredClaw",
                     "num": 1
                 },
                 {					
-                    "item_id": 15960,
+                    "item_id": "DemonWolfsSinewyMeat",
                     "num": 3
                 },
                 {				
-                    "item_id": 7555,
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3					
                 }
             ]
@@ -45,14 +46,64 @@
         {
             "stage_id": {
                 "id": 372,
-                "group_id": 4
+                "group_id": 35
             },
+			"starting_index": 1,
             "enemies": [
                 {
+					"comment": "Bifröst",
                     "enemy_id": "0x015321",
                     "level": 75,
-                    "exp": 88000,
+                    "exp": 12175,
                     "is_boss": true			
+                },
+                {
+					"comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 75,
+                    "exp": 2435		
+                },
+                {
+					"comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 75,
+                    "exp": 2435		
                 }
             ]
         }
@@ -69,11 +120,14 @@
                 "layer_no": 0
             },
             "npc_id": "Fabio0",
-            "message_id": 10800
+            "message_id": 19389
         },
         {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 12, "Param2": 19390}
+            ],
             "groups": [0]
         },
         {
@@ -91,7 +145,7 @@
             },
             "announce_type": "Update",
             "npc_id": "Fabio0",
-            "message_id": 11842
+            "message_id": 19391
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014002.json
@@ -1,0 +1,385 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "High Difficulty: Lurker in the Deep Woods",
+  "quest_id": 21014002,
+  "base_level": 75,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ElanWaterGrove",
+  "news_image": 282,
+  "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 29220
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4493
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 675
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Platinum Blood",
+          "item_id": 15935,
+          "num": 1
+        },
+        {
+          "comment": "Dazzling Silver Plume",
+          "item_id": 15967,
+          "num": 1
+        },
+        {
+          "comment": "Sharp Back Spine",
+          "item_id": 15969,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 372,
+        "group_id": 34
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Spineback",
+          "enemy_id": "0x015506",
+          "level": 75,
+          "exp": 12175,
+          "is_boss": true
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 416,
+        "group_id": 1
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Silver Roar",
+          "enemy_id": "0x015505",
+          "level": 75,
+          "exp": 12175,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 75,
+          "exp": 2435,
+          "index": 2
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 75,
+          "exp": 2435,
+          "index": 3
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 75,
+          "exp": 2435,
+          "index": 4
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 75,
+          "exp": 2435,
+          "index": 5
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 75,
+          "exp": 2435,
+          "index": 6
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 75,
+          "exp": 2435,
+          "index": 7
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 416,
+        "group_id": 3
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Ent",
+          "enemy_id": "0x015031",
+          "level": 75,
+          "exp": 12175,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Mole Troll",
+          "enemy_id": "0x015041",
+          "level": 75,
+          "exp": 12175,
+          "is_boss": true,
+          "index": 2
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 75,
+          "exp": 2435,
+          "index": 4
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 75,
+          "exp": 2435,
+          "index": 5
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 75,
+          "exp": 2435,
+          "index": 6
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 75,
+          "exp": 2435,
+          "index": 7
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 75,
+          "exp": 2435,
+          "index": 8
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 416,
+        "group_id": 4
+      },
+      "enemies": [
+        {
+          "comment": "White Griffin",
+          "enemy_id": "0x015320",
+          "level": 75,
+          "exp": 60875,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "White Chimera",
+          "enemy_id": "0x015202",
+          "level": 75,
+          "exp": 12175,
+          "index": 1
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 75,
+          "exp": 2435,
+          "index": 2
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 75,
+          "exp": 2435,
+          "index": 5
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 75,
+          "exp": 2435,
+          "index": 12
+        },
+        {
+          "comment": "Saurian Sage",
+          "enemy_id": "0x010430",
+          "level": 75,
+          "exp": 2435,
+          "index": 17
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 339
+          },
+          "npc_id": "Musel0",
+          "message_id": 19393
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {"type": "QstTalkChg", "Param1": 4509, "Param2": 19394}
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 339
+          },
+          "npc_id": "Musel0",
+          "message_id": 19395
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014003.json
@@ -1,0 +1,143 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Wealth and Power",
+  "quest_id": 21014003,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ElanWaterGrove",
+  "news_image": 538,
+  "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 7}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4408
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 555
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Twisted Iron Scrap",
+          "item_id": 15919,
+          "num": 4
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 425,
+        "group_id": 3
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Troll",
+          "enemy_id": "0x015040",
+          "level": 75,
+          "exp": 12175,
+          "is_boss": true,
+          "index": 3
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435,
+          "index": 13
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435,
+          "index": 14
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435,
+          "index": 15
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 75,
+          "exp": 2435,
+          "index": 16
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 339
+      },
+      "npc_id": "Dirith1",
+      "message_id": 19396
+    },
+    {
+      "type": "DeliverItems",
+      "stage_id": {
+        "id": 339
+      },
+      "npc_id": "Dirith1",
+      "announce_type": "Accept",
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 559, "Param2": 19397}
+      ],
+      "items": [
+        {"id": 15921, "amount": 4, "comment": "Shrieking Mushroom"}
+      ],
+      "message_id": 19398
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 559, "Param2": 19399}
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 339
+      },
+      "announce_type": "Update",
+      "npc_id": "Dirith1",
+      "message_id": 19400
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
+    "news_image": 284,
     "rewards": [
         {
             "type": "wallet",
@@ -111,7 +112,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 22}
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 22},
+                        {"type": "StageNo", "Param1": 121}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
 	"area_id": "ElanWaterGrove",
+    "news_image": 281,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 8}],
     "rewards": [
         {
@@ -112,7 +113,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "WeatherEq", "Param1": 3}
+                        {"type": "WeatherEq", "Param1": 3},
+                        {"type": "StageNo", "Param1": 121}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014007.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
+    "news_image": 583,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 4}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014008.json
@@ -6,7 +6,8 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",
+    "area_id": "ElanWaterGrove",
+    "news_image": 583,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 4}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15915,
+                    "item_id": "PurplePetals",
                     "num": 3
                 },
                 {
-                    "item_id": 15961,
+                    "item_id": "StiffCrocodileSkin",
                     "num": 3
                 },
                 {
-                    "item_id": 15960,
-                    "num": 3					
+                    "item_id": "DemonWolfsSinewyMeat",
+                    "num": 3
                 }
             ]
         }
@@ -47,31 +48,49 @@
                 "id": 415,
                 "group_id": 1
             },
+            "placement_type": "manual",
             "enemies": [
                 {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000
-                },
-                {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000
-                },
-                {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000
-                },
-                {
+                    "comment": "Foot-Biter",
                     "enemy_id": "0x011500",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535,
+                    "index": 3
                 },
                 {
+                    "comment": "Foot-Biter",
                     "enemy_id": "0x011500",
                     "level": 70,
-                    "exp": 3000						
+                    "exp": 1535,
+                    "index": 4
+                },
+                {
+                    "comment": "Foot-Biter",
+                    "enemy_id": "0x011500",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 5
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 7
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 8
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 9
                 }
             ]
         },
@@ -80,32 +99,43 @@
                 "id": 415,
                 "group_id": 4
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 8
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 9
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 10
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 11
+                },
+                {
+                    "comment": "Silver Roar",
                     "enemy_id": "0x015505",
                     "level": 70,
-                    "exp": 85000,
-					"is_boss": true
-                },
-                {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000
-                },
-                {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000
-                },
-                {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000
-                },
-                {
-                    "enemy_id": "0x010203",
-                    "level": 70,
-                    "exp": 3000					
+                    "exp": 7675,
+                    "is_boss": true,
+                    "index": 14
                 }
             ]
         },
@@ -114,37 +144,68 @@
                 "id": 415,
                 "group_id": 5
             },
+            "starting_index": 3,
             "enemies": [
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535
                 },
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535
                 },
                 {
+                    "comment": "Saurian Sage",
                     "enemy_id": "0x010430",
                     "level": 70,
-                    "exp": 3000
+                    "exp": 1535
+                },
+                {
+                    "comment": "Foot-Biter",
+                    "enemy_id": "0x011500",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Foot-Biter",
+                    "enemy_id": "0x011500",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Foot-Biter",
+                    "enemy_id": "0x011500",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 1535
                 }
             ]
         }
     ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 372
-      },
-      "npc_id": "Enna",
-      "message_id": 10800
-    },
-    {
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 372
+            },
+            "npc_id": "Enna",
+            "message_id": 19252
+        },
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 556, "Param2": 19253}
+            ],
             "groups": [0]
         },
         {
@@ -153,10 +214,10 @@
             "reset_group": false,
             "groups": [0]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
-            "groups": [1]			
+            "groups": [1]
         },
         {
             "type": "KillGroup",
@@ -164,27 +225,25 @@
             "reset_group": false,
             "groups": [1]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
             "groups": [2]
         },
-        {				
+        {
             "type": "KillGroup",
             "announce_type": "Update",
             "reset_group": false,
-            "groups": [2]			
+            "groups": [2]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 372,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 372
             },
             "announce_type": "Update",
             "npc_id": "Enna",
-            "message_id": 11842			
-    }
-  ]
+            "message_id": 19254
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014009.json
@@ -6,37 +6,38 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",
+    "area_id": "ElanWaterGrove",
+    "news_image": 282,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 8}],
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 2309
+            "amount": 4408
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 300
+            "amount": 555
         },
         {
             "type": "exp",
-            "amount": 9210
+            "amount": 19665
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 7937,
+                    "item_id": "SharpBackSpine",
+                    "num": 1
+                },
+                {
+                    "item_id": "DemonWolfsSinewyMeat",
                     "num": 3
                 },
-                {					
-                    "item_id": 9364,
+                {
+                    "item_id": "BronzeTailFeather",
                     "num": 3
-                },
-                {				
-                    "item_id": 41,
-                    "num": 3					
                 }
             ]
         }
@@ -45,90 +46,111 @@
         {
             "stage_id": {
                 "id": 372,
-                "group_id": 23
+                "group_id": 22
             },
+            "starting_index": 4,
             "enemies": [
                 {
-                    "enemy_id": "0x010430",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 73,
+                    "exp": 2185
                 },
                 {
-                    "enemy_id": "0x010430",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 73,
+                    "exp": 2185
                 },
                 {
-                    "enemy_id": "0x010430",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 73,
+                    "exp": 2185
                 },
                 {
-                    "enemy_id": "0x010430",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 73,
+                    "exp": 2185
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 372,
-                "group_id": 14
+                "group_id": 30
             },
             "enemies": [
                 {
+                    "comment": "Little Spine",
                     "enemy_id": "0x015507",
-                    "level": 70,
-                    "exp": 3000
+                    "level": 73,
+                    "exp": 2185
                 },
                 {
+                    "comment": "Little Spine",
                     "enemy_id": "0x015507",
-                    "level": 70,
-                    "exp": 3000
+                    "level": 73,
+                    "exp": 2185
                 },
                 {
+                    "comment": "Little Spine",
                     "enemy_id": "0x015507",
-                    "level": 70,
-                    "exp": 3000
+                    "level": 73,
+                    "exp": 2185
                 },
                 {
+                    "comment": "Little Spine",
                     "enemy_id": "0x015507",
-                    "level": 70,
-                    "exp": 3000					
+                    "level": 73,
+                    "exp": 2185
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 372,
-                "group_id": 44
+                "group_id": 20
             },
             "enemies": [
                 {
+                    "comment": "Spineback",
                     "enemy_id": "0x015506",
-                    "level": 70,
-                    "exp": 80000,
-					"is_boss": true
+                    "level": 73,
+                    "exp": 10925,
+                    "is_boss": true
                 }
             ]
         }
-    ],		
+    ],
     "blocks": [
-    {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 339
-      },
-      "npc_id": "Dirith1",
-      "message_id": 10800
-    },
-    {
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 339
+            },
+            "npc_id": "Dirith1",
+            "message_id": 19255
+        },
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 559, "Param2": 19258}
+            ],
             "groups": [0]
         },
         {
@@ -137,10 +159,10 @@
             "reset_group": false,
             "groups": [0]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
-            "groups": [1]			
+            "groups": [1]
         },
         {
             "type": "KillGroup",
@@ -148,27 +170,25 @@
             "reset_group": false,
             "groups": [1]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
             "groups": [2]
         },
-        {				
+        {
             "type": "KillGroup",
             "announce_type": "Update",
             "reset_group": false,
-            "groups": [2]			
+            "groups": [2]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 339,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 339
             },
             "announce_type": "Update",
             "npc_id": "Dirith1",
-            "message_id": 11842			
-    }
-  ]
+            "message_id": 19259
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014010.json
@@ -1,0 +1,265 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Don't Look Behind You",
+  "quest_id": 21014010,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ElanWaterGrove",
+  "news_image": 504,
+  "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 7}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4408
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 555
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Shrieking Mushroom",
+          "item_id": 15921,
+          "num": 3
+        },
+        {
+          "comment": "Stiff Crocodile Skin",
+          "item_id": 15961,
+          "num": 3
+        },
+        {
+          "comment": "Demon Wolf's Sinewy Meat",
+          "item_id": 15960,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 425,
+        "group_id": 1
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 73,
+          "exp": 2185,
+          "index": 0
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 73,
+          "exp": 2185,
+          "index": 4
+        },
+        {
+          "comment": "Brute Ape",
+          "enemy_id": "0x015504",
+          "level": 73,
+          "exp": 2185,
+          "index": 6
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 73,
+          "exp": 2185,
+          "index": 7
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 73,
+          "exp": 2185,
+          "index": 8
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 425,
+        "group_id": 2
+      },
+      "starting_index": 9,
+      "enemies": [
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Little Spine",
+          "enemy_id": "0x015507",
+          "level": 73,
+          "exp": 2185
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 425,
+        "group_id": 5
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Witch",
+          "enemy_id": "0x015604",
+          "level": 73,
+          "exp": 10925,
+          "is_boss": true
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 73,
+          "exp": 2185
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NewNpcTalkAndOrder",
+      "stage_id": {
+        "id": 372,
+        "group_id": 0,
+        "layer_no": 0
+      },
+      "npc_id": "Caradoc",
+      "message_id": 19617,
+      "result_commands": [
+        {"type": "QstLayoutFlagOn", "Param1": 4233, "comment": "Spawns Caradoc NPC"}
+      ]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 914, "Param2": 19618}
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [1]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [2]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [2]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 372,
+        "group_id": 0,
+        "layer_no": 0
+      },
+      "npc_id": "Caradoc",
+      "message_id": 19619
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014011.json
@@ -6,7 +6,8 @@
     "base_level": 75,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "ElanWaterGrove",
+    "area_id": "ElanWaterGrove",
+    "news_image": 583,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
     "rewards": [
         {
@@ -27,16 +28,16 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 15931,
+                    "item_id": "AncientManuscriptScrap",
                     "num": 3
                 },
                 {
-                    "item_id": 15969,
+                    "item_id": "SharpBackSpine",
                     "num": 1
                 },
                 {
-                    "item_id": 15962,
-                    "num": 3					
+                    "item_id": "BronzeTailFeather",
+                    "num": 3
                 }
             ]
         }
@@ -47,32 +48,38 @@
                 "id": 372,
                 "group_id": 16
             },
+            "starting_index": 4,
             "enemies": [
                 {
+                    "comment": "Dread Ape",
                     "enemy_id": "0x015502",
                     "level": 75,
-                    "exp": 86000,
-					"is_boss": true
+                    "exp": 12175,
+                    "is_boss": true
                 },
                 {
+                    "comment": "Stymphalides",
                     "enemy_id": "0x010611",
                     "level": 75,
-                    "exp": 5000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Stymphalides",
                     "enemy_id": "0x010611",
                     "level": 75,
-                    "exp": 5000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Stymphalides",
                     "enemy_id": "0x010611",
                     "level": 75,
-                    "exp": 5000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Stymphalides",
                     "enemy_id": "0x010611",
                     "level": 75,
-                    "exp": 5000					
+                    "exp": 2435
                 }
             ]
         },
@@ -81,158 +88,135 @@
                 "id": 372,
                 "group_id": 32
             },
+            "starting_index": 4,
             "enemies": [
                 {
+                    "comment": "Troll",
                     "enemy_id": "0x015040",
                     "level": 75,
-                    "exp": 87000,
-					"is_boss": true
+                    "exp": 12175,
+                    "is_boss": true
                 },
                 {
+                    "comment": "Warg",
                     "enemy_id": "0x010203",
                     "level": 75,
-                    "exp": 5000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Warg",
                     "enemy_id": "0x010203",
                     "level": 75,
-                    "exp": 5000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Warg",
                     "enemy_id": "0x010203",
                     "level": 75,
-                    "exp": 5000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Warg",
                     "enemy_id": "0x010203",
                     "level": 75,
-                    "exp": 5000					
+                    "exp": 2435
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 416,
-                "group_id": 5
+                "group_id": 6
             },
+            "starting_index": 4,
             "enemies": [
                 {
+                    "comment": "Spineback",
                     "enemy_id": "0x015506",
                     "level": 75,
-                    "exp": 87000,
-					"is_boss": true
+                    "exp": 12175,
+                    "is_boss": true
                 },
                 {
+                    "comment": "Little Spine",
                     "enemy_id": "0x015507",
                     "level": 75,
-                    "exp": 3000
+                    "exp": 2435
                 },
                 {
+                    "comment": "Little Spine",
                     "enemy_id": "0x015507",
                     "level": 75,
-                    "exp": 3000
+                    "exp": 2435
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2435
                 }
             ]
         }
     ],
-    "processes": [
+    "blocks": [
         {
-            "comment": "Process 0",
-            "blocks": [
-                {
-                    "type": "NpcTalkAndOrder",
-                    "stage_id": {
-                        "id": 372
-                    },
-                    "npc_id": "Gobinet",
-                    "message_id": 11372
-                },
-                {
-                    "type": "MyQstFlags",
-                    "announce_type": "Accept",
-                    "set_flags": [1],
-                    "check_flags": [2, 3, 4]
-                },
-                {
-                    "type": "TalkToNpc",
-                    "stage_id": {
-                        "id": 372
-                    },
-                    "announce_type": "Update",
-                    "npc_id": "Gobinet",
-                    "message_id": 11842
-                }
-            ]
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 372
+            },
+            "npc_id": "Gobinet",
+            "message_id": 19620
         },
         {
-            "comment": "Process1 (Demon Group 1)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-				},
-				{
-					"type": "SeekOutEnemiesAtMarkedLocation",
-					"announce_type": "Update",
-					"groups": [0]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [0]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [2]
-                }
-            ]
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 557, "Param2": 19621}
+            ],
+            "groups": [0]
         },
         {
-            "comment": "Process2 (Demons Group 2)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-                },
-                {
-                    "type": "DiscoverEnemy",
-                    "groups": [1]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [1]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [3]
-                }
-            ]
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
         },
         {
-            "comment": "Process3 (Demons Group 3)",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [1]
-                },
-                {
-                    "type": "DiscoverEnemy",
-                    "groups": [2]
-                },
-                {
-                    "type": "KillGroup",
-                    "announce_type": "Update",
-                    "reset_group": false,
-                    "groups": [2]
-                },
-                {
-                    "type": "MyQstFlags",
-                    "set_flags": [4]					
-                }
-            ]
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 372
+            },
+            "announce_type": "Update",
+            "npc_id": "Gobinet",
+            "message_id": 19622
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014012.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
+    "news_image": 582,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 10}],
     "rewards": [
         {
@@ -27,15 +28,15 @@
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": 13483,
+                    "item_id": "UnappraisedFlowerTrinketSoldier",
                     "num": 3
                 },
                 {
-                    "item_id": 15962,
+                    "item_id": "BronzeTailFeather",
                     "num": 3
                 },
                 {
-                    "item_id": 7555,
+                    "item_id": "SuperiorHealingRemedy",
                     "num": 3
                 }
             ]
@@ -47,131 +48,133 @@
                 "id": 416,
                 "group_id": 5
             },
-          "enemies": [
-            {
-              "enemy_id": "0x015504",
-              "level": 75,
-              "exp": 5000
-            },
-            {
-              "enemy_id": "0x015504",
-              "level": 75,
-              "exp": 5000
-            },
-            {
-              "enemy_id": "0x015504",
-              "level": 75,
-              "exp": 5000
-            },
-            {
-              "enemy_id": "0x010611",
-              "level": 75,
-              "exp": 5000
-            },
-            {
-              "enemy_id": "0x010611",
-              "level": 75,
-              "exp": 5000
-            },
-            {
-              "enemy_id": "0x010611",
-              "level": 75,
-              "exp": 5000
-            },
-            {
-              "enemy_id": "0x010611",
-              "level": 75,
-              "exp": 5000
-            }
-          ]
-        }
-    ],
-  "blocks": [
-    {
-      "type": "NewNpcTalkAndOrder",
-      "stage_id": {
-        "id": 372,
-        "group_id": 0,
-        "layer_no": 0
-      },
-      "npc_id": "561",
-      "message_id": 19495,
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 4474,
-          "comment": "Spawns Sullivan NPC"
-        }
-      ]
-    },
-    {
-      "type": "NewTalkToNpc",
-      "announce_type": "Accept",
-      "stage_id": {
-        "id": 416,
-        "group_id": 0,
-        "layer_no": 0
-      },
-      "npc_id": "562",
-      "message_id": 21095,
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 4471,
-          "comment": "Spawns Glenis NPC"
-        }
-      ]
-    },
-    {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "groups": [ 0 ],
-      "flags": [
-        {
-          "type": "MyQst",
-          "action": "Set",
-          "value": 2094,
-          "comment": "Starts Glenis NPC FSM"
-        }
-      ]
-    },
-    {
-      "type": "NewTalkToNpc",
-      "announce_type": "Update",
-      "stage_id": {
-        "id": 416,
-        "group_id": 2,
-        "layer_no": 0
-      },
-      "npc_id": "562",
-      "message_id": 19843,
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Clear",
-          "value": 4471,
-          "comment": "Spawns Glenis NPC"
+            "enemies": []
         },
         {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 4476,
-          "comment": "Spawns Glenis NPC"
+            "stage_id": {
+                "id": 416,
+                "group_id": 5
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2435
+                }
+            ]
         }
-      ]
-    },
-    {
-      "type": "NewTalkToNpc",
-      "announce_type": "CheckpointAndUpdate",
-      "stage_id": {
-        "id": 372,
-        "group_id": 0,
-        "layer_no": 0
-      },
-      "npc_id": "561",
-      "message_id": 19477
-    }
-  ]
+    ],
+
+    "blocks": [
+        {
+            "type": "NewNpcTalkAndOrder",
+            "stage_id": {
+                "id": 372,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Sullivan",
+            "message_id": 19495,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4474, "comment": "Spawns Sullivan NPC"}
+            ]
+        },
+        {
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 561, "Param2": 19496, "comment": "Extra dialogue - Sullivan"}
+            ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 815}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 416,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Glenis",
+            "message_id": 21095,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4471, "comment": "Spawns Glenis NPC"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [1],
+            "result_commands": [
+                {"type": "CallMessage", "Param1": 562, "Param1": 19498},
+                {"type": "MyQstFlagOn", "Param1": 2094, "comment": "Glenis FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 416,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "Glenis",
+            "message_id": 19561,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 4471, "comment": "Clears Glenis NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4476, "comment": "Spawns Glenis (Alive) NPC"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 372,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Sullivan",
+            "message_id": 19477
+        }
+    ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014013.json
@@ -1,42 +1,42 @@
 {
     "state_machine": "GenericStateMachine",
     "type": "World",
-    "comment": "Water Grove Wayfarers",
-    "quest_id": 21014014,
-    "base_level": 73,
+    "comment": "The Arisen Corps' Blunder",
+    "quest_id": 21014013,
+    "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
-    "news_image": 623,
-    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 7}],
+    "news_image": 583,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 4}],
     "rewards": [
         {
             "type": "wallet",
             "wallet_type": "Gold",
-            "amount": 4408
+            "amount": 2309
         },
         {
             "type": "wallet",
             "wallet_type": "RiftPoints",
-            "amount": 555
+            "amount": 300
         },
         {
             "type": "exp",
-            "amount": 19665
+            "amount": 13814
         },
         {
             "type": "select",
             "loot_pool": [
                 {
-                    "item_id": "ShriekingMushroom",
-                    "num": 3
-                },
-                {
-                    "item_id": "BronzeTailFeather",
+                    "item_id": "PurplePetals",
                     "num": 3
                 },
                 {
                     "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
                     "num": 3
                 }
             ]
@@ -45,41 +45,42 @@
     "enemy_groups" : [
         {
             "stage_id": {
-                "id": 425,
-                "group_id": 3
+                "id": 415,
+                "group_id": 2
             },
             "enemies": []
         },
         {
             "stage_id": {
-                "id": 425,
-                "group_id": 3
+                "id": 415,
+                "group_id": 2
             },
+            "starting_index": 4,
             "enemies": [
                 {
-                    "comment": "Silver Roar",
-                    "enemy_id": "0x015505",
-                    "level": 73,
-                    "exp": 10925,
+                    "comment": "Troll",
+                    "enemy_id": "0x015040",
+                    "level": 70,
+                    "exp": 7675,
                     "is_boss": true
                 },
                 {
-                    "comment": "Stymphalides",
-                    "enemy_id": "0x010611",
-                    "level": 73,
-                    "exp": 2185
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 1535
                 },
                 {
-                    "comment": "Stymphalides",
-                    "enemy_id": "0x010611",
-                    "level": 73,
-                    "exp": 2185
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 1535
                 },
                 {
-                    "comment": "Stymphalides",
-                    "enemy_id": "0x010611",
-                    "level": 73,
-                    "exp": 2185
+                    "comment": "Saurian Sage",
+                    "enemy_id": "0x010430",
+                    "level": 70,
+                    "exp": 1535
                 }
             ]
         }
@@ -92,10 +93,10 @@
                 "group_id": 0,
                 "layer_no": 0
             },
-            "npc_id": "Nora",
-            "message_id": 19519,
+            "npc_id": "ArisenCorpsRegimentalSoldier7",
+            "message_id": 19511,
             "result_commands": [
-                {"type": "QstLayoutFlagOn", "Param1": 4486, "comment": "Spawns Nora NPC"}
+                {"type": "QstLayoutFlagOn", "Param1": 4480, "comment": "Spawns Regimental Soldier NPC"}
             ]
         },
         {
@@ -103,23 +104,23 @@
             "announce_type": "Accept",
             "groups": [0],
             "result_commands": [
-                {"type": "QstTalkChg", "Param1": 4753, "Param2": 19520, "comment": "Extra dialogue - Nora"}
+                {"type": "QstTalkChg", "Param1": 530, "Param2": 19512, "comment": "Extra dialogue - Regimental Soldier 7"}
             ],
             "check_commands": [
-                {"type": "StageNo", "Param1": 844}
+                {"type": "StageNo", "Param1": 814}
             ]
         },
         {
             "type": "NewTalkToNpc",
             "stage_id": {
-                "id": 425,
+                "id": 415,
                 "group_id": 0,
                 "layer_no": 0
             },
-            "npc_id": "Ifa",
-            "message_id": 21097,
+            "npc_id": "ArisenCorpsRegimentalSoldier6",
+            "message_id": 21096,
             "result_commands": [
-                {"type": "QstLayoutFlagOn", "Param1": 4483, "comment": "Spawns Aoife NPC"}
+                {"type": "QstLayoutFlagOn", "Param1": 4477, "comment": "Spawns Regimental Soldier 6 NPC"}
             ]
         },
         {
@@ -127,23 +128,23 @@
             "announce_type": "Update",
             "groups": [1],
             "result_commands": [
-                {"type": "CallMessage", "Param1": 563, "Param1": 19522},
-                {"type": "MyQstFlagOn", "Param1": 2102, "comment": "Aoife FSM"}
+                {"type": "CallMessage", "Param1": 529, "Param1": 19514},
+                {"type": "MyQstFlagOn", "Param1": 2098, "comment": "Regimental Soldier 6 FSM"}
             ]
         },
         {
             "type": "NewTalkToNpc",
             "announce_type": "Update",
             "stage_id": {
-                "id": 425,
+                "id": 415,
                 "group_id": 2,
                 "layer_no": 0
             },
-            "npc_id": "Ifa",
-            "message_id": 19565,
+            "npc_id": "ArisenCorpsRegimentalSoldier6",
+            "message_id": 19563,
             "result_commands": [
-                {"type": "QstLayoutFlagOff", "Param1": 4483, "comment": "Clears Aoife NPC"},
-                {"type": "QstLayoutFlagOn", "Param1": 4488, "comment": "Spawns Aoife (Alive) NPC"}
+                {"type": "QstLayoutFlagOff", "Param1": 4477, "comment": "Clears Regimental Soldier 6 NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4482, "comment": "Spawns Regimental Soldier 6 (Alive) NPC"}
             ]
         },
         {
@@ -154,8 +155,8 @@
                 "group_id": 0,
                 "layer_no": 0
             },
-            "npc_id": "Nora",
-            "message_id": 19517
+            "npc_id": "ArisenCorpsRegimentalSoldier7",
+            "message_id": 19509
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014015.json
@@ -1,0 +1,147 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Medal To Set an Example",
+  "quest_id": 21014015,
+  "base_level": 73,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ElanWaterGrove",
+  "news_image": 581,
+  "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 7}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 19665
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4408
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 555
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": "SharpBackSpine",
+          "num": 1
+        },
+        {
+          "item_id": "StiffCrocodileSkin",
+          "num": 3
+        },
+        {
+          "item_id": "SuperiorHealingRemedy",
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 425,
+        "group_id": 4
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Spineback",
+          "enemy_id": "0x015506",
+          "level": 73,
+          "exp": 10925,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Spineback",
+          "enemy_id": "0x015506",
+          "level": 73,
+          "exp": 10925,
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185,
+          "index": 2
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185,
+          "index": 3
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185,
+          "index": 9
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185,
+          "index": 10
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185,
+          "index": 11
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 73,
+          "exp": 2185,
+          "index": 12
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 339
+      },
+      "npc_id": "Dirith1",
+      "message_id": 19406
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 559, "Param2": 19407}
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 339
+      },
+      "announce_type": "Update",
+      "npc_id": "Dirith1",
+      "message_id": 19408
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014017.json
@@ -1,0 +1,259 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Snow-White Gleam in the Deep Woods",
+  "quest_id": 21014017,
+  "base_level": 78,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "ElanWaterGrove",
+  "news_image": 537,
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 29220
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 4493
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 675
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Platinum Blood",
+          "item_id": 15935,
+          "num": 1
+        },
+        {
+          "comment": "Dazzling Silver Plume",
+          "item_id": 15967,
+          "num": 1
+        },
+        {
+          "comment": "Sharp Back Spine",
+          "item_id": 15969,
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 439,
+        "group_id": 6
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 78,
+          "exp": 3685,
+          "index": 3
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 78,
+          "exp": 3685,
+          "index": 5
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 78,
+          "exp": 3685,
+          "index": 6
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 78,
+          "exp": 3685,
+          "index": 7
+        },
+        {
+          "comment": "Stymphalides",
+          "enemy_id": "0x010611",
+          "level": 78,
+          "exp": 3685,
+          "index": 8
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 78,
+          "exp": 3685,
+          "index": 9
+        },
+        {
+          "comment": "Warg",
+          "enemy_id": "0x010203",
+          "level": 78,
+          "exp": 3685,
+          "index": 10
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 439,
+        "group_id": 2
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Foot Biter",
+          "enemy_id": "0x011500",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 439,
+        "group_id": 3
+      },
+      "starting_index": 7,
+      "enemies": [
+        {
+          "comment": "White Griffin",
+          "enemy_id": "0x015320",
+          "level": 78,
+          "exp": 92125,
+          "is_boss": true
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        },
+        {
+          "comment": "Green Guardian",
+          "enemy_id": "0x010210",
+          "level": 78,
+          "exp": 3685
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 339
+      },
+      "npc_id": "Dirith1",
+      "message_id": 20036
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Accept",
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 559, "Param2": 20037}
+      ],
+      "groups": [0]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [1]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [1]
+    },
+    {
+      "type": "SeekOutEnemiesAtMarkedLocation",
+      "announce_type": "Update",
+      "groups": [2]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [2]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 339
+      },
+      "announce_type": "Update",
+      "npc_id": "Dirith1",
+      "message_id": 20038
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014020.json
@@ -1,0 +1,180 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Call From Beneath the Ivy",
+    "quest_id": 21014020,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 583,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 33165
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "TransparentCoarseSand",
+                    "num": 3
+                },
+                {
+                    "item_id": "ProtectedBeastsGreenFur",
+                    "num": 1
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 7
+            },
+            "enemies": []
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 7
+            },
+            "starting_index": 5,
+            "enemies": [
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Dread Ape",
+                    "enemy_id": "0x015502",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Warg",
+                    "enemy_id": "0x010203",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NewNpcTalkAndOrder",
+            "stage_id": {
+                "id": 372,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "ArisenCorpsRegimentalSoldier12",
+            "message_id": 20050,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4699, "comment": "Spawns Regimental Soldier 12 NPC"}
+            ]
+        },
+        {
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 535, "Param2": 20051, "comment": "Extra dialogue - Regimental Soldier 12"}
+            ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 818}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 439,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "ArisenCorpsRegimentalSoldier8",
+            "message_id": 21098,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4697, "comment": "Spawns Regimental Soldier 8 NPC"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [1],
+            "result_commands": [
+                {"type": "CallMessage", "Param1": 531, "Param1": 20072},
+                {"type": "MyQstFlagOn", "Param1": 2331, "comment": "Regimental Soldier 8 FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 439,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "ArisenCorpsRegimentalSoldier8",
+            "message_id": 20052,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 4697, "comment": "Clears Regimental Soldier 8 NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4701, "comment": "Spawns Regimental Soldier 8 (Alive) NPC"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 372,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "ArisenCorpsRegimentalSoldier12",
+            "message_id": 20048
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014021.json
@@ -1,0 +1,142 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Trampled Heart",
+    "quest_id": 21014021,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 531,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 33165
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "ThickShell",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 451,
+                "group_id": 2
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Mole Troll",
+                    "enemy_id": "0x015041",
+                    "level": 75,
+                    "exp": 13675,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Spineback",
+                    "enemy_id": "0x015506",
+                    "level": 75,
+                    "exp": 13675,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2735,
+                    "repop_count": 2,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2735,
+                    "repop_count": 2,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2735,
+                    "repop_count": 2,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Stymphalides",
+                    "enemy_id": "0x010611",
+                    "level": 75,
+                    "exp": 2735,
+                    "repop_count": 2,
+                    "repop_wait_second": 10
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NewNpcTalkAndOrder",
+            "stage_id": {
+                "id": 372,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Eluned",
+            "message_id": 19999,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4744, "comment": "Spawns Eluned NPC"}
+            ]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 916, "Param2": 20001}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 372,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Eluned",
+            "message_id": 20002
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "ElanWaterGrove",
+    "news_image": 283,
     "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
     "rewards": [
         {
@@ -112,7 +113,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 7}
+                        {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 7},
+                        {"type": "StageNo", "Param1": 121}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014024.json
@@ -7,6 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "ElanWaterGrove",
+  "news_image": 531,
   "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
   "rewards": [
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015001.json
@@ -1,0 +1,96 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Commendable Novice",
+    "quest_id": 21015001,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+	"area_id": "FaranaPlains",
+    "news_image": 264,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 10}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4493
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "exp",
+            "amount": 24614
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "TarasqueShell",
+                    "num": 1
+                },
+                {					
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {				
+                    "item_id": "Panacea",
+                    "num": 3					
+                }
+            ]
+        }
+    ],
+	"enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 3
+            },
+            "starting_index": 10,
+            "enemies": [
+                {
+                    "comment": "Tarasque",
+                    "enemy_id": "0x015720",
+                    "level": 75,
+                    "exp": 60875,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],	
+    "blocks": [	
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 371
+            },
+            "npc_id": "Fionn",
+            "message_id": 19410
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2507, "Param2": 19411}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 371
+            },
+            "announce_type": "Update",
+            "npc_id": "Fionn",
+            "message_id": 19412
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "news_image": 261,
     "rewards": [
         {
             "type": "wallet",
@@ -111,7 +112,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeEq", "Param1": 11, "Param2": 15}
+                        {"type": "IngameTimeRangeEq", "Param1": 11, "Param2": 15},
+                        {"type": "StageNoWithoutMarker", "Param1": 120}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "news_image": 264,
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 9}],
     "rewards": [
         {
@@ -112,7 +113,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "WeatherEq", "Param1": 2}
+                        {"type": "WeatherEq", "Param1": 2},
+                        {"type": "StageNoWithoutMarker", "Param1": 120}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015007.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "news_image": 611,
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 4}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015009.json
@@ -1,0 +1,96 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Ordeal of the Weak",
+    "quest_id": 21015009,
+    "base_level": 70,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+	"area_id": "FaranaPlains",
+    "news_image": 902,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4618
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 600
+        },
+        {
+            "type": "exp",
+            "amount": 38375
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {					
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {				
+                    "item_id": "Panacea",
+                    "num": 3					
+                }
+            ]
+        }
+    ],
+	"enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 40
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Bounty Gorechimera",
+                    "enemy_id": "0x015201",
+                    "named_enemy_params_id": 458,
+                    "level": 70,
+                    "exp": 53725,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],	
+    "blocks": [	
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 341
+            },
+            "npc_id": "Flannan",
+            "message_id": 19425
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2504, "Param2": 19426}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 341
+            },
+            "announce_type": "Update",
+            "npc_id": "Flannan",
+            "message_id": 19427
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015010.json
@@ -1,0 +1,237 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "An Old Hand at the Spear",
+    "quest_id": 21015010,
+    "base_level": 73,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 282,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 6}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 13110
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4408
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "ScrollOfGreatSorcery",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 11
+            },
+            "starting_index": 9,
+            "enemies": [
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 31
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 73,
+                    "exp": 2185
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 28
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 73,
+                    "exp": 2185
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 341
+            },
+            "npc_id": "Audran",
+            "message_id": 19630
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2502, "Param2": 19631}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 341
+            },
+            "announce_type": "Update",
+            "npc_id": "Audran",
+            "message_id": 19629
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015011.json
@@ -1,0 +1,237 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Teacher and Pupil's Unspoken Affection",
+    "quest_id": 21015011,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 262,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 10}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 14610
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4493
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "ScrollOfMagickalDefense",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 42
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Pixie Din",
+                    "enemy_id": "0x010152",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Din",
+                    "enemy_id": "0x010152",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Din",
+                    "enemy_id": "0x010152",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2435
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 48
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Biff",
+                    "enemy_id": "0x010151",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 75,
+                    "exp": 2435
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 53
+            },
+            "starting_index": 5,
+            "enemies": [
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 75,
+                    "exp": 2435
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 75,
+                    "exp": 2435
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 371
+            },
+            "npc_id": "Marhon",
+            "message_id": 19632
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2506, "Param2": 19633}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 371
+            },
+            "announce_type": "Update",
+            "npc_id": "Marhon",
+            "message_id": 19634
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015014.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015014.json
@@ -1,0 +1,172 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Missing Cohort",
+    "quest_id": 21015014,
+    "base_level": 73,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 623,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 7}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4408
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 13110
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "TwistedIronScrap",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 420,
+                "group_id": 4
+            },
+            "enemies": []
+        },
+        {
+            "stage_id": {
+                "id": 420,
+                "group_id": 4
+            },
+            "placement_type": "manual",
+            "enemies": [
+                {
+                    "comment": "Dark Skeleton Brute",
+                    "enemy_id": "0x010324",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 0
+                },
+                {
+                    "comment": "Dark Skeleton Brute",
+                    "enemy_id": "0x010324",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 1
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 7
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 8
+                },
+                {
+                    "comment": "Eliminator",
+                    "enemy_id": "0x010508",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 9
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 10
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 371
+            },
+            "npc_id": "Wine",
+            "message_id": 19569
+        },
+        {
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2508, "Param2": 19570, "comment": "Extra dialogue - Wine"}
+            ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 827}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 420,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Corentin",
+            "message_id": 21100,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4338, "comment": "Spawns Corentin NPC"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [1],
+            "result_commands": [
+                {"type": "CallMessage", "Param1": 560, "Param1": 19574},
+                {"type": "MyQstFlagOn", "Param1": 2114, "comment": "Corentin FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 420,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "Corentin",
+            "message_id": 19572,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 4338, "comment": "Clears Corentin NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4343, "comment": "Spawns Corentin (Alive) NPC"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 371
+            },
+            "npc_id": "Wine",
+            "message_id": 19567
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015015.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015015.json
@@ -1,0 +1,130 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Champion from that Day",
+    "quest_id": 21015015,
+    "base_level": 73,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 7}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4408
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 19665
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "CompositeOrgan",
+                    "num": 1
+                },
+                {
+                    "item_id": "TwistedIronScrap",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 420,
+                "group_id": 7
+            },
+            "enemies": [
+                {
+                    "comment": "Gorechimera",
+                    "enemy_id": "0x015201",
+                    "level": 73,
+                    "exp": 10925,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 341
+            },
+            "npc_id": "Evey",
+            "message_id": 19429
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2503, "Param2": 19430}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 341
+            },
+            "announce_type": "Update",
+            "npc_id": "Evey",
+            "message_id": 19431
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015017.json
@@ -1,0 +1,260 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Disturbance Stirring Curiosity",
+    "quest_id": 21015017,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 263,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 22110
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "AncientSagoPalm",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 27
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "High Pixie Biff",
+                    "enemy_id": "0x010190",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Biff",
+                    "enemy_id": "0x010190",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Biff",
+                    "enemy_id": "0x010190",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Biff",
+                    "enemy_id": "0x010190",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 52
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Zolda",
+                    "enemy_id": "0x010191",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Zolda",
+                    "enemy_id": "0x010191",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Zolda",
+                    "enemy_id": "0x010191",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "High Pixie Zolda",
+                    "enemy_id": "0x010191",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 1
+            },
+            "enemies": [
+                {
+                    "comment": "Death Knight",
+                    "enemy_id": "0x010310",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Death Knight",
+                    "enemy_id": "0x010310",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Dark Corpse Punisher",
+                    "enemy_id": "0x010520",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Dark Corpse Punisher",
+                    "enemy_id": "0x010520",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Dark Corpse Punisher",
+                    "enemy_id": "0x010520",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 411
+            },
+            "npc_id": "Darin",
+            "message_id": 20039
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2555, "Param2": 20040}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 411
+            },
+            "announce_type": "Update",
+            "npc_id": "Darin",
+            "message_id": 20041
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015020.json
@@ -1,0 +1,167 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Flawless Grave-Robbing",
+    "quest_id": 21015020,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 623,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 33165
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "TwistedIronScrap",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 6
+            },
+            "enemies": []
+        },
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 6
+            },
+            "starting_index": 8,
+            "enemies": [
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Living Armor",
+                    "enemy_id": "0x010306",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Living Armor",
+                    "enemy_id": "0x010306",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 411
+            },
+            "npc_id": "Henin",
+            "message_id": 20056
+        },
+        {
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2556, "Param2": 20057, "comment": "Extra dialogue - Henin"}
+            ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 861}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 367,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Ludovika",
+            "message_id": 21108,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4702, "comment": "Spawns Ludovika NPC"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [1],
+            "result_commands": [
+                {"type": "CallMessage", "Param1": 4735, "Param1": 20075},
+                {"type": "MyQstFlagOn", "Param1": 2334, "comment": "Ludovika FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 367,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "Ludovika",
+            "message_id": 20058,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 4702, "comment": "Clears Ludovika NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4706, "comment": "Spawns Ludovika (Alive) NPC"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 411
+            },
+            "npc_id": "Henin",
+            "message_id": 20054
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015021.json
@@ -1,0 +1,143 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "King of the Fairies",
+    "quest_id": 21015021,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 262,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5106
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "exp",
+            "amount": 36315
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "PixieCrown",
+                    "num": 1
+                },
+                {
+                    "item_id": "FineFemur",
+                    "num": 2
+                },
+                {
+                    "item_id": "UnappraisedWindTrinketGeneral",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 397,
+                "group_id": 0
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Pixie King",
+                    "enemy_id": "0x010195",
+                    "level": 80,
+                    "exp": 100875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "High Pixie Pow",
+                    "enemy_id": "0x010192",
+                    "level": 80,
+                    "exp": 630,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "High Pixie Pow",
+                    "enemy_id": "0x010192",
+                    "level": 80,
+                    "exp": 630,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "High Pixie Pow",
+                    "enemy_id": "0x010192",
+                    "level": 80,
+                    "exp": 630,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "High Pixie Pow",
+                    "enemy_id": "0x010192",
+                    "level": 80,
+                    "exp": 630,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "High Pixie Pow",
+                    "enemy_id": "0x010192",
+                    "level": 80,
+                    "exp": 630,
+                    "repop_count": 1,
+                    "repop_wait_second": 10
+                },
+                {
+                    "comment": "Gorechimera",
+                    "enemy_id": "0x015201",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 371
+            },
+            "npc_id": "Dewey",
+            "message_id": 20004
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2510, "Param2": 20005}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 371
+            },
+            "announce_type": "Update",
+            "npc_id": "Dewey",
+            "message_id": 20006
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "news_image": 261,
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 11}],
     "rewards": [
         {
@@ -112,7 +113,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 23}
+                        {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 23},
+                        {"type": "StageNoWithoutMarker", "Param1": 120}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015024.json
@@ -1,0 +1,138 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Door of Treasures: Claws that Cleave the Glacier",
+    "quest_id": 21015024,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 526,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 11}],
+    "quest_layout_set_info_flags": [
+        {
+            "flag_no": 4738,
+            "stage_no": 831,
+            "group_id": 8
+        }
+    ],
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 26961
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "exp",
+            "amount": 13675
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "AzureDragonscale",
+                    "num": 1
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 440,
+                "group_id": 8
+            },
+            "placement_type": "manual",
+            "enemies": [
+                {
+                    "comment": "Treasure-Bearing Wyrm",
+                    "enemy_id": "0x015701",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 11660,
+                    "is_boss": true,
+                    "index": 0
+                },
+                {
+                    "comment": "Treasure-Bearing Frost Corpse Punisher",
+                    "enemy_id": "0x010511",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 340,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 1
+                },
+                {
+                    "comment": "Treasure-Bearing Frost Corpse Punisher",
+                    "enemy_id": "0x010511",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 340,
+                    "repop_count": 1,
+                    "repop_wait_second": 10,
+                    "index": 2
+                },
+                {
+                    "comment": "Treasure-Bearing Frost Corpse Punisher",
+                    "enemy_id": "0x010511",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 340,
+                    "index": 3
+                },
+                {
+                    "comment": "Treasure-Bearing Frost Corpse Punisher",
+                    "enemy_id": "0x010511",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 340,
+                    "index": 4
+                },
+                {
+                    "comment": "Treasure-Bearing Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 3770,
+                    "is_boss": true,
+                    "index": 6
+                },
+                {
+                    "comment": "Treasure-Bearing Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 1579,
+                    "level": 75,
+                    "exp": 3770,
+                    "is_boss": true,
+                    "index": 7
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "DiscoverEnemy",
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Accept",
+            "reset_group": false,
+            "groups": [0]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016005.json
@@ -108,7 +108,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "IngameTimeRangeEq", "Param1": 16, "Param2": 20}
+                        {"type": "IngameTimeRangeEq", "Param1": 16, "Param2": 20},
+                        {"type": "StageNoWithoutMarker", "Param1": 123}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016006.json
@@ -113,7 +113,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "WeatherEq", "Param1": 1}
+                        {"type": "WeatherEq", "Param1": 1},
+                        {"type": "StageNoWithoutMarker", "Param1": 123}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016023.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MorrowForest",
+    "news_image": 322,
     "order_conditions": [{"type": "AreaRank", "Param1": 16, "Param2": 11}],
     "rewards": [
         {
@@ -112,7 +113,8 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "WeatherEq", "Param1": 3}
+                        {"type": "WeatherEq", "Param1": 3},
+                        {"type": "StageNoWithoutMarker", "Param1": 123}
                     ]
                 },
                 {


### PR DESCRIPTION
Updates all but one of the existing Bloodbane Isle world quests, adds two quests (Knight's Pride on the Line and As a Knight) and updates news images from a few other quests.