### PR TITLE
WQ Updates (Farana + Mergoda + Night spawns)

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011.json
@@ -65,6 +65,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20005011_1.json
@@ -66,6 +66,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]  
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002.json
@@ -92,6 +92,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]  
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_1.json
@@ -93,6 +93,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]  
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20015002_2.json
@@ -98,6 +98,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]  
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009.json
@@ -67,9 +67,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "18 * 3600000 + 0 * 60000",
-      "spawn_time_end": "6 * 3600000 + 59 * 60000",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20025009_1.json
@@ -68,9 +68,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "18 * 3600000 + 0 * 60000",
-      "spawn_time_end": "6 * 3600000 + 59 * 60000",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002.json
@@ -65,6 +65,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 518}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_1.json
@@ -66,6 +66,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 518}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20045002_2.json
@@ -66,6 +66,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 518}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000.json
@@ -9,76 +9,83 @@
   "area_id": "MysreeForest",
   "news_image": 105,
   "rewards": [
-      {
-          "type": "wallet",
-          "wallet_type": "Gold",
-          "amount": 440
-      },
-      {
-          "type": "wallet",
-          "wallet_type": "RiftPoints",
-          "amount": 80
-      },
-      {
-          "type": "exp",
-          "amount": 420
-      },
-      {
-          "type": "select",
-          "loot_pool": [
-              {
-                  "comment": "Iron Legs",
-                  "item_id": 8403,
-                  "num": 1
-              },
-              {
-                  "comment": "Superior Healing Potion",
-                  "item_id": 35,
-                  "num": 2
-              }
-          ]
-      }
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 440
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 80
+    },
+    {
+      "type": "exp",
+      "amount": 420
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Iron Legs",
+          "item_id": 8403,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Potion",
+          "item_id": 35,
+          "num": 2
+        }
+      ]
+    }
   ],
   "enemy_groups": [
-      {
-          "stage_id": {
-              "id": 1,
-              "group_id": 47
-          },
-          "starting_index": 4,
-          "enemies": [
-              {
-                  "comment": "Vigilant Giant Saurian",
-                  "enemy_id": "0x010401",
-                  "named_enemy_params_id": 53,
-                  "level": 16,
-                  "exp": 107,
-                  "repop_count": 2,
-                  "repop_wait_second": 10
-              },
-              {
-                  "comment": "Vigilant Giant Saurian",
-                  "enemy_id": "0x010401",
-                  "named_enemy_params_id": 53,
-                  "level": 16,
-                  "exp": 107,
-                  "repop_count": 2,
-                  "repop_wait_second": 10
-              }
-          ]
-      }
+    {
+      "stage_id": {
+        "id": 1,
+        "group_id": 47
+      },
+      "starting_index": 4,
+      "enemies": [
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 107,
+          "repop_count": 2,
+          "repop_wait_second": 10
+        },
+        {
+          "comment": "Vigilant Giant Saurian",
+          "enemy_id": "0x010401",
+          "named_enemy_params_id": 53,
+          "level": 16,
+          "exp": 107,
+          "repop_count": 2,
+          "repop_wait_second": 10
+        }
+      ]
+    }
   ],
   "blocks": [
-      {
-          "type": "DiscoverEnemy",
-          "show_marker": false,
-          "groups": [ 0 ]
-      },
-      {
-          "type": "KillGroup",
-          "announce_type": "Accept",
-          "reset_group": false,
-          "groups": [ 0 ]
-      }
+    {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
+      "type": "DiscoverEnemy",
+      "show_marker": false,
+      "groups": [ 0 ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Accept",
+      "reset_group": false,
+      "groups": [ 0 ]
+    }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_1.json
@@ -71,6 +71,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20055000_2.json
@@ -71,6 +71,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000.json
@@ -124,9 +124,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "(18 * 3600000) + (0 * 60000)",
-      "spawn_time_end": "(6 * 3600000) + (59 * 60000)",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20065000_1.json
@@ -125,9 +125,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "(18 * 3600000) + (0 * 60000)",
-      "spawn_time_end": "(6 * 3600000) + (59 * 60000)",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006.json
@@ -114,9 +114,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "(18 * 3600000) + (0 * 60000)",
-      "spawn_time_end": "(6 * 3600000) + (59 * 60000)",
       "groups": [ 0 ]
     },
     { "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_1.json
@@ -93,9 +93,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "18 * 3600000 + 0 * 60000",
-      "spawn_time_end": "6 * 3600000 + 59 * 60000",
       "groups": [ 0 ]
     },
     { "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20075006_2.json
@@ -135,9 +135,14 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 100}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
-      "spawn_time_start": "(18 * 3600000) + (0 * 60000)",
-      "spawn_time_end": "(6 * 3600000) + (59 * 60000)",
       "groups": [ 0 ]
     },
     { "type": "KillGroup",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006.json
@@ -112,6 +112,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 701}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20105006_1.json
@@ -96,6 +96,13 @@
   ],
   "blocks": [
     {
+      "type": "Raw",
+      "check_commands": [
+        {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+        {"type": "StageNo", "Param1": 701}
+      ]
+    },
+    {
       "type": "DiscoverEnemy",
       "groups": [ 0 ]
     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 229,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 229,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 230,
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990003_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 230,
     "variant_index": 1,
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 234,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990004_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 234,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995000.json
@@ -7,7 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
-    "news_image": 235,
+    "news_image": 53,
     "quest_layout_set_info_flags": [
         {
           "flag_no": 346,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 224,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995002_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 901,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 22}],
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 225,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}, {"type": "AreaRank", "Param1": 12, "Param2": 4}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995004_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 225,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}, {"type": "AreaRank", "Param1": 12, "Param2": 4}],
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 231,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995005_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 900,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995010.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 234,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 23}],
     "rewards": [
         {
@@ -114,6 +115,13 @@
         }
     ],
     "blocks": [
+        {
+            "type": "Raw",
+            "check_commands": [
+                {"type": "IngameTimeRangeNotEq", "Param1": 6, "Param2": 18},
+                {"type": "StageNo", "Param1": 418}
+            ]
+        },
         {
             "type": "DiscoverEnemy",
             "groups": [0]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 233,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "rewards": [
         {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_1.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 900,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "variant_index": 1,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20995011_2.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
+    "news_image": 900,
     "order_conditions": [{"type": "MainQuestCompleted", "Param1": 24}, {"type": "AreaRank", "Param1": 12, "Param2": 5}],
     "variant_ìndex": 2,
     "rewards": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000079.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000079.json
@@ -7,8 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MergodaRuins",
-  "news_image": 562,
-  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
+  "news_image": 622,
+  "order_conditions": [{"type": "AreaRank", "Param1": 12, "Param2": 13}],
   "rewards": [
     {
       "type": "wallet",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000080.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000080.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MergodaRuins",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 11 } ],
+  "news_image": 15,
+  "order_conditions": [{"type": "AreaRank", "Param1": 12, "Param2": 11}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000088.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000088.json
@@ -7,7 +7,8 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "MergodaRuins",
-    "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 11 } ],
+    "news_image": 229,
+    "order_conditions": [{"type": "AreaRank", "Param1": 12, "Param2": 11}],
     "rewards": [
         {
             "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000091.json
@@ -7,7 +7,8 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MergodaRuins",
-  "order_conditions": [ { "type": "AreaRank", "Param1": 12, "Param2": 13 } ],
+  "news_image": 622,
+  "order_conditions": [{"type": "AreaRank", "Param1": 12, "Param2": 13}],
   "rewards": [
     {
       "type": "exp",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015000.json
@@ -6,7 +6,8 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",
+    "area_id": "FaranaPlains",
+    "news_image": 593,
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 7}],
     "rewards": [
         {
@@ -27,62 +28,66 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Twisted Iron Scrap",
                     "item_id": 15919,
                     "num": 3
                 },
-                {					
+                {
+                    "comment": "Superior Healing Remedy",
                     "item_id": 7555,
                     "num": 3
                 },
-                {				
+                {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         }
     ],
-  "enemy_groups" : [
+    "enemy_groups": [
         {
             "stage_id": {
                 "id": 371,
                 "group_id": 49
             },
+            "starting_index": 4,
             "enemies": [
                 {
-                    "enemy_id": "0x010205",
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010205",
+                    "exp": 2185
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010205",
+                    "exp": 2185
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
                     "enemy_id": "0x010610",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
                     "enemy_id": "0x010610",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 2185
+                },
+                {
+                    "comment": "Strix",
                     "enemy_id": "0x010610",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false					
+                    "exp": 2185
                 }
             ]
         },
@@ -91,42 +96,43 @@
                 "id": 371,
                 "group_id": 27
             },
+            "starting_index": 4,
             "enemies": [
                 {
-                    "enemy_id": "0x010205",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010205",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 2185
+                },
+                {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 2185
+                },
+                {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 2185
+                },
+                {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false					
+                    "exp": 2185
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 73,
+                    "exp": 2185
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 73,
+                    "exp": 2185
                 }
             ]
         },
@@ -135,72 +141,82 @@
                 "id": 420,
                 "group_id": 6
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 2
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 3
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 4
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 12
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 13
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 14
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 73,
+                    "exp": 2185,
+                    "index": 15
+                },
+                {
+                    "comment": "Large Newt",
                     "enemy_id": "0x010461",
                     "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010610",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010610",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010610",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010460",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010460",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010460",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010460",
-                    "level": 73,
-                    "exp": 4000,
-                    "is_boss": false					
+                    "exp": 2185,
+                    "index": 16
                 }
             ]
         }
-    ],		
-    "blocks": [	
+    ],
+    "blocks": [
         {
-            "type": "NpcTalkAndOrder",	
+            "type": "NpcTalkAndOrder",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },				
+                "id": 341
+            },
             "npc_id": "Evey",
-            "message_id": 10800
-    },
-    {
+            "message_id": 19623
+        },
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2503, "Param2": 19624}
+            ],
             "groups": [0]
         },
         {
@@ -209,10 +225,10 @@
             "reset_group": false,
             "groups": [0]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
-            "groups": [1]			
+            "groups": [1]
         },
         {
             "type": "KillGroup",
@@ -220,27 +236,25 @@
             "reset_group": false,
             "groups": [1]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
             "groups": [2]
         },
-        {				
+        {
             "type": "KillGroup",
             "announce_type": "Update",
             "reset_group": false,
-            "groups": [2]			
+            "groups": [2]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 341
             },
             "announce_type": "Update",
             "npc_id": "Evey",
-            "message_id": 11842			
+            "message_id": 19625
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015002.json
@@ -1,0 +1,404 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "High Difficulty: The Specter's Invasion",
+    "quest_id": 21015002,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 900,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 10}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 48420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5138
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 940
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "UnappraisedStarTrinketKing",
+                    "num": 2
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups": [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 55
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Chimera",
+                    "enemy_id": "0x015200",
+                    "level": 80,
+                    "exp": 21000,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4200
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 420,
+                "group_id": 1
+            },
+            "placement_type": "manual",
+            "enemies": [
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 80,
+                    "exp": 21000,
+                    "is_boss": true,
+                    "index": 0
+                },
+                {
+                    "comment": "Undead Warrior",
+                    "enemy_id": "0x010504",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 1
+                },
+                {
+                    "comment": "Undead Warrior",
+                    "enemy_id": "0x010504",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 2
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "start_think_tbl_no": 8,
+                    "level": 80,
+                    "exp": 4200,
+                    "is_required": false,
+                    "is_manual_set": true,
+                    "index": 3
+                },
+                {
+                    "comment": "Undead Warrior",
+                    "enemy_id": "0x010504",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 8
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "start_think_tbl_no": 8,
+                    "level": 80,
+                    "exp": 4200,
+                    "is_required": false,
+                    "is_manual_set": true,
+                    "index": 9
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "start_think_tbl_no": 8,
+                    "level": 80,
+                    "exp": 4200,
+                    "is_required": false,
+                    "is_manual_set": true,
+                    "index": 10
+                },
+                {
+                    "comment": "Frost Corpse Torturer",
+                    "enemy_id": "0x010512",
+                    "start_think_tbl_no": 8,
+                    "level": 80,
+                    "exp": 4200,
+                    "is_required": false,
+                    "is_manual_set": true,
+                    "index": 11
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 420,
+                "group_id": 3
+            },
+            "enemies": [
+                {
+                    "comment": "Empress Ghost",
+                    "enemy_id": "0x015605",
+                    "level": 80,
+                    "exp": 21000,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "start_think_tbl_no": 2,
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "start_think_tbl_no": 2,
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "start_think_tbl_no": 2,
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "start_think_tbl_no": 2,
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "start_think_tbl_no": 2,
+                    "level": 80,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "start_think_tbl_no": 2,
+                    "level": 80,
+                    "exp": 4200
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 420,
+                "group_id": 5
+            },
+            "placement_type": "manual",
+            "enemies": [
+                {
+                    "comment": "Mist Wyrm",
+                    "enemy_id": "0x015711",
+                    "level": 80,
+                    "exp": 105000,
+                    "is_boss": true,
+                    "index": 0
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 1
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 2
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 3
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 4
+                },
+                {
+                    "comment": "Wyrm",
+                    "enemy_id": "0x015701",
+                    "level": 80,
+                    "exp": 21000,
+                    "is_boss": true,
+                    "index": 5
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 7
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4200,
+                    "index": 8
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 341
+                    },
+                    "npc_id": "Razanailt",
+                    "message_id": 19414
+                },
+                {
+                    "type": "SeekOutEnemiesAtMarkedLocation",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2501, "Param2": 19415, "comment": "Extra dialogue - Razanailt"}
+                    ],
+                    "groups": [0]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "reset_group": false,
+                    "groups": [0]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "set_flags": [1],
+                    "check_flags": [2, 3, 4]
+                },
+                {
+                    "type": "TalkToNpc",
+                    "stage_id": {
+                        "id": 341
+                    },
+                    "announce_type": "Update",
+                    "npc_id": "Razanailt",
+                    "message_id": 19416
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [1]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "groups": [1]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+                    "reset_group": false,
+                    "groups": [1]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "set_flags": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [1]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "groups": [2]
+                },
+                {
+                    "type": "KillGroup",
+                    "reset_group": false,
+                    "groups": [2]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "announce_type": "Update",
+                    "set_flags": [3]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [1]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "groups": [3]
+                },
+                {
+                    "type": "KillGroup",
+                    "reset_group": false,
+                    "groups": [3]
+                },
+                {
+                    "type": "MyQstFlags",
+                    "set_flags": [4]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015003.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015003.json
@@ -6,7 +6,7 @@
     "base_level": 73,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",
+    "area_id": "FaranaPlains",
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 7}],
     "rewards": [
         {
@@ -27,57 +27,47 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Icon Fragment",
                     "item_id": 15923,
                     "num": 6
                 },
-                {					
+                {
+                    "comment": "Superior Healing Remedy",
                     "item_id": 7555,
                     "num": 3
                 },
-                {				
+                {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         }
     ],
     "blocks": [
         {
-            "type": "NpcTalkAndOrder",	
+            "type": "NpcTalkAndOrder",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },				
+                "id": 341
+            },
             "npc_id": "Lewela",
-            "message_id": 10800
+            "message_id": 19417
         },
         {
             "type": "DeliverItems",
             "stage_id": {
-                "id": 374,
-                "group_id": 1
+                "id": 374
             },
             "npc_id": "Reich",
             "announce_type": "Accept",
-            "items": [
-                {
-                    "id": 15919,
-                    "amount": 6
-                }
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2505, "Param2": 19418, "comment": "Extra dialogue - Llywela"},
+                {"type": "QstTalkChg", "Param1": 2607, "Param2": 19419, "comment": "Extra dialogue - Raith"}
             ],
-            "message_id": 10737
-        },
-        {
-            "type": "TalkToNpc",
-            "stage_id": {
-                "id": 374,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "announce_type": "Update",
-            "npc_id": "Reich",
-            "message_id": 11842			
+            "items": [
+                {"id": 15919, "amount": 6, "comment": "Twisted Iron Scrap"}
+            ],
+            "message_id": 19420
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015008.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015008.json
@@ -6,7 +6,7 @@
     "base_level": 70,
     "minimum_item_rank": 0,
     "discoverable": true,
-	"area_id": "FaranaPlains",	
+    "area_id": "FaranaPlains",
     "rewards": [
         {
             "type": "wallet",
@@ -26,62 +26,66 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Courtly Cloth",
                     "item_id": 7939,
                     "num": 3
                 },
-                {					
+                {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
                     "num": 3
                 },
-                {				
+                {
+                    "comment": "Panacea",
                     "item_id": 41,
-                    "num": 3					
+                    "num": 3
                 }
             ]
         }
     ],
-  "enemy_groups" : [
+    "enemy_groups": [
         {
             "stage_id": {
                 "id": 413,
                 "group_id": 2
             },
+            "starting_index": 3,
             "enemies": [
                 {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535
+                },
+                {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535
+                },
+                {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Pow",
                     "enemy_id": "0x010153",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Pow",
                     "enemy_id": "0x010153",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Pow",
                     "enemy_id": "0x010153",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false					
+                    "exp": 1535
                 }
             ]
         },
@@ -90,36 +94,42 @@
                 "id": 413,
                 "group_id": 6
             },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535,
+                    "index": 0
+                },
+                {
+                    "comment": "Blue Newt",
                     "enemy_id": "0x010460",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010460",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010460",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535,
+                    "index": 4
+                },
+                {
+                    "comment": "Large Newt",
                     "enemy_id": "0x010461",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false		
+                    "exp": 1535,
+                    "index": 5
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 6
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 70,
+                    "exp": 1535,
+                    "index": 7
                 }
             ]
         },
@@ -128,66 +138,68 @@
                 "id": 413,
                 "group_id": 10
             },
+            "starting_index": 5,
             "enemies": [
                 {
-                    "enemy_id": "0x010461",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010461",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010153",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010153",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
-                    "enemy_id": "0x010153",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "comment": "Pixie Jabber",
                     "enemy_id": "0x010155",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-    },
-    {
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Jabber",
                     "enemy_id": "0x010155",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false					
+                    "exp": 1535
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Large Newt",
+                    "enemy_id": "0x010461",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Pixie Pow",
+                    "enemy_id": "0x010153",
+                    "level": 70,
+                    "exp": 1535
                 }
             ]
         }
-    ],		
-    "blocks": [	
+    ],
+    "blocks": [
         {
-            "type": "NpcTalkAndOrder",	
+            "type": "NpcTalkAndOrder",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },				
+                "id": 341
+            },
             "npc_id": "Flannan",
-            "message_id": 10800
-    },
-    {
+            "message_id": 19626
+        },
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2504, "Param2": 19627}
+            ],
             "groups": [0]
         },
         {
@@ -196,10 +208,10 @@
             "reset_group": false,
             "groups": [0]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
-            "groups": [1]			
+            "groups": [1]
         },
         {
             "type": "KillGroup",
@@ -207,27 +219,25 @@
             "reset_group": false,
             "groups": [1]
         },
-        {			
+        {
             "type": "SeekOutEnemiesAtMarkedLocation",
             "announce_type": "Update",
             "groups": [2]
         },
-        {				
+        {
             "type": "KillGroup",
             "announce_type": "Update",
             "reset_group": false,
-            "groups": [2]			
+            "groups": [2]
         },
-        {		
+        {
             "type": "TalkToNpc",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 341
             },
             "announce_type": "Update",
             "npc_id": "Flannan",
-            "message_id": 11842			
+            "message_id": 19628
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015012.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015012.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "news_image": 538,
     "rewards": [
         {
             "type": "wallet",
@@ -26,14 +27,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Red Chromium",
                     "item_id": 7879,
                     "num": 3
                 },
                 {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
                     "num": 3
                 },
                 {
+                    "comment": "Panacea",
                     "item_id": 41,
                     "num": 3
                 }
@@ -46,42 +50,56 @@
                 "id": 413,
                 "group_id": 3
             },
+            "enemies": []
+        },
+        {
+            "stage_id": {
+                "id": 413,
+                "group_id": 3
+            },
+            "placement_type": "manual",
             "enemies": [
                 {
+                    "comment": "Bolt Grimwarg",
                     "enemy_id": "0x010211",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535,
+                    "index": 3
                 },
                 {
+                    "comment": "Bolt Grimwarg",
                     "enemy_id": "0x010211",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535,
+                    "index": 5
                 },
                 {
+                    "comment": "Bolt Grimwarg",
                     "enemy_id": "0x010211",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535,
+                    "index": 6
                 },
                 {
+                    "comment": "Undead Warrior",
                     "enemy_id": "0x010504",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535,
+                    "index": 7
                 },
                 {
+                    "comment": "Undead Warrior",
                     "enemy_id": "0x010504",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535,
+                    "index": 8
                 },
                 {
+                    "comment": "Undead Warrior",
                     "enemy_id": "0x010504",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535,
+                    "index": 9
                 }
             ]
         }
@@ -90,54 +108,67 @@
         {
             "type": "NpcTalkAndOrder",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 341
             },
             "npc_id": "Lewela",
-            "message_id": 10800
+            "message_id": 19525
         },
         {
-            "type": "TalkToNpc",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 4489, "comment": "Spawns Fergal NPC"}
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2505, "Param2": 19526, "comment": "Extra dialogue - Llywela"}
             ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 812}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
             "stage_id": {
                 "id": 413,
-                "group_id": 1,
-                "layer_no": 1
+                "group_id": 0,
+                "layer_no": 0
             },
-            "announce_type": "Accept",
             "npc_id": "Fergal",
-            "message_id": 11842
-        },
-        {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Update",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 2106, "comment": "Start NPC state machine"}
-            ],
-            "groups": [0]
+            "message_id": 21094,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4489, "comment": "Spawns Fergal NPC"}
+            ]
         },
         {
             "type": "KillGroup",
             "announce_type": "Update",
-            "reset_group": false,
-            "groups": [0]
+            "groups": [1],
+            "result_commands": [
+                {"type": "CallMessage", "Param1": 4756, "Param1": 19530},
+                {"type": "MyQstFlagOn", "Param1": 2106, "comment": "Fergal FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 413,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "Fergal",
+            "message_id": 19559,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 4489, "comment": "Clears Fergal NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4494, "comment": "Spawns Fergal (Alive) NPC"}
+            ]
         },
         {
             "type": "TalkToNpc",
-            "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },
-            "flags": [
-                {"type": "MyQst", "action": "Clear", "value": 2106, "comment": "Start NPC state machine"}
-            ],
             "announce_type": "Update",
+            "stage_id": {
+                "id": 341
+            },
             "npc_id": "Lewela",
-            "message_id": 11842
+            "message_id": 19527
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015013.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015013.json
@@ -7,6 +7,7 @@
     "minimum_item_rank": 0,
     "discoverable": true,
     "area_id": "FaranaPlains",
+    "news_image": 611,
     "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 4}],
     "rewards": [
         {
@@ -27,14 +28,17 @@
             "type": "select",
             "loot_pool": [
                 {
+                    "comment": "Carved Potsherd",
                     "item_id": 15913,
                     "num": 3
                 },
                 {
+                    "comment": "Superior Healing Remedy",
                     "item_id": 7555,
                     "num": 3
                 },
                 {
+                    "comment": "Superior Strong Gala Extract",
                     "item_id": 9364,
                     "num": 3
                 }
@@ -47,30 +51,39 @@
                 "id": 366,
                 "group_id": 2
             },
+            "enemies": []
+        },
+        {
+            "stage_id": {
+                "id": 366,
+                "group_id": 2
+            },
+            "starting_index": 5,
             "enemies": [
                 {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 70,
+                    "exp": 1535
+                },
+                {
+                    "comment": "Wight",
                     "enemy_id": "0x015600",
                     "level": 70,
-                    "exp": 85000,
+                    "exp": 7675,
                     "is_boss": true
                 },
                 {
+                    "comment": "Strix",
                     "enemy_id": "0x010610",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535
                 },
                 {
+                    "comment": "Strix",
                     "enemy_id": "0x010610",
                     "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
-                },
-                {
-                    "enemy_id": "0x010610",
-                    "level": 70,
-                    "exp": 3000,
-                    "is_boss": false
+                    "exp": 1535
                 }
             ]
         }
@@ -79,51 +92,67 @@
         {
             "type": "NpcTalkAndOrder",
             "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
+                "id": 341
             },
             "npc_id": "Etna",
-            "message_id": 10800
+            "message_id": 19551
+        },
+        {
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 2511, "Param2": 19552, "comment": "Extra dialogue - Eithne"}
+            ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 860}
+            ]
         },
         {
             "type": "NewTalkToNpc",
-            "flags": [
-                {"type": "QstLayout", "action": "Set", "value": 4332, "comment": "Spawns Alan0 NPC"}
-            ],
             "stage_id": {
                 "id": 366,
                 "group_id": 0,
                 "layer_no": 0
             },
-            "announce_type": "Accept",
             "npc_id": "Alan0",
-            "message_id": 11842
-        },
-        {
-            "type": "SeekOutEnemiesAtMarkedLocation",
-            "announce_type": "Update",
-            "flags": [
-                {"type": "MyQst", "action": "Set", "value": 2110, "comment": "Start NPC state machine"}
-            ],
-            "groups": [0]
+            "message_id": 21099,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 4332, "comment": "Spawns Alan NPC"}
+            ]
         },
         {
             "type": "KillGroup",
             "announce_type": "Update",
-            "reset_group": false,
-            "groups": [0]
+            "groups": [1],
+            "result_commands": [
+                {"type": "CallMessage", "Param1": 1027, "Param1": 19554},
+                {"type": "MyQstFlagOn", "Param1": 2110, "comment": "Alan FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 366,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "Alan0",
+            "message_id": 19557,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 4332, "comment": "Clears Alan NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 4337, "comment": "Spawns Alan (Alive) NPC"}
+            ]
         },
         {
             "type": "TalkToNpc",
-            "stage_id": {
-                "id": 341,
-                "group_id": 1,
-                "layer_no": 1
-            },
             "announce_type": "Update",
+            "stage_id": {
+                "id": 341
+            },
             "npc_id": "Etna",
-            "message_id": 11842
+            "message_id": 19549
         }
     ]
 }


### PR DESCRIPTION
Updates five Farana Plains world quests:

- The Store Girl's Trials (q21015000)
- To The Faraway Child (q21015003)
- Pride of The Weak (q21015008)
- A Foreign Investigation (q21015012)
- The Troubled Fortification (q21015013)

Also updates the following quests to only spawn at night:

- A Man-Eating Ogre Appears! (q20005011)
- Phantoms in the Moonlight (q20015002)
- A Whirling Hawk on a Dark Night (q20025009)
- Shadows Within the Cave (q20045002)
- Scaled Soldiers (q20055000)
- A Faint Ill Omen (q20065000)
- The Evil in the Dark Night (q20075006)
- The Old Witch of the Woods (q20105006)
- The Misguided Soldiers (q20995010)

Adds the following quest:

- High Difficulty: The Specter's Invasion (q21015002)

Additionally, several Mergoda world quests now have news banner images.