### PR TITLE
More Feryana personal quests / Caution spot adjustments

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar03_demon_army_relay_station.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar03_demon_army_relay_station.csx
@@ -12,30 +12,27 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGorecyclopsLightArmor0, 88, 0, isBoss: true),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 4),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 5),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 6),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 7),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 8),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 88, 105000, 1)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 3),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 8),
         };
 
         // Available Items (4): BattleArmorFragment, UnrefinedAlloyLump, SkeletonSmasherStoneShard, SkeletonSmasherStone
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
             .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.VERY_RARE);
+        enemies[0].SetDropsTable(dropsTable);
+
+        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
+            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.RARE);
         enemies[1].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
@@ -58,34 +55,6 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.VERY_RARE);
         enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.VERY_RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.VERY_RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.VERY_RARE);
-        enemies[7].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[8]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.SkeletonSmasherStone, 1, 1, DropRate.VERY_RARE);
-        enemies[8].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_gate_camp.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_gate_camp.csx
@@ -1,10 +1,10 @@
-// Gate Camp — stageid463 GroupId9 MaxPos4 (positions 0-4)
+// Gate Camp — stageid463 GroupId80 MaxPos4 (positions 0-4)
 // Monster Caution Spot — Feryana Wilderness, Lv88, AR0
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(9);
+    public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(80);
     public override QuestAreaId AreaId => QuestAreaId.FeryanaWilderness;
     public override uint RequiredAreaRank => 5;
 
@@ -12,19 +12,19 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGoremanticoreLightArmor, 88, 0, isBoss: true),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 88, 4),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGoremanticoreLightArmor, 88, 105000, 3)
+				.SetIsBoss(true),
         };
 
         // Available Items (4): BattleArmorFragment, UnrefinedAlloyLump, GiantKillerStoneShard, GiantKillerStone
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.GiantKillerStoneShard, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.GiantKillerStone, 1, 1, DropRate.RARE);
+            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.GiantKillerStoneShard, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.GiantKillerStone, 1, 1, DropRate.VERY_RARE);
         enemies[0].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
@@ -42,18 +42,11 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         enemies[2].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantKillerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantKillerStone, 1, 1, DropRate.VERY_RARE);
+            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.GiantKillerStoneShard, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.GiantKillerStone, 1, 1, DropRate.RARE);
         enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantKillerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantKillerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[4].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_wailing_wetland.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_wailing_wetland.csx
@@ -12,24 +12,23 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.Lindwurm0, 88, 0, isBoss: true),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 4),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 5),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 6),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 7),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadySaurianLightArmor, 88, 8),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 88, 4200, 0)
+				.SetInfectionType(3),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 88, 4200, 1)
+				.SetInfectionType(3),
+            LibDdon.Enemy.Create(EnemyId.Lindwurm0, 88, 105000, 2)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 88, 4200, 3)
+				.SetInfectionType(3),
         };
 
         // Available Items (5): FeryanaSweetMushroom, ScarredLizardscalePelt, UnrefinedAlloyLump, UndeadDestroyerStoneShard, UndeadDestroyerStone
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.RARE);
+            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
         enemies[0].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
@@ -41,11 +40,11 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         enemies[1].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
+            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.RARE);
         enemies[2].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
@@ -55,46 +54,6 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
         enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[7].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[8]).Clone()
-            .AddDrop(ItemId.FeryanaSweetMushroom, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.ScarredLizardscalePelt, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.UndeadDestroyerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[8].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar07_silver_hermits_stronghold.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar07_silver_hermits_stronghold.csx
@@ -1,10 +1,10 @@
-// Silver Hermit's Stronghold — stageid463 GroupId65 MaxPos3 (positions 0-3)
+// Silver Hermit's Stronghold — stageid463 GroupId8 MaxPos3 (positions 0-3)
 // Monster Caution Spot — Feryana Wilderness, Lv88, AR0
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(65);
+    public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(8);
     public override QuestAreaId AreaId => QuestAreaId.FeryanaWilderness;
     public override uint RequiredAreaRank => 7;
 
@@ -17,11 +17,13 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGorecyclopsLightArmor0, 88, 0, isBoss: true)
-                .SetNamedEnemyParams(NamedParamId.BrutalHermit),
-            LibDdon.Enemy.CreateAuto(EnemyId.SnowHarpy, 88, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.SnowHarpy, 88, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.SnowHarpy, 88, 3),
+            LibDdon.Enemy.Create(EnemyId.Goremanticore, 88, 105000, 0)
+                .SetNamedEnemyParams(NamedParamId.BrutalHermit)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 3),
+            LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 4),
         };
 
         // Available Items (4): WarmMud, UnrefinedAlloyLump, DemonExpellerStoneShard, DemonExpellerStone
@@ -52,6 +54,13 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
         enemies[3].SetDropsTable(dropsTable);
+
+        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
+            .AddDrop(ItemId.WarmMud, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.UnrefinedAlloyLump, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
+        enemies[4].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319001.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319001.csx
@@ -1,0 +1,105 @@
+/**
+ * @brief Feryana Wilderness: Pursue and Defeat Enemies
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60319001; // Schedule ID: 1677099136
+    public override ushort RecommendedLevel => 88;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.FeryanaWilderness;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.FeryanaWilderness, 5));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.SkeletonSmasherStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.FeryanaWilderness, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 88, 105000, 1)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 3),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 8),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.CheckAreaRank(19, 5)
+			]);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.FeryanaWilderness, 0, 0, NpcId.Guy, 23876)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5683)
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Guy, 23875)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(132, NpcId.Guy, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.NewTalkNpc(132, 0, 0, 60319001),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Guy, 23874),
+				QuestManager.ResultCommand.LayoutFlagRandomOn(6208, 6209, -1, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(132, 1, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(132, 2, 0, 0)
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6208),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6209),
+				QuestManager.ResultCommand.LayoutFlagRandomOn(6210, 6211, -1, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(132, 3, 0, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.OmSetTouchRadius(132, 4, 0, 0)
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6210),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6211)
+			]);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FeryanaWilderness, 0, 0, NpcId.Guy, 23873);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319002.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319002.csx
@@ -1,0 +1,150 @@
+/**
+ * @brief Feryana Wilderness: Liberation Army Support
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60319002; // Schedule ID: 1677099264
+    public override ushort RecommendedLevel => 86;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.FeryanaWilderness;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+        public const uint Encounter1 = 11;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60319003));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.SkeletonSmasherStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.FeryanaWilderness, 2, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 86, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 86, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.Lindwurm0, 86, 105000, 2)
+				.SetIsBoss(true),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter1, Stage.ShrineoftheEternalBlaze, 10, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Witch, 85, 5384, 0)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.SkeletonMage0, 85, 5384, 1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonMage0, 85, 5384, 2)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonSorcerer0, 85, 5384, 3)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SkeletonSorcerer0, 85, 5384, 4)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsTutorialQuestClear(60319003)
+			]);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.FeryanaWilderness, 0, 0, NpcId.Versa, 23877)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5684)
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Versa, 23879)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(1)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.NewTalkNpc(132, 0, 0, 60319002),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+        process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(2)
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter0)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(5, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Versa, 24332)
+			]);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter0, resetGroup: false)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(6, 3)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Checkpoint, Stage.FeryanaWilderness, 0, 0, NpcId.Versa, 23881)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(7, 3)
+			]);
+        process0.AddProcessEndBlock(true);
+
+		// Branch 1 - Procure supplies
+        var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(132, NpcId.Versa, 0)
+			]);
+		process1.AddNewDeliverItemsBlock(QuestAnnounceType.None, Stage.FeryanaWilderness, 0, 0, NpcId.Versa, ItemId.UnderworldDrop, 5, 24330)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(0),
+				QuestManager.ResultCommand.UpdateAnnounceDirect(1, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Versa, 23878)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(2)
+			]);
+
+		//Branch 2 - Survey spots
+        var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(132, NpcId.Versa, 1)
+			]);
+        process2.AddDiscoverGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter1)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(1),
+				QuestManager.ResultCommand.UpdateAnnounceDirect(2, 3),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Versa, 23880)
+			]);
+        process2.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter1, resetGroup: false)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(3, 3)
+			]);
+        process2.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.FeryanaWilderness, 0, 0, NpcId.Versa, 24327)
+			.AddResultCommands([
+				QuestManager.ResultCommand.UpdateAnnounceDirect(4, 3)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(2)
+			]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319003.csx
@@ -1,0 +1,153 @@
+/**
+ * @brief Feryana Wilderness: Rescue Request
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60319003; // Schedule ID: 1677099392
+    public override ushort RecommendedLevel => 86;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.FeryanaWilderness;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+        public const uint Encounter1 = 11;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.FeryanaWilderness, 2));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.GiantKillerStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.FeryanaWilderness, 80, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 86, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 86, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGoremanticoreLightArmor, 86, 105000, 3)
+				.SetIsBoss(true),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter1, Stage.FeryanaWilderness, 9, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 86, 4200, 0)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 86, 4200, 1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 86, 4200, 2)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 86, 4200, 3)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.CheckAreaRank(19, 2)
+			]);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.FeryanaWilderness, 1, 0, NpcId.Dana, 24180)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5685)
+			]);
+		process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Dana, 24181),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Artin, 23882)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.MyQstFlagOn(0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpc(635, NpcId.Artin),
+				QuestManager.CheckCommand.DummyNotProgress()
+			]);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0, resetGroup: false)
+			.AddResultCommands([
+				QuestManager.ResultCommand.StartTimer(1, 20)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FeryanaWilderness, 1, 0, NpcId.Dana, 24048)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(2963),
+				QuestManager.ResultCommand.QstLayoutFlagOff(10)
+			]);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(635, NpcId.Artin, 0)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(0),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Artin, 23885)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEndTimer(2),
+				QuestManager.CheckCommand.MyQstFlagOff(2963)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5610),
+				QuestManager.ResultCommand.CallGeneralAnnounce(1, 100219)
+			]);
+
+        var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.TalkNpcChoice(635, NpcId.Artin, 1)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.MyQstFlagOn(0),
+				QuestManager.ResultCommand.QstTalkChg(NpcId.Artin, 23886)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEndTimer(2),
+				QuestManager.CheckCommand.MyQstFlagOff(2963)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5700),
+				QuestManager.ResultCommand.CallGeneralAnnounce(1, 100219)
+			]);
+
+        var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(10)
+			]);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEndTimer(1),
+				QuestManager.CheckCommand.MyQstFlagOff(2963)
+			]);
+        process3.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter1)
+			.AddResultCommands([
+				QuestManager.ResultCommand.StartTimer(2, 30),
+				QuestManager.ResultCommand.CallGeneralAnnounce(1, 100220)
+			]);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319004.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60319004.csx
@@ -1,0 +1,241 @@
+/**
+ * @brief Feryana Wilderness: Prevent Enemy Attack
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)60319004; // Schedule ID: 1677099520
+    public override ushort RecommendedLevel => 88;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.FeryanaWilderness;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter0 = 10;
+        public const uint Encounter1 = 11;
+    }
+
+    private class NamedParamId
+    {
+        public const uint BrutalHermit = 1735;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared((QuestId)60319001));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 42000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.DemonExpellerStone, 1);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter0, Stage.FeryanaWilderness, 15, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 0)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+            LibDdon.Enemy.Create(EnemyId.Goremanticore, 88, 105000, 1)
+                .SetNamedEnemyParams(NamedParamId.BrutalHermit)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 2)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 10)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter1, Stage.FeryanaWilderness, 8, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Goremanticore, 88, 105000, 0)
+                .SetNamedEnemyParams(NamedParamId.BrutalHermit)
+				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 1)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 2)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 3)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+            LibDdon.Enemy.Create(EnemyId.Mudman, 88, 4200, 4)
+				.SetRepopCount(1)
+				.SetRepopWaitSecond(10),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsTutorialQuestClear(60319001)
+			]);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.FeryanaWilderness, 0, 0, NpcId.Eileen, 23887)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(5686)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.FeryanaWilderness, 0, 0, NpcId.Eileen, 23888);
+		process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOn(6271),
+				QuestManager.ResultCommand.QstLayoutFlagOn(6272),
+				QuestManager.ResultCommand.QstLayoutFlagOn(6273)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(10)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(11)
+			]);
+		process0.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(10),
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(11)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FeryanaWilderness, 0, 0, NpcId.Eileen, 23891)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6271),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6272),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6273)
+			]);
+        process0.AddProcessEndBlock(true);
+
+		// Branch 1a - Shenay
+		var process1 = AddNewProcess(1);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6271)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Shenai, 23889)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.QuestTalkNpcRadius(132, 1, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6271)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6271)
+			]);
+		process1.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6272),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6273),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Shenai, 23890),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Keiku, 24505),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Elton, 24589)
+			]);
+
+		// Branch 1b - Keik
+		var process2 = AddNewProcess(2);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6272)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Keiku, 24503)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.QuestTalkNpcRadius(132, 2, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6272)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6272)
+			]);
+		process2.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6271),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6273)
+			]);
+
+		var process3 = AddNewProcess(3);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6271),
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6273)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6272),
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6273)
+			]);
+        process3.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Shenai, 23890),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Keiku, 24505),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Elton, 24589)
+			]);
+        process3.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter0, resetGroup: false);
+		process3.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(10)
+			]);
+
+		// Branch 2 - Elton
+		var process4 = AddNewProcess(4);
+		process4.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6273)
+			]);
+		process4.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Elton, 24504)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.QuestTalkNpcRadius(132, 3, 0)
+			])
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6273)
+			]);
+		process4.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6273)
+			]);
+		process4.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(6271),
+				QuestManager.ResultCommand.QstLayoutFlagOff(6272)
+			]);
+
+		var process5 = AddNewProcess(5);
+		process5.AddRawBlock(QuestAnnounceType.None)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6271),
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOff(6272),
+				QuestManager.CheckCommand.IsMyquestLayoutFlagOn(6273)
+			]);
+        process5.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter1)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Elton, 24506),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Shenai, 24587),
+				QuestManager.ResultCommand.QstTalkChgFsm(NpcId.Keiku, 24588)
+			]);
+        process5.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter1, resetGroup: false);
+		process5.AddRawBlock(QuestAnnounceType.None)
+			.AddResultCommands([
+				QuestManager.ResultCommand.QstLayoutFlagOff(11)
+			]);
+    }
+}
+
+return new ScriptedQuest();


### PR DESCRIPTION
The following quests have been added:

- Feryana Wilderness: Pursue and Defeat Enemies (q60319001)
- Feryana Wilderness: Liberation Army Support (q60319002)
- Feryana Wilderness: Rescue Request (q60319003)
- Feryana Wilderness: Prevent Enemy Attack (q60319004)

The following Feryana Wilderness caution spots have been adjusted:

- Demon Army Relay Station: Four Dwarf Orcs have been removed.
- Gate Camp: Group ID moved to 80, one Dwarf Orc has been removed.
- Wailing Wetland: Five Saurians have been removed, the remaining three now have Heavy Armour.
- Silver Hermit's Stronghold: Group ID moved to 8, one Snow Harpy has been added, caution boss has been changed to a Goremanticore.

Note: You might see Clear announces when doing these quests, as they are supposed to unlock the four caution spots (which right now are unlocked by AR), so there's some overlap going on.