### PR TITLE
feat: Add support for partial deliveries

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 61;
+    public const uint Version = 62;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_quest_delivery_progress.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_quest_delivery_progress.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "ddon_quest_delivery_progress"
+(
+    "character_common_id" INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
+    "item_id"             INTEGER NOT NULL,
+    "amount_delivered"    INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "pk_ddon_quest_delivery_progress" PRIMARY KEY ("character_common_id", "quest_schedule_id", "item_id"),
+    CONSTRAINT "fk_ddon_quest_delivery_progress_quest_progress"
+        FOREIGN KEY ("character_common_id", "quest_schedule_id")
+        REFERENCES "ddon_quest_progress" ("character_common_id", "quest_schedule_id")
+        ON DELETE CASCADE
+);

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -612,6 +612,19 @@ CREATE TABLE IF NOT EXISTS "ddon_quest_progress"
 );
 CREATE INDEX IF NOT EXISTS "idx_ddon_quest_progress_character_common_id" ON "ddon_quest_progress" ("character_common_id");
 
+CREATE TABLE IF NOT EXISTS "ddon_quest_delivery_progress"
+(
+    "character_common_id" INTEGER NOT NULL,
+    "quest_schedule_id"   INTEGER NOT NULL,
+    "item_id"             INTEGER NOT NULL,
+    "amount_delivered"    INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "pk_ddon_quest_delivery_progress" PRIMARY KEY ("character_common_id", "quest_schedule_id", "item_id"),
+    CONSTRAINT "fk_ddon_quest_delivery_progress_quest_progress"
+        FOREIGN KEY ("character_common_id", "quest_schedule_id")
+        REFERENCES "ddon_quest_progress" ("character_common_id", "quest_schedule_id")
+        ON DELETE CASCADE
+);
+
 CREATE TABLE IF NOT EXISTS "ddon_completed_quests"
 (
     "character_common_id" INTEGER NOT NULL,

--- a/Arrowgene.Ddon.Database/IDatabase.cs
+++ b/Arrowgene.Ddon.Database/IDatabase.cs
@@ -348,6 +348,11 @@ public interface IDatabase
     List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
     QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
 
+    // Quest Delivery Progress
+    bool UpsertQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, uint itemId, uint amountDelivered, DbConnection? connectionIn = null);
+    bool DeleteQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
+    List<QuestDeliveryProgress> GetAllQuestDeliveryProgress(uint characterCommonId, DbConnection? connectionIn = null);
+
     // Quest Priority
     bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
     List<uint> GetPriorityQuestScheduleIds(uint characterCommonId, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -252,7 +252,7 @@ public partial class DdonSqlDb : SqlDb
                 }
                 if (!equipItemMap.TryGetValue(uid, out Item? item))
                 {
-                    // No storage row found — leave slot as null, same as vanilla silent failure
+                    // No storage row found - leave slot as null, same as vanilla silent failure
                     continue;
                 }
                 if (crestMap.TryGetValue(uid, out var crests))
@@ -310,7 +310,7 @@ public partial class DdonSqlDb : SqlDb
                 }
                 if (!jobItemMap.TryGetValue(uid, out Item? item))
                 {
-                    // No storage row found — leave slot as null, same as vanilla silent failure
+                    // No storage row found - leave slot as null, same as vanilla silent failure
                     continue;
                 }
                 common.EquipmentTemplate.SetJobItem(item, job, equipSlot);

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlQuestDeliveryProgress.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlQuestDeliveryProgress.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using Arrowgene.Ddon.Shared.Model.Quest;
+
+namespace Arrowgene.Ddon.Database.Sql.Core;
+
+public partial class DdonSqlDb : SqlDb
+{
+    private readonly string SqlUpsertQuestDeliveryProgress =
+        """
+        INSERT INTO "ddon_quest_delivery_progress" ("character_common_id", "quest_schedule_id", "item_id", "amount_delivered")
+            VALUES (@character_common_id, @quest_schedule_id, @item_id, @amount_delivered)
+            ON CONFLICT ("character_common_id", "quest_schedule_id", "item_id")
+            DO UPDATE SET "amount_delivered" = EXCLUDED."amount_delivered";
+        """;
+
+    private readonly string SqlDeleteQuestDeliveryProgress =
+        "DELETE FROM \"ddon_quest_delivery_progress\" WHERE \"character_common_id\" = @character_common_id AND \"quest_schedule_id\" = @quest_schedule_id;";
+
+    private readonly string SqlSelectAllQuestDeliveryProgress =
+        "SELECT \"character_common_id\", \"quest_schedule_id\", \"item_id\", \"amount_delivered\" FROM \"ddon_quest_delivery_progress\" WHERE \"character_common_id\" = @character_common_id;";
+
+    public override bool UpsertQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, uint itemId, uint amountDelivered, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            return ExecuteNonQuery(connection, SqlUpsertQuestDeliveryProgress, cmd =>
+            {
+                AddParameter(cmd, "character_common_id", characterCommonId);
+                AddParameter(cmd, "quest_schedule_id", questScheduleId);
+                AddParameter(cmd, "item_id", itemId);
+                AddParameter(cmd, "amount_delivered", amountDelivered);
+            }) == 1;
+        });
+    }
+
+    public override bool DeleteQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            return ExecuteNonQuery(connection, SqlDeleteQuestDeliveryProgress, cmd =>
+            {
+                AddParameter(cmd, "character_common_id", characterCommonId);
+                AddParameter(cmd, "quest_schedule_id", questScheduleId);
+            }) >= 0;
+        });
+    }
+
+    public override List<QuestDeliveryProgress> GetAllQuestDeliveryProgress(uint characterCommonId, DbConnection? connectionIn = null)
+    {
+        return ExecuteQuerySafe(connectionIn, connection =>
+        {
+            List<QuestDeliveryProgress> results = new();
+            ExecuteReader(connection, SqlSelectAllQuestDeliveryProgress,
+                cmd => AddParameter(cmd, "@character_common_id", characterCommonId),
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                        results.Add(new QuestDeliveryProgress
+                        {
+                            CharacterCommonId = GetUInt32(reader, "character_common_id"),
+                            QuestScheduleId = GetUInt32(reader, "quest_schedule_id"),
+                            ItemId = GetUInt32(reader, "item_id"),
+                            AmountDelivered = GetUInt32(reader, "amount_delivered")
+                        });
+                    }
+                });
+            return results;
+        });
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000062_QuestDeliveryProgressMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000062_QuestDeliveryProgressMigration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class QuestDeliveryProgressMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 61;
+        public uint To => 62;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/migration_quest_delivery_progress.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.Database/Sql/SqlDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/SqlDb.cs
@@ -522,6 +522,9 @@ public abstract class SqlDb : IDatabase
     public abstract bool RemoveAllQuestProgressByType(QuestType questType, DbConnection? connectionIn = null);
     public abstract List<QuestProgress> GetQuestProgressByType(uint characterCommonId, QuestType questType, DbConnection? connectionIn = null);
     public abstract QuestProgress GetQuestProgressByScheduleId(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
+    public abstract bool UpsertQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, uint itemId, uint amountDelivered, DbConnection? connectionIn = null);
+    public abstract bool DeleteQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
+    public abstract List<QuestDeliveryProgress> GetAllQuestDeliveryProgress(uint characterCommonId, DbConnection? connectionIn = null);
     public abstract bool InsertPriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);
     public abstract List<uint> GetPriorityQuestScheduleIds(uint characterCommonId, DbConnection? connectionIn = null);
     public abstract bool DeletePriorityQuest(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null);

--- a/Arrowgene.Ddon.GameServer/Characters/AreaRankManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/AreaRankManager.cs
@@ -320,7 +320,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return false;
             }
 
-            // Scripted quests may have QuestAreaId = None — resolve from the stored rankings
+            // Scripted quests may have QuestAreaId = None - resolve from the stored rankings
             var areaId = quest.QuestAreaId != QuestAreaId.None
                 ? quest.QuestAreaId
                 : QuestManager.GetAreaIdForTrial(quest.QuestScheduleId);

--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -551,8 +551,31 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return freeSlots >= slotsRequired;
         }
 
+        private bool CanAddItem(Character character, StorageType destinationStorageType, uint itemId, long num, uint stackLimit, byte plusvalue = 0)
+        {
+            Storage storage = character.Storage.GetStorage(destinationStorageType);
+
+            long existingAvailableStackSlots = storage.Items
+                .Where(x => x != null && x.Item1.ItemId == itemId && x.Item1.PlusValue == plusvalue && x.Item2 < stackLimit)
+                .Sum(x => stackLimit - x!.Item2);
+
+            if (num <= existingAvailableStackSlots)
+            {
+                return true;
+            }
+
+            long requiredFreeStacks = num - existingAvailableStackSlots;
+            uint slotsRequired = (uint)Math.Ceiling(((double)requiredFreeStacks) / stackLimit);
+            return storage.EmptySlots() >= slotsRequired;
+        }
+
         private List<CDataItemUpdateResult> DoAddItem(IDatabase database, Character character, StorageType destinationStorageType, uint itemId, uint num, uint stackLimit = UInt32.MaxValue, byte plusvalue = 0, DbConnection? connectionIn = null)
         {
+            if (!CanAddItem(character, destinationStorageType, itemId, num, stackLimit, plusvalue))
+            {
+                throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_STORAGE_OVERFLOW);
+            }
+
             // Add to existing stacks or make new stacks until there are no more items to add
             // The stack limit is specified by the stackLimit arg
             List<CDataItemUpdateResult> results = new List<CDataItemUpdateResult>();
@@ -630,6 +653,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
         // TODO: Maybe make this more smoothly a part of the existing DoAddItem.
         private List<CDataItemUpdateResult> DoAddItemNoStack(IDatabase database, Character character, StorageType destinationStorageType, uint itemId, uint num, byte plusvalue = 0, DbConnection? connectionIn = null)
         {
+            if (character.Storage.GetStorage(destinationStorageType).EmptySlots() == 0)
+            {
+                throw new ResponseErrorException(ErrorCode.ERROR_CODE_ITEM_STORAGE_OVERFLOW);
+            }
+
             // Add to existing stacks or make new stacks until there are no more items to add
             // The stack limit is specified by the stackLimit arg
             List<CDataItemUpdateResult> results = new List<CDataItemUpdateResult>();

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -97,7 +97,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 }
 
                 // Search all process states for a CheckAreaRank command rather than assuming
-                // it is always the very first command — JSON quests and scripted .csx quests
+                // it is always the very first command - JSON quests and scripted .csx quests
                 // serialize their process state lists differently, so .First() is unreliable.
                 var questData = quest.ToCDataQuestList(0);
                 uint requiredRank = 0;

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
@@ -76,12 +76,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
 
                 var progress = Server.Database.GetQuestProgressByType(currentLeader.Client.Character.CommonId, QuestType.All);
+                var deliveryProgressByQuest = Server.Database.GetAllQuestDeliveryProgress(currentLeader.Client.Character.CommonId)
+                    .GroupBy(x => x.QuestScheduleId)
+                    .ToDictionary(g => g.Key, g => g.ToList());
                 foreach (var questProgress in progress)
                 {
                     var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
                     if (quest is null) continue;
                     QuestStateManager questStateManager = QuestManager.GetQuestStateManager(currentLeader.Client, quest);
                     questStateManager.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+
+                    if (deliveryProgressByQuest.TryGetValue(questProgress.QuestScheduleId, out var deliveryItems))
+                    {
+                        foreach (var dp in deliveryItems)
+                            questStateManager.RestoreDeliveryProgress(questProgress.QuestScheduleId, (ItemId)dp.ItemId, dp.AmountDelivered);
+                    }
                 }
 
                 party.SendToAll(new S2CQuestGetMainQuestNtc());

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyCreateHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -31,6 +32,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
             party.QuestState.EnforceInitialPoolEligibility();
             
             var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
+            var deliveryProgressByQuest = Server.Database.GetAllQuestDeliveryProgress(client.Character.CommonId)
+                .GroupBy(x => x.QuestScheduleId)
+                .ToDictionary(g => g.Key, g => g.ToList());
             foreach (var questProgress in progress)
             {
                 var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
@@ -43,6 +47,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 QuestStateManager questStateManager = QuestManager.GetQuestStateManager(client, quest);
                 questStateManager.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+
+                if (deliveryProgressByQuest.TryGetValue(questProgress.QuestScheduleId, out var deliveryItems))
+                {
+                    foreach (var dp in deliveryItems)
+                        questStateManager.RestoreDeliveryProgress(questProgress.QuestScheduleId, (ItemId)dp.ItemId, dp.AmountDelivered);
+                }
             }
 
             // Add quest for debug command

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyJoinHandler.cs
@@ -45,12 +45,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
+            var deliveryProgressByQuest = Server.Database.GetAllQuestDeliveryProgress(client.Character.CommonId)
+                .GroupBy(x => x.QuestScheduleId)
+                .ToDictionary(g => g.Key, g => g.ToList());
             foreach (var questProgress in progress)
             {
                 var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
                 if (quest != null && quest.IsPersonal)
-                { 
+                {
                     join.QuestState.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+
+                    if (deliveryProgressByQuest.TryGetValue(questProgress.QuestScheduleId, out var deliveryItems))
+                    {
+                        foreach (var dp in deliveryItems)
+                            join.QuestState.RestoreDeliveryProgress(questProgress.QuestScheduleId, (ItemId)dp.ItemId, dp.AmountDelivered);
+                    }
                 }
             }
 

--- a/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
@@ -31,6 +31,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             Dictionary<uint, CDataDeliveredItem> deliveredItems = new Dictionary<uint, CDataDeliveredItem>();
             List<CDataItemUpdateResult> itemUpdateResults = new List<CDataItemUpdateResult>();
+            // Holds validated (remaining, newTotal) per item, populated inside the transaction,
+            // applied to in-memory state only after the transaction commits successfully.
+            Dictionary<uint, (uint Remaining, uint NewTotal)> deliveryCommits = new Dictionary<uint, (uint, uint)>();
             Server.Database.ExecuteInTransaction(connection =>
             {
                 foreach (var item in request.ItemUIDList)
@@ -57,10 +60,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 foreach (var deliveredItem in deliveredItems.Values)
                 {
-                    // Do this check in the transaction so the DB rolls back if something goes wrong.
-                    deliveredItem.NeedNum = (ushort)questState.UpdateDeliveryRequest((ItemId)deliveredItem.ItemId, deliveredItem.ItemNum);
+                    // Validate and compute without mutating in-memory state; if the DB upsert
+                    // below throws the transaction rolls back cleanly with no state left behind.
+                    var result = questState.ValidateDeliveryRequest((ItemId)deliveredItem.ItemId, deliveredItem.ItemNum);
+                    deliveryCommits[deliveredItem.ItemId] = result;
+                    Server.Database.UpsertQuestDeliveryProgress(client.Character.CommonId, request.QuestScheduleId, deliveredItem.ItemId, result.NewTotal, connection);
                 }
             });
+
+            // Transaction committed, now safe to apply in-memory mutations.
+            foreach (var deliveredItem in deliveredItems.Values)
+            {
+                var (remaining, newTotal) = deliveryCommits[deliveredItem.ItemId];
+                deliveredItem.NeedNum = (ushort)remaining;
+                questState.RestoreDeliveryAmount((ItemId)deliveredItem.ItemId, newTotal);
+            }
 
             client.Send(new S2CItemUpdateCharacterItemNtc()
             {

--- a/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestDeliverItemHandler.cs
@@ -5,6 +5,7 @@ using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -36,6 +37,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             Dictionary<uint, (uint Remaining, uint NewTotal)> deliveryCommits = new Dictionary<uint, (uint, uint)>();
             Server.Database.ExecuteInTransaction(connection =>
             {
+                var deliveryProgressCommonIds = GetDeliveryProgressCommonIds(client, quest.IsPersonal, request.QuestScheduleId, connection);
                 foreach (var item in request.ItemUIDList)
                 {
                     uint itemId = client.Character.Storage.FindItemByUIdInStorage(ItemManager.AllItemStorages, item.ItemUID)?.Item2.Item2.ItemId
@@ -64,7 +66,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     // below throws the transaction rolls back cleanly with no state left behind.
                     var result = questState.ValidateDeliveryRequest((ItemId)deliveredItem.ItemId, deliveredItem.ItemNum);
                     deliveryCommits[deliveredItem.ItemId] = result;
-                    Server.Database.UpsertQuestDeliveryProgress(client.Character.CommonId, request.QuestScheduleId, deliveredItem.ItemId, result.NewTotal, connection);
+                    foreach (var commonId in deliveryProgressCommonIds)
+                    {
+                        if (!Server.Database.UpsertQuestDeliveryProgress(commonId, request.QuestScheduleId, deliveredItem.ItemId, result.NewTotal, connection))
+                        {
+                            throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_INTERNAL_ERROR, $"Failed to save delivery progress for character common id {commonId}.");
+                        }
+                    }
                 }
             });
 
@@ -103,6 +111,35 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             return res;
+        }
+
+        private List<uint> GetDeliveryProgressCommonIds(GameClient client, bool isPersonal, uint questScheduleId, DbConnection connection)
+        {
+            if (isPersonal || client.Party == null)
+            {
+                return new List<uint>() { client.Character.CommonId };
+            }
+
+            var commonIds = new HashSet<uint>();
+            foreach (var memberClient in client.Party.Clients)
+            {
+                if (memberClient?.Character == null)
+                {
+                    continue;
+                }
+
+                if (Server.Database.GetQuestProgressByScheduleId(memberClient.Character.CommonId, questScheduleId, connection) != null)
+                {
+                    commonIds.Add(memberClient.Character.CommonId);
+                }
+            }
+
+            if (commonIds.Count == 0)
+            {
+                throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_INTERNAL_ERROR, $"No party members have quest progress for delivery quest {questScheduleId}.");
+            }
+
+            return commonIds.ToList();
         }
     }
 }

--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetSetQuestListHandler.cs
@@ -3,9 +3,11 @@ using Arrowgene.Ddon.GameServer.Quests;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Logging;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Arrowgene.Ddon.GameServer.Handler
 {
@@ -31,12 +33,21 @@ namespace Arrowgene.Ddon.GameServer.Handler
             if (client.Party.Leader?.Client == client && client.Party.QuestState.GetActiveQuestScheduleIds().Count == 0)
             {
                 var progress = Server.Database.GetQuestProgressByType(client.Character.CommonId, QuestType.All);
+                var deliveryProgressByQuest = Server.Database.GetAllQuestDeliveryProgress(client.Character.CommonId)
+                    .GroupBy(x => x.QuestScheduleId)
+                    .ToDictionary(g => g.Key, g => g.ToList());
                 foreach (var questProgress in progress)
                 {
                     var quest = QuestManager.GetQuestByScheduleId(questProgress.QuestScheduleId);
                     if (quest is null) continue;
                     QuestStateManager questStateManager = QuestManager.GetQuestStateManager(client, quest);
                     questStateManager.AddNewQuest(questProgress.QuestScheduleId, questProgress.Step);
+
+                    if (deliveryProgressByQuest.TryGetValue(questProgress.QuestScheduleId, out var deliveryItems))
+                    {
+                        foreach (var dp in deliveryItems)
+                            questStateManager.RestoreDeliveryProgress(questProgress.QuestScheduleId, (ItemId)dp.ItemId, dp.AmountDelivered);
+                    }
                 }
                 Logger.Info(client, $"[QuestGetSetQuestList] Reloaded quest state for promoted leader {client.Character.CharacterId}");
             }
@@ -58,6 +69,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
             {
                 client.Send(ntc);
             }
+
+            // Resync the client's delivery UI with any partial deliveries already in memory.
+            uint charId = client.Character.CharacterId;
+            foreach (var deliveryNtc in client.QuestState.GetRestoredDeliveryNtcs(charId))
+                client.Send(deliveryNtc);
+            foreach (var deliveryNtc in client.Party.QuestState.GetRestoredDeliveryNtcs(charId))
+                client.Send(deliveryNtc);
 
             return res;
         }

--- a/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyGroup.cs
@@ -359,7 +359,7 @@ namespace Arrowgene.Ddon.GameServer.Party
                 PlayerPartyMember partyMember = GetPlayerPartyMember(client);
                 if (partyMember == null)
                 {
-                    // Not in this party at all — nothing to clean up.
+                    // Not in this party at all - nothing to clean up.
                     return;
                 }
 

--- a/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
+++ b/Arrowgene.Ddon.GameServer/Party/PartyManager.cs
@@ -88,7 +88,7 @@ public class PartyManager
                     $"PartyMemberCount:{invitation.Party.MemberCount()} " +
                     $"AliveClients:{invitation.Party.Clients.Count}");
 
-        // KickNtc must be sent before Leave() — after Leave() frees the slot, SendToAll
+        // KickNtc must be sent before Leave() - after Leave() frees the slot, SendToAll
         // won't include the invitee and they won't see their own ghost slot removal.
         if (memberIndex != PartyGroup.InvalidSlotIndex)
         {

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -126,6 +126,11 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             lock (DeliveryRecords)
             {
+                if (DeliveryRecords.TryGetValue(itemId, out var existing))
+                {
+                    Logger.Info($"Quest {QuestId} already has delivery item {itemId} registered at process {existing.ProcessNo}, block {existing.BlockNo}; overwriting with process {processNo}, block {blockNo}.");
+                }
+
                 DeliveryRecords[itemId] = new QuestDeliveryRecord()
                 {
                     ProcessNo = processNo,

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -75,7 +75,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
             InstanceVars = new QuestInstanceVars();
         }
 
-        public uint UpdateDeliveryRequest(ItemId itemId, uint amount)
+        // Validates the delivery and returns (remaining, newTotal) without mutating state.
+        // Call RestoreDeliveryAmount with newTotal after all side-effects (DB writes) succeed.
+        public (uint Remaining, uint NewTotal) ValidateDeliveryRequest(ItemId itemId, uint amount)
         {
             lock (DeliveryRecords)
             {
@@ -86,16 +88,37 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 }
 
                 var deliveryRecord = DeliveryRecords[itemId];
+                uint newTotal = deliveryRecord.AmountDelivered + amount;
 
-                deliveryRecord.AmountDelivered += amount;
-
-                if (deliveryRecord.AmountDelivered > deliveryRecord.AmountRequired)
+                if (newTotal > deliveryRecord.AmountRequired)
                 {
                     Logger.Error($"Delivery overage {itemId} for quest {QuestId}");
                     throw new ResponseErrorException(ErrorCode.ERROR_CODE_QUEST_OVERRUN_DELIVER_ITEM);
                 }
 
-                return deliveryRecord.AmountRequired - deliveryRecord.AmountDelivered;
+                return (deliveryRecord.AmountRequired - newTotal, newTotal);
+            }
+        }
+
+        public void RestoreDeliveryAmount(ItemId itemId, uint amountDelivered)
+        {
+            lock (DeliveryRecords)
+            {
+                if (DeliveryRecords.TryGetValue(itemId, out var record))
+                    record.AmountDelivered = amountDelivered;
+            }
+        }
+
+        public void ClearCompletedDeliveryRecords()
+        {
+            lock (DeliveryRecords)
+            {
+                var completed = DeliveryRecords
+                    .Where(kv => kv.Value.AmountDelivered >= kv.Value.AmountRequired)
+                    .Select(kv => kv.Key)
+                    .ToList();
+                foreach (var key in completed)
+                    DeliveryRecords.Remove(key);
             }
         }
 
@@ -648,6 +671,15 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
         }
 
+        public void RestoreDeliveryProgress(uint questScheduleId, ItemId itemId, uint amountDelivered)
+        {
+            lock (ActiveQuests)
+            {
+                if (ActiveQuests.TryGetValue(questScheduleId, out var questState))
+                    questState.RestoreDeliveryAmount(itemId, amountDelivered);
+            }
+        }
+
         public abstract bool UpdateQuestProgress(uint questScheduleId, DbConnection? connectionIn = null);
         public abstract bool CompleteQuestProgress(uint questScheduleId, DbConnection? connectionIn = null);
         public abstract PacketQueue DistributeQuestRewards(uint questScheduleId, DbConnection? connectionIn = null);
@@ -973,6 +1005,49 @@ namespace Arrowgene.Ddon.GameServer.Quests
         {
             return IsQuestAccepted(QuestManager.GetQuestByQuestId(questId).QuestScheduleId);
         }
+
+        public List<S2CQuestDeliverItemNtc> GetRestoredDeliveryNtcs(uint characterId)
+        {
+            var ntcs = new List<S2CQuestDeliverItemNtc>();
+            lock (ActiveQuests)
+            {
+                foreach (var (questScheduleId, questState) in ActiveQuests)
+                {
+                    var byProcess = new Dictionary<ushort, List<CDataDeliveredItem>>();
+                    lock (questState.DeliveryRecords)
+                    {
+                        foreach (var (itemId, record) in questState.DeliveryRecords)
+                        {
+                            if (record.AmountDelivered > 0)
+                            {
+                                if (!byProcess.ContainsKey(record.ProcessNo))
+                                    byProcess[record.ProcessNo] = new List<CDataDeliveredItem>();
+                                byProcess[record.ProcessNo].Add(new CDataDeliveredItem()
+                                {
+                                    ItemId = (uint)itemId,
+                                    ItemNum = (ushort)record.AmountDelivered,
+                                    NeedNum = (ushort)(record.AmountRequired - record.AmountDelivered)
+                                });
+                            }
+                        }
+                    }
+                    foreach (var (processNo, items) in byProcess)
+                    {
+                        ntcs.Add(new S2CQuestDeliverItemNtc()
+                        {
+                            DeliveredItemRecord = new CDataDeliveredItemRecord()
+                            {
+                                CharacterId = characterId,
+                                QuestScheduleId = questScheduleId,
+                                ProcessNo = processNo,
+                                DeliveredItemList = items
+                            }
+                        });
+                    }
+                }
+            }
+            return ntcs;
+        }
     }
 
     public class SharedQuestStateManager : QuestStateManager
@@ -1030,7 +1105,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
 
         /// <summary>
         /// Replaces RolledInstanceWorldQuests with a copy of serverPool, then removes any quests
-        /// the party leader is not eligible for (no re-roll replacement — server pool is canonical).
+        /// the party leader is not eligible for (no re-roll replacement - server pool is canonical).
         /// </summary>
         public void ApplyServerPool(Dictionary<QuestAreaId, HashSet<uint>> serverPool)
         {
@@ -1405,8 +1480,10 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 }
 
                 Server.Database.UpdateQuestProgress(memberClient.Character.CommonId, questState.QuestScheduleId, questState.QuestType, questState.Step + 1, connectionIn);
+                Server.Database.DeleteQuestDeliveryProgress(memberClient.Character.CommonId, questState.QuestScheduleId, connectionIn);
             }
 
+            questState.ClearCompletedDeliveryRecords();
             questState.Step += 1;
 
             return true;
@@ -1447,7 +1524,9 @@ namespace Arrowgene.Ddon.GameServer.Quests
             }
 
             Server.Database.UpdateQuestProgress(Member.Client.Character.CommonId, questState.QuestScheduleId, questState.QuestType, questState.Step + 1, connectionIn);
+            Server.Database.DeleteQuestDeliveryProgress(Member.Client.Character.CommonId, questState.QuestScheduleId, connectionIn);
 
+            questState.ClearCompletedDeliveryRecords();
             questState.Step += 1;
 
             return true;

--- a/Arrowgene.Ddon.Scripts/scripts/chat_commands/giveitem.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/chat_commands/giveitem.csx
@@ -71,7 +71,25 @@ public class ChatCommand : IChatCommand
         var (queue, isSpecial) = server.ItemManager.HandleSpecialItem(client, ntc, (ItemId)itemId, amount);
         if (!isSpecial)
         {
-            ntc.UpdateItemList.AddRange(server.ItemManager.AddItem(server, client.Character, true, itemId, amount));
+            var itemInfo = server.AssetRepository.ClientItemInfos[itemId];
+            var destinationStorage = force ? StorageType.StorageBoxNormal : itemInfo.StorageType;
+            if (!server.ItemManager.CanAddItem(client.Character, destinationStorage, itemId, amount))
+            {
+                string hint = force
+                    ? "Storage is also full."
+                    : $"Use `/giveitem {itemId} {amount} true` to send regular items to storage.";
+                responses.Add(ChatResponse.CommandError(client, $"Not enough room in {destinationStorage} for {itemInfo.Name} x{amount}. {hint}"));
+                return;
+            }
+
+            if (force)
+            {
+                ntc.UpdateItemList.AddRange(server.ItemManager.AddItem(server, client.Character, StorageType.StorageBoxNormal, itemId, amount));
+            }
+            else
+            {
+                ntc.UpdateItemList.AddRange(server.ItemManager.AddItem(server, client.Character, true, itemId, amount));
+            }
         }
 
         queue.Send();

--- a/Arrowgene.Ddon.Server/Settings/TimeZoneId.cs
+++ b/Arrowgene.Ddon.Server/Settings/TimeZoneId.cs
@@ -5,7 +5,7 @@ namespace Arrowgene.Ddon.Server.Settings
     /// <summary>
     /// Named timezone constants for use with ServerTimeZone.
     /// Each constant returns a TimeZoneInfo that covers both DST-observing and fixed-offset
-    /// timezones — no manual update is needed when clocks change.
+    /// timezones - no manual update is needed when clocks change.
     ///
     /// If your timezone is not listed, use FindSystemTimeZoneById with any IANA ID:
     ///   settings.ServerTimeZone = TimeZoneInfo.FindSystemTimeZoneById("America/Indiana/Knox");
@@ -20,7 +20,7 @@ namespace Arrowgene.Ddon.Server.Settings
         // ── Universal ─────────────────────────────────────────────────────────
         public static TimeZoneInfo UTC              => TimeZoneInfo.FindSystemTimeZoneById("UTC");
 
-        // ── Europe — DST-observing ────────────────────────────────────────────
+        // ── Europe - DST-observing ────────────────────────────────────────────
         public static TimeZoneInfo UKIreland        => TimeZoneInfo.FindSystemTimeZoneById("Europe/London");    // UK, Ireland              (GMT/BST)
         public static TimeZoneInfo PortugalMainland => TimeZoneInfo.FindSystemTimeZoneById("Europe/Lisbon");    // Portugal mainland         (WET/WEST)
         public static TimeZoneInfo CentralEurope    => TimeZoneInfo.FindSystemTimeZoneById("Europe/Berlin");    // Germany, France, Spain, Italy, Netherlands,
@@ -31,12 +31,12 @@ namespace Arrowgene.Ddon.Server.Settings
         public static TimeZoneInfo SoutheastEurope  => TimeZoneInfo.FindSystemTimeZoneById("Europe/Athens");   // Greece, Romania, Bulgaria, Cyprus  (EET/EEST)
         public static TimeZoneInfo Ukraine          => TimeZoneInfo.FindSystemTimeZoneById("Europe/Kyiv");     // Ukraine                   (EET/EEST)
 
-        // ── Europe — fixed offset (no DST) ───────────────────────────────────
+        // ── Europe - fixed offset (no DST) ───────────────────────────────────
         public static TimeZoneInfo Iceland          => TimeZoneInfo.FindSystemTimeZoneById("Atlantic/Reykjavik"); // Iceland                (UTC+0)
         public static TimeZoneInfo Moscow           => TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow");   // Russia (Moscow zone)       (UTC+3, no DST since 2014)
         public static TimeZoneInfo Turkey           => TimeZoneInfo.FindSystemTimeZoneById("Europe/Istanbul"); // Turkey                    (UTC+3, no DST since 2016)
 
-        // ── Americas — DST-observing ──────────────────────────────────────────
+        // ── Americas - DST-observing ──────────────────────────────────────────
         public static TimeZoneInfo Eastern          => TimeZoneInfo.FindSystemTimeZoneById("America/New_York");    // US/Canada Eastern      (EST/EDT)
         public static TimeZoneInfo Central          => TimeZoneInfo.FindSystemTimeZoneById("America/Chicago");     // US/Canada Central      (CST/CDT)
         public static TimeZoneInfo Mountain         => TimeZoneInfo.FindSystemTimeZoneById("America/Denver");      // US Mountain            (MST/MDT)
@@ -44,11 +44,11 @@ namespace Arrowgene.Ddon.Server.Settings
         public static TimeZoneInfo Alaska           => TimeZoneInfo.FindSystemTimeZoneById("America/Anchorage");   // Alaska                 (AKST/AKDT)
         public static TimeZoneInfo Brazil           => TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo");   // Brazil (Brasília)      (BRT/BRST)
 
-        // ── Americas — fixed offset (no DST) ─────────────────────────────────
+        // ── Americas - fixed offset (no DST) ─────────────────────────────────
         public static TimeZoneInfo Arizona          => TimeZoneInfo.FindSystemTimeZoneById("America/Phoenix");     // Arizona                (MST, no DST)
         public static TimeZoneInfo Hawaii           => TimeZoneInfo.FindSystemTimeZoneById("Pacific/Honolulu");    // Hawaii                 (HST, no DST)
 
-        // ── Asia — fixed offset (no DST) ─────────────────────────────────────
+        // ── Asia - fixed offset (no DST) ─────────────────────────────────────
         public static TimeZoneInfo Japan            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Tokyo");          // Japan                  (JST, UTC+9)
         public static TimeZoneInfo Korea            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Seoul");          // South Korea            (KST, UTC+9)
         public static TimeZoneInfo China            => TimeZoneInfo.FindSystemTimeZoneById("Asia/Shanghai");       // China                  (CST, UTC+8)

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardBoxItem.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataRewardBoxItem.cs
@@ -20,7 +20,7 @@ public class CDataRewardBoxItem
     public bool IsHelp { get; set; }
     public uint SelectGroupId { get; set; }
 
-    // Server-side only — not serialized to the client
+    // Server-side only - not serialized to the client
     public long RewardBoxItemId { get; set; }
     public bool IsInstance { get; set; }
     public StagedRewardItem? StagedItem { get; set; }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017.json
@@ -80,7 +80,7 @@
         "group_id": 0
       },
       "npc_id": "Fabio0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",
@@ -105,7 +105,7 @@
         "group_id": 0
       },
       "npc_id": "Fabio0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_1.json
@@ -81,7 +81,7 @@
         "group_id": 0
       },
       "npc_id": "Fabio0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",
@@ -106,7 +106,7 @@
         "group_id": 0
       },
       "npc_id": "Fabio0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20000017_2.json
@@ -81,7 +81,7 @@
         "group_id": 0
       },
       "npc_id": "Fabio0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",
@@ -106,7 +106,7 @@
         "group_id": 0
       },
       "npc_id": "Fabio0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -231,7 +231,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
         /// <summary>
         /// Reads bit 17 (0x20000) of *(ctx+0x5c)+0x20c, inverts it, and stores the boolean result into the global
-        /// side-effect slot at DAT_021c06b8+0x263. Does NOT return a check result — only writes global state.
+        /// side-effect slot at DAT_021c06b8+0x263. Does NOT return a check result - only writes global state.
         /// Takes no quest parameters; the function signature is effectively void(cQuestProcess* this).
         /// </summary>
         StoreLinkageEnemyFlagGlobal = 212, // 0x00635A30 (cQuestProcess* this, s32 param01_unused, s32 param02_unused, s32 param03_unused, s32 param04_unused)
@@ -322,7 +322,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// <summary>
         /// Displays a radius marker around an OM object and progresses when a player exits its radius.
         /// Thunks to FUN_00638ab0 which calls FUN_00638150; same structure as OmSetTouchRadius but checks
-        /// bit 4 of ctx+0x208 (touch-exit flag) instead of bit 3. Complementary to OmSetTouchRadius — NOT identical.
+        /// bit 4 of ctx+0x208 (touch-exit flag) instead of bit 3. Complementary to OmSetTouchRadius - NOT identical.
         /// </summary>
         OmReleaseTouchRadius = 227, // 0x00636450 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 param04)
 
@@ -367,7 +367,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// FUN_00868170() (accesses this+0x29cc+0x45c), iterates entries matching pawnId against entry+8,
         /// and returns true if a match is found with entry+0x18 or entry+0x1c non-zero (active state).
         /// Only two parameters are used (this, pawnId); params 3 and 4 are ignored.
-        /// @note Previous description "action type 6" was incorrect — no such constant exists in the decompilation.
+        /// @note Previous description "action type 6" was incorrect - no such constant exists in the decompilation.
         /// </summary>
         IsPawnAvailable = 233, // 0x00636900 (cQuestProcess* this, s32 pawnId, s32 param02_unused, s32 param03_unused, s32 param04_unused)
 
@@ -417,7 +417,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
         /// <summary>
         /// Kill-group completion check gated on content mode. Checks ctx+0x4654 == ctx+0x45cc (content mode counter);
-        /// if not in content mode, also checks FUN_009d07f0() and *(this+0x82) byte — if that byte is non-zero,
+        /// if not in content mode, also checks FUN_009d07f0() and *(this+0x82) byte - if that byte is non-zero,
         /// returns early. Forwards all four params to FUN_0063a5e0(param01, param02, param03, param04) which iterates
         /// the kill-group list, matches param01 against entry+0x14, checks entry+0x18 (valid) and entry+4 == 0 (done).
         /// The marker/no-marker distinction vs ID 243 is a runtime property of the this+0x82 byte.
@@ -437,7 +437,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Reads the boundary from DAT_0220456c+0xb28/+0xb2c. Calls FUN_0064d170(timerNo) which searches
         /// Timer List B at offset +0x104 for an entry with +4 == timerNo and returns its +8 field (elapsed value).
         /// Returns 1 if the elapsed value is within the boundary. Params 2-4 are unused.
-        /// @note Previous description "evaluates bit-flag, not elapsed time" was incorrect — this IS a time comparison.
+        /// @note Previous description "evaluates bit-flag, not elapsed time" was incorrect - this IS a time comparison.
         /// </summary>
         IsContentsTimerBElapsed = 244, // 0x00637180 (cQuestProcess* this, s32 timerNo, s32 param02_unused, s32 param03_unused, s32 param04_unused)
 
@@ -463,7 +463,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Direct thunk to FUN_0063a5e0 with no content-mode guard (unlike IDs 242/243).
         /// Iterates the kill-group list on this, finds entry matching flagNo by entry+0x14,
         /// checks entry+0x18 (valid) and entry+4 == 0 (kill complete). Only two parameters are used (this, flagNo).
-        /// @note Previous description "shape type 4 radius" was incorrect — no shape-type filtering in this function.
+        /// @note Previous description "shape type 4 radius" was incorrect - no shape-type filtering in this function.
         /// The "radius" framing comes from the kill zone's visual representation, not the code.
         /// </summary>
         IsKillGroupCompleteInRadius = 248, // 0x00637430 (cQuestProcess* this, s32 flagNo, s32 param02_unused, s32 param03_unused, s32 param04_unused)
@@ -473,7 +473,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Calls FUN_0064d130(timerNo) which searches Timer List A at offset +0xf0 for entry with +4 == timerNo,
         /// returns its +8 field (state value). Returns true if that state value == 0.
         /// Only two parameters used (this, timerNo); params 3-4 ignored.
-        /// @note Previous description "byte-flag at +0x1e95" was incorrect — offset +0x1e95 does not appear in decompilation.
+        /// @note Previous description "byte-flag at +0x1e95" was incorrect - offset +0x1e95 does not appear in decompilation.
         /// </summary>
         IsContentsTimerAZero = 251, // 0x006375E0 (cQuestProcess* this, s32 timerNo, s32 param02_unused, s32 param03_unused, s32 param04_unused)
 
@@ -481,7 +481,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// Checks if a player has entered a proximity zone associated with a wild hunt target set.
         /// Iterates the Wild Hunt check-command object's zone-entry list (count at this[2], array at this[5]).
         /// For each entry where entry+0x14 == param01 (zone/linkage ID), walks sub-entries and calls
-        /// FUN_00636c20(em_id_field1, em_id_field2, -1, param04) — a generic OM enemy killed-state checker.
+        /// FUN_00636c20(em_id_field1, em_id_field2, -1, param04) - a generic OM enemy killed-state checker.
         /// Kill state is confirmed via vtable+0x2ec returning 0xc, or via FUN_00c82ac0 (alternate path).
         /// @note "MobHunt" is the internal engine name for the Wild Hunt system (cMobHuntQuestManager).
         /// @note param02 and param03 are unused. param01 = zone/linkage ID filter, param04 = markerFlag passed to FUN_00636c20.
@@ -494,7 +494,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// </summary>
         IsContentsModeStateFlag = 253, // 0x00637820 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
-        Padding254 = 254, // 0x00637860 stub/nop — always returns 0
+        Padding254 = 254, // 0x00637860 stub/nop - always returns 0
 
         /// <summary>
         /// Checks if a quest enemy's HP-lost percentage &lt;= hpLostPct. Looks up enemy (type 3) via FUN_00a41780,

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestDeliveryProgress.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestDeliveryProgress.cs
@@ -1,0 +1,10 @@
+namespace Arrowgene.Ddon.Shared.Model.Quest
+{
+    public class QuestDeliveryProgress
+    {
+        public uint CharacterCommonId { get; set; }
+        public uint QuestScheduleId { get; set; }
+        public uint ItemId { get; set; }
+        public uint AmountDelivered { get; set; }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
@@ -114,7 +114,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// <summary>
         /// Adds a signed delta to a substory progress value, clamped to [0, max].
         /// The substory category key and objective key are read from stored quest-state fields at
-        /// ctx+0x5c+0x244 and ctx+0x5c+0x248 — they are baked into the quest context, not passed as params.
+        /// ctx+0x5c+0x244 and ctx+0x5c+0x248 - they are baked into the quest context, not passed as params.
         /// Only param01 (delta) is used: positive advances progress, negative regresses it, zero is a no-op.
         /// Sends packet 0x117 (increase) or 0x118 (decrease) to update the UI, then FUN_00bd3280 to
         /// report old and new progress ratios to the client.
@@ -158,7 +158,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// </summary>
         SetSubstoryEnemyInvincible = 105, // 0x00633A80 (cQuestProcess* this, s32 enemyGroupFlag, s32 invincible, s32 param03, s32 param04)
 
-        Padding106 = 106, // 0x00633B00 stub/nop — always returns 0
+        Padding106 = 106, // 0x00633B00 stub/nop - always returns 0
 
         /// <summary>
         /// Adds an NPC to the FSM talk NPC list at this+0x94/0xa0. Validates FSM mode via FUN_009d07f0 first.
@@ -228,7 +228,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// </summary>
         SetQuestOmMontageFixEx = 119, // 0x006341F0 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 poseId)
 
-        Padding120 = 120, // 0x006342D0 stub/nop — always returns 0
+        Padding120 = 120, // 0x006342D0 stub/nop - always returns 0
 
         /// <summary>
         /// Sets the level of a layout enemy (type 2) by queuing it into a critical-section-guarded buffer via FUN_00b55e70.
@@ -236,15 +236,15 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// </summary>
         SetQuestLayoutEnemyLevel = 121, // 0x00634300 (cQuestProcess* this, s32 stageNo, s32 groupNo, s32 setNo, s32 level)
 
-        Padding122 = 122, // 0x00634390 stub/nop — always returns 0
-        Padding123 = 123, // 0x006343C0 stub/nop — always returns 0
+        Padding122 = 122, // 0x00634390 stub/nop - always returns 0
+        Padding123 = 123, // 0x006343C0 stub/nop - always returns 0
 
         /// <summary>
         /// Removes an FSM NPC entry from the process list at this+0x28/0x1c, freeing its children. Calls FUN_0063dda0(param01).
         /// </summary>
         RemoveFsmNpcFromSchedule = 124, // 0x006343F0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
-        Padding125 = 125, // 0x00634410 stub/nop — always returns 0
+        Padding125 = 125, // 0x00634410 stub/nop - always returns 0
 
         /// <summary>
         /// Controls enemy expedition state. mode=2: FUN_00bc6ff0(9) sets global to 10 and signals start.
@@ -252,7 +252,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// </summary>
         SetEnemyExpeditionState = 126, // 0x00634450 (cQuestProcess* this, s32 mode, s32 param02, s32 param03, s32 param04)
 
-        Padding127 = 127, // 0x006344B0 stub/nop — always returns 0
+        Padding127 = 127, // 0x006344B0 stub/nop - always returns 0
 
         /// <summary>
         /// Fires a substory ending sequence. Calls FUN_00be9960, FUN_00b85670, then sends messages 0x25f and 0x260
@@ -260,15 +260,15 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         /// </summary>
         TriggerSubstoryEndSequence = 128, // 0x006345D0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
-        Padding129 = 129, // 0x00634690 stub/nop — always returns 0
+        Padding129 = 129, // 0x00634690 stub/nop - always returns 0
 
         /// <summary>
         /// Checks if a pawn has OM state == 4 and a specific animation condition via FUN_0087dc50.
         /// </summary>
         CheckSubstoryCondition = 130, // 0x006346B0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
-        Padding131 = 131, // 0x00634720 stub/nop — always returns 0
-        Padding132 = 132, // 0x00634750 stub/nop — always returns 0
+        Padding131 = 131, // 0x00634720 stub/nop - always returns 0
+        Padding132 = 132, // 0x00634750 stub/nop - always returns 0
 
         /// <summary>
         /// Controls pawn expedition. mode=1: FUN_00b6ce30() starts expedition (writes action DAT_01d4db50).

--- a/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
+++ b/Arrowgene.Ddon.Test/Database/DatabaseMigratorTest.cs
@@ -280,6 +280,9 @@ namespace Arrowgene.Ddon.Test.Database
         public bool InsertWalletPoint(uint characterId, CDataWalletPoint walletPoint) { return true; }
         public bool RemoveQuestProgress(uint characterCommonId, uint questScheduleId, QuestType questType, DbConnection? connectionIn = null) { return true; }
         public bool RemoveAllQuestProgressByType(QuestType questType, DbConnection? connectionIn = null) { return true; }
+        public bool UpsertQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, uint itemId, uint amountDelivered, DbConnection? connectionIn = null) { return true; }
+        public bool DeleteQuestDeliveryProgress(uint characterCommonId, uint questScheduleId, DbConnection? connectionIn = null) { return true; }
+        public List<QuestDeliveryProgress> GetAllQuestDeliveryProgress(uint characterCommonId, DbConnection? connectionIn = null) { return new List<QuestDeliveryProgress>(); }
         public bool ReplaceCharacterJobData(uint commonId, CDataCharacterJobData replacedCharacterJobData, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceCommunicationShortcut(uint characterId, CDataCommunicationShortCut communicationShortcut, DbConnection? connectionIn = null) { return true; }
         public bool ReplaceEquipItem(uint commonId, JobId job, EquipType equipType, byte equipSlot, string itemUId, DbConnection? connectionIn = null) { return true; }


### PR DESCRIPTION
Allow a player to trade in x/y items and remember that x was traded next time they log in.

- Added checkpoints to
  - q20000017.json
  - q20000017_1.json
  - q20000017_2.json

Database Version 61 -> 62