### PR TITLE
Hotfix: BBM Inventory Swap Bug

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
@@ -97,10 +97,24 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 UpdateType = ItemNoticeType.SwitchingStorage,
                 UpdateItemList = SwapCharacterInventories(client.Character, previousStorage, 
                     [.. ItemManager.ItemBagStorageTypes, 
-                    StorageType.StorageBoxNormal, 
-                    StorageType.StorageBoxExpansion, 
                     StorageType.CharacterEquipment
                 ])
+            });
+
+            client.Send(new S2CItemUpdateCharacterItemNtc()
+            {
+                UpdateType = ItemNoticeType.SwitchingStorage,
+                UpdateItemList = SwapCharacterInventories(client.Character, previousStorage,
+                    [StorageType.StorageBoxNormal]
+                )
+            });
+
+            client.Send(new S2CItemUpdateCharacterItemNtc()
+            {
+                UpdateType = ItemNoticeType.SwitchingStorage,
+                UpdateItemList = SwapCharacterInventories(client.Character, previousStorage,
+                    [StorageType.StorageBoxExpansion]
+               )
             });
 
             client.Send(new S2CEquipChangeCharacterEquipLobbyNtc()


### PR DESCRIPTION
Split inventory swap when moving between game modes into three packets to avoid packet size limits.
