### PR TITLE
Ifrit EXM Update

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q50303000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q50303000.json
@@ -126,6 +126,78 @@
                     "is_boss": true,
                     "start_think_tbl_no": 1,
                     "montage_fix_no": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
+                },
+                {
+                    "comment": "Blazing Boulder",
+                    "enemy_id": "0x030106",
+                    "level": 95,
+                    "exp": 0,
+                    "repop_count": 50,
+                    "is_required": false,
+                    "enemy_target_types_id": 1
                 }
             ]
         },
@@ -137,28 +209,28 @@
             },
             "enemies": [
                 {
-                    "enemy_id": "0x010608",
-                    "level": 95,
-                    "exp": 0,
-                    "repop_count": 50,
-                    "repop_wait_second": 60,
-                    "enemy_target_types_id": 1
+                  "enemy_id": "0x010608",
+                  "level": 95,
+                  "exp": 0,
+                  "repop_count": 50,
+                  "repop_wait_second": 60,
+                  "enemy_target_types_id": 1
                 },
                 {
-                    "enemy_id": "0x010608",
-                    "level": 95,
-                    "exp": 0,
-                    "repop_count": 50,
-                    "repop_wait_second": 60,
-                    "enemy_target_types_id": 1
+                  "enemy_id": "0x010608",
+                  "level": 95,
+                  "exp": 0,
+                  "repop_count": 50,
+                  "repop_wait_second": 60,
+                  "enemy_target_types_id": 1
                 },
                 {
-                    "enemy_id": "0x010608",
-                    "level": 95,
-                    "exp": 0,
-                    "repop_count": 50,
-                    "repop_wait_second": 60,
-                    "enemy_target_types_id": 1
+                  "enemy_id": "0x010608",
+                  "level": 95,
+                  "exp": 0,
+                  "repop_count": 50,
+                  "repop_wait_second": 60,
+                  "enemy_target_types_id": 1
                 },
                 {
                   "enemy_id": "0x010608",


### PR DESCRIPTION
Ifrit (second form) now summons Blazing Boulders when slamming the arena.
Blazing Boulders ignite the area around them, dealing damage and inflicting Burning until destroyed.