### PR TITLE
fix: Fix exception when claiming rewards

### DIFF
--- a/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxItemHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestGetRewardBoxItemHandler.cs
@@ -69,7 +69,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
 
             if (selectedRewards
-                .Where(x => x.SelectGroupId != 0 && x.Type == (byte)QuestRewardType.Select)
+                .Where(x => x.SelectGroupId != 0)
                 .GroupBy(x => x.SelectGroupId)
                 .Any(x => x.Count() > 1))
             {

--- a/Arrowgene.Ddon.GameServer/Quests/Quest.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Quest.cs
@@ -1210,7 +1210,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 RewardBoxItemId = reward.RewardBoxItemId,
                 ItemId = reward.ItemId,
                 Num = reward.Num,
-                UID = reward.UID,
+                UID = GetRewardBoxItemUID(reward),
                 Type = reward.Type,
                 IsCharge = reward.IsCharge,
                 IsHelp = reward.IsHelp,
@@ -1275,10 +1275,20 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 ItemId = item.ItemId,
                 Num = item.Num,
                 Type = (byte)rewardType,
-                UID = item.GetUID(),
+                UID = item.GetUID(rewardType, isHelp, selectGroupId),
                 IsHelp = isHelp,
                 SelectGroupId = selectGroupId,
             };
+        }
+
+        private static string GetRewardBoxItemUID(CDataRewardBoxItem item)
+        {
+            if (item.IsInstance)
+            {
+                return item.UID;
+            }
+
+            return LootPoolItem.CreateUID(item.ItemId, item.Num, (QuestRewardType)item.Type, item.IsHelp, item.SelectGroupId);
         }
 
         private void AppendCategorizedRewardBoxItems(List<CDataRewardBoxItem> results, QuestBoxRewards rewards)

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestInstancedRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestInstancedRewards.cs
@@ -16,6 +16,11 @@ public class InstancedLootPoolItem : LootPoolItem
         return Guid.CreateVersion7(DateTimeOffset.UtcNow).ToString();
     }
 
+    public override string GetUID(QuestRewardType rewardType, bool isHelp = false, uint selectGroupId = 0)
+    {
+        return GetUID();
+    }
+
     public StagedRewardItem ToStagedRewardItem()
     {
         string uid = GetUID();

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestRewards.cs
@@ -31,9 +31,37 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
 
         public virtual string GetUID()
         {
+            return CreateUID(ItemId, Num);
+        }
+
+        public virtual string GetUID(QuestRewardType rewardType, bool isHelp = false, uint selectGroupId = 0)
+        {
+            return CreateUID(ItemId, Num, rewardType, isHelp, selectGroupId);
+        }
+
+        public static string CreateUID(ItemId itemId, ushort num)
+        {
+            return CreateUIDInternal(itemId, num, null, false, 0);
+        }
+
+        public static string CreateUID(ItemId itemId, ushort num, QuestRewardType rewardType, bool isHelp = false, uint selectGroupId = 0)
+        {
+            return CreateUIDInternal(itemId, num, rewardType, isHelp, selectGroupId);
+        }
+
+        private static string CreateUIDInternal(ItemId itemId, ushort num, QuestRewardType? rewardType, bool isHelp, uint selectGroupId)
+        {
             IncrementalHash hash = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
-            hash.AppendData(BitConverter.GetBytes((uint) ItemId));
-            hash.AppendData(BitConverter.GetBytes(Num));
+            hash.AppendData(BitConverter.GetBytes((uint)itemId));
+            hash.AppendData(BitConverter.GetBytes(num));
+
+            if (rewardType != null || isHelp || selectGroupId != 0)
+            {
+                hash.AppendData(BitConverter.GetBytes((uint)(rewardType ?? QuestRewardType.Unknown)));
+                hash.AppendData(BitConverter.GetBytes(isHelp));
+                hash.AppendData(BitConverter.GetBytes(selectGroupId));
+            }
+
             return BitConverter.ToString(hash.GetHashAndReset()).Replace("-", string.Empty).Substring(0, 8);
         }
     }
@@ -119,7 +147,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
                     Type = (byte)(rewardTypeOverride ?? RewardType),
                     IsHelp = isHelp,
                     SelectGroupId = selectGroupId,
-                    UID = item.GetUID()
+                    UID = item.GetUID(rewardTypeOverride ?? RewardType, isHelp, selectGroupId)
                 });
             }
             return rewards;
@@ -171,12 +199,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             var item = LootPool[ItemIndex];
             return new CDataRewardBoxItem()
             {
-                UID = item.GetUID(),
                 ItemId = item.ItemId,
                 Num = item.Num,
                 Type = (byte)(rewardTypeOverride ?? RewardType),
                 IsHelp = isHelp,
                 SelectGroupId = selectGroupId,
+                UID = item.GetUID(rewardTypeOverride ?? RewardType, isHelp, selectGroupId),
             };
         }
 
@@ -185,12 +213,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             var item = LootPool[index];
             return new CDataRewardBoxItem()
             {
-                UID = item.GetUID(),
                 ItemId = item.ItemId,
                 Num = item.Num,
                 Type = (byte)(rewardTypeOverride ?? RewardType),
                 IsHelp = isHelp,
                 SelectGroupId = selectGroupId,
+                UID = item.GetUID(rewardTypeOverride ?? RewardType, isHelp, selectGroupId),
             };
         }
 


### PR DESCRIPTION
Fix an issue encountered with the new reward implementation where it would throw an ERROR_CODE_QUEST_NOT_EXIST_REWARD_BOX_LIST_NO exception when certain reward edge conditions were hit.

Co-authored-by: @Maxunit
