### PR TITLE
update quests with deliveries

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000021.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000021.json
@@ -153,7 +153,6 @@
                         {"type": "QstLayout", "action": "Clear", "value": 1026, "comment": "Spawns Karno, White Knight and Gerd"},
                         {"type": "QstLayout", "action": "Set", "value": 919, "comment": "Blocks Boss Room"}
                     ],
-                    "announce_type": "Update",
                     "groups": [0]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020000.json
@@ -85,7 +85,7 @@
         "group_id": 1
       },
       "npc_id": "Vanessa0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "type": "QstTalkChg",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20020000_1.json
@@ -86,7 +86,7 @@
         "group_id": 1
       },
       "npc_id": "Vanessa0",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "type": "QstTalkChg",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000.json
@@ -118,7 +118,7 @@
         "layer_no": 1
       },
       "npc_id": "WearyHarpy",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "type": "QstTalkChg",
@@ -138,7 +138,7 @@
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_1.json
@@ -119,7 +119,7 @@
         "layer_no": 1
       },
       "npc_id": "WearyHarpy",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "type": "QstTalkChg",
@@ -139,7 +139,7 @@
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_2.json
@@ -119,7 +119,7 @@
         "layer_no": 1
       },
       "npc_id": "WearyHarpy",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "type": "QstTalkChg",
@@ -139,7 +139,7 @@
     },
     {
       "type": "SeekOutEnemiesAtMarkedLocation",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "groups": [ 0 ]
     },
     {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070006.json
@@ -176,7 +176,7 @@
         "layer_no": 1
       },
       "npc_id": "LightlyEquippedSoldier",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070006_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20070006_1.json
@@ -166,7 +166,7 @@
         "layer_no": 1
       },
       "npc_id": "LightlyEquippedSoldier",
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "result_commands": [
         {
           "comment": "Idle dialogue",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001.json
@@ -86,7 +86,7 @@
                 "group_id": 1
             },
             "npc_id": "Theodor",
-            "announce_type": "Update",
+            "announce_type": "CheckpointAndUpdate",
             "result_commands": [ 
                 { 
                 "type": "QstTalkChg", 

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20990001_1.json
@@ -87,7 +87,7 @@
                 "group_id": 1
             },
             "npc_id": "Theodor",
-            "announce_type": "Update",
+            "announce_type": "CheckpointAndUpdate",
             "result_commands": [ 
                 { 
                 "type": "QstTalkChg", 

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
@@ -87,7 +87,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 339
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 339
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 339
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
@@ -87,7 +87,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 341
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 341
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 341
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016005.json
@@ -83,7 +83,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 340
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016006.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 340
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016023.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 340
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017005.json
@@ -87,7 +87,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 377
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017006.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 377
                     },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017023.json
@@ -88,7 +88,7 @@
                 },
                 {
                     "type": "DeliverItems",
-                    "announce_type": "Update",
+                    "announce_type": "CheckpointAndUpdate",
                     "stage_id": {
                         "id": 377
                     },


### PR DESCRIPTION
Add checkpoints to world quests with deliveries so partial delivery support works better.
