### PR TITLE
fix: Cleanup main story quest progress in parties

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -420,6 +420,22 @@ namespace Arrowgene.Ddon.GameServer.Characters
             return GetQuestStateManager(client, QuestManager.GetQuestByScheduleId(questScheduleId));
         }
 
+        public static bool IsClientAlignedForMainQuestProgress(DdonGameServer server, GameClient client, Quest quest, uint step, DbConnection? connectionIn = null)
+        {
+            if (quest.QuestType != QuestType.Main)
+            {
+                return true;
+            }
+
+            if (client.Character.HasQuestCompleted(quest.QuestId))
+            {
+                return false;
+            }
+
+            var progress = server.Database.GetQuestProgressByScheduleId(client.Character.CommonId, quest.QuestScheduleId, connectionIn);
+            return progress != null && (quest.SaveWorkAsStep || progress.Step == step);
+        }
+
         public static HashSet<uint> CollectQuestScheduleIds(GameClient client, StageLayoutId stageId)
         {
             var questScheduleIds = new HashSet<uint>();

--- a/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/QuestQuestProgressHandler.cs
@@ -52,6 +52,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             else
             {
                 QuestStateManager questStateManager = QuestManager.GetQuestStateManager(client, quest);
+                uint questStep = questStateManager.GetQuestState(questScheduleId)?.Step ?? 0;
+                HashSet<uint> questProgressRecipientIds = new();
 
                 var processState = questStateManager.GetProcessState(questScheduleId, processNo);
                 res.QuestProcessState = quest.StateMachineExecute(Server, client, processState, packets, out questProgressState);
@@ -64,6 +66,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
                 Server.Database.ExecuteInTransaction(connection =>
                 {
+                    questProgressRecipientIds = GetQuestProgressRecipientIds(client, quest, questStep, connection);
+
                     if (questProgressState == QuestProgressState.Accepted && quest.QuestType == QuestType.World)
                     {
                         foreach (var memberClient in client.Party.Clients)
@@ -101,7 +105,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     else if (questProgressState == QuestProgressState.Complete)
                     {
                         res.QuestProgressResult = 3; // ProcessEnd
-                        var ntcs = CompleteQuest(quest, client, questStateManager, connection);
+                        var ntcs = CompleteQuest(quest, client, questStateManager, connection, questProgressRecipientIds);
                         packets.AddRange(ntcs);
 
                         // Add Deferred work
@@ -115,7 +119,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     Logger.Info($"{quest.QuestId} ({quest.QuestScheduleId}): QuestBlock={res.QuestProcessState[0]}");
                     Logger.Info("==========================================================================================");
                 }
-
 
                 if (!quest.IsPersonal)
                 {
@@ -143,6 +146,26 @@ namespace Arrowgene.Ddon.GameServer.Handler
             return packets;
         }
 
+        private HashSet<uint> GetQuestProgressRecipientIds(GameClient client, Quest quest, uint step, DbConnection? connectionIn = null)
+        {
+            if (quest.IsPersonal)
+            {
+                return new HashSet<uint>() { client.Character.CharacterId };
+            }
+
+            if (quest.QuestType != QuestType.Main)
+            {
+                return client.Party.Clients
+                    .Select(memberClient => memberClient.Character.CharacterId)
+                    .ToHashSet();
+            }
+
+            return client.Party.Clients
+                .Where(memberClient => QuestManager.IsClientAlignedForMainQuestProgress(Server, memberClient, quest, step, connectionIn))
+                .Select(memberClient => memberClient.Character.CharacterId)
+                .ToHashSet();
+        }
+
         private PacketQueue HandleDefferredWork(GameClient client, Quest quest)
         {
             PacketQueue packets = new();
@@ -163,7 +186,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             return packets;
         }
 
-        private PacketQueue CompleteQuest(Quest quest, GameClient client, QuestStateManager questState, DbConnection? connectionIn = null)
+        private PacketQueue CompleteQuest(Quest quest, GameClient client, QuestStateManager questState, DbConnection? connectionIn = null, HashSet<uint>? questProgressRecipientIds = null)
         {
             PacketQueue packets = new();
 
@@ -253,9 +276,13 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
+                var completionClients = quest.QuestType == QuestType.Main && questProgressRecipientIds != null
+                    ? client.Party.Clients.Where(memberClient => questProgressRecipientIds.Contains(memberClient.Character.CharacterId)).ToList()
+                    : client.Party.Clients.ToList();
+
                 client.Party.EnqueueToAll(completeNtc, packets);
                 packets.AddRange(client.Party.QuestState.UpdatePriorityQuestList(client.Party.Leader.Client, connectionIn));
-                foreach(var memberClient in client.Party.Clients)
+                foreach(var memberClient in completionClients)
                 {
                     packets.AddRange(Server.AchievementManager.HandleClearQuest(memberClient, quest, connectionIn));
                 }

--- a/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/QuestStateManager.cs
@@ -1263,6 +1263,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
                     continue;
                 }
 
+                if (quest.QuestType == QuestType.Main
+                    && !QuestManager.IsClientAlignedForMainQuestProgress(Server, memberClient, quest, questState.Step, connectionIn))
+                {
+                    continue;
+                }
+
                 if (result.Step != questState.Step && !quest.SaveWorkAsStep)
                 {
                     continue;
@@ -1324,13 +1330,7 @@ namespace Arrowgene.Ddon.GameServer.Quests
                 // If this is a main quest, check to see that the member is currently on this quest, otherwise don't reward
                 if (quest.QuestType == QuestType.Main)
                 {
-                    var result = Server.Database.GetQuestProgressByScheduleId(memberClient.Character.CommonId, quest.QuestScheduleId, connectionIn);
-                    if (result == null)
-                    {
-                        continue;
-                    }
-
-                    if (result.Step != questState.Step)
+                    if (!QuestManager.IsClientAlignedForMainQuestProgress(Server, memberClient, quest, questState.Step, connectionIn))
                     {
                         continue;
                     }
@@ -1494,6 +1494,12 @@ namespace Arrowgene.Ddon.GameServer.Quests
             {
                 var result = Server.Database.GetQuestProgressByScheduleId(memberClient.Character.CommonId, questState.QuestScheduleId, connectionIn);
                 if (result == null)
+                {
+                    continue;
+                }
+
+                if (quest.QuestType == QuestType.Main
+                    && !QuestManager.IsClientAlignedForMainQuestProgress(Server, memberClient, quest, questState.Step, connectionIn))
                 {
                     continue;
                 }


### PR DESCRIPTION
Attempt to handle some of the progress of party members better and prevent quest state from being saved for players who did not accept, already completed or are not at the proper quest progress as compared to the party leader.
