### PR TITLE
feat: Hot reload JSON quest and epitaph trial files

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/EpitaphRoadManager.cs
@@ -628,14 +628,12 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public T GetEpitahObject<T>(uint epitaphId)
         {
-            if (_EpitaphAssets.EpitaphObjects.ContainsKey(epitaphId))
-            {
-                return (T) Convert.ChangeType(_EpitaphAssets.EpitaphObjects[epitaphId], typeof(T));
-            }
-            else if (_TrialAssets.EpitahObjects.ContainsKey(epitaphId))
-            {
-                return (T) Convert.ChangeType(_TrialAssets.EpitahObjects[epitaphId], typeof(T));
-            }
+            var epitaphObjects = _EpitaphAssets.EpitaphObjects;
+            if (epitaphObjects.TryGetValue(epitaphId, out var epitaphObj))
+                return (T) Convert.ChangeType(epitaphObj, typeof(T));
+            var trialObjects = _TrialAssets.EpitahObjects;
+            if (trialObjects.TryGetValue(epitaphId, out var trialObj))
+                return (T) Convert.ChangeType(trialObj, typeof(T));
             return default;
         }
 
@@ -646,7 +644,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public bool IsEpitaphId(uint epitaphId)
         {
-            return _EpitaphAssets.EpitaphObjects.ContainsKey(epitaphId) || _TrialAssets.EpitahObjects.ContainsKey(epitaphId);
+            var epitaphObjects = _EpitaphAssets.EpitaphObjects;
+            var trialObjects = _TrialAssets.EpitahObjects;
+            return epitaphObjects.ContainsKey(epitaphId) || trialObjects.ContainsKey(epitaphId);
         }
 
         public EpitaphTrialOption GetTrialOption(PartyGroup party)
@@ -664,11 +664,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public EpitaphTrial GetTrial(StageLayoutId stageId, uint posId)
         {
-            if (_TrialAssets == null || !_TrialAssets.Trials.ContainsKey(stageId))
-            {
+            var trials = _TrialAssets?.Trials;
+            if (trials == null || !trials.TryGetValue(stageId, out var list))
                 return null;
-            }
-            return _TrialAssets.Trials[stageId].Where(x => x.PosId == posId).FirstOrDefault();
+            return list.FirstOrDefault(x => x.PosId == posId);
         }
 
         public EpitaphTrial GetTrial(uint epitaphId)
@@ -909,25 +908,19 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public List<CDataSoulOrdealItem> GetCostByEpitahId(uint epitahId)
         {
-            var result = new List<CDataSoulOrdealItem>();
+            var trialObjects = _TrialAssets.EpitahObjects;
+            if (trialObjects.TryGetValue(epitahId, out var trialObj) && trialObj is EpitaphTrial trial)
+                return trial.UnlockCost;
 
-            if (_Server.AssetRepository.EpitaphTrialAssets.EpitahObjects.ContainsKey(epitahId))
+            var epitaphObjects = _EpitaphAssets.EpitaphObjects;
+            if (epitaphObjects.TryGetValue(epitahId, out var epitaphObj))
             {
-                result = GetEpitahObject<EpitaphTrial>(epitahId).UnlockCost;
+                if (epitaphObj is EpitaphSection section)
+                    return section.UnlockCost;
+                if (epitaphObj is EpitaphBarrier barrier)
+                    return barrier.UnlockCost;
             }
-            else if (_Server.AssetRepository.EpitaphRoadAssets.EpitaphObjects.ContainsKey(epitahId))
-            {
-                var epitaphObject = _Server.AssetRepository.EpitaphRoadAssets.EpitaphObjects[epitahId];
-                if (epitaphObject is EpitaphSection section)
-                {
-                    result = section.UnlockCost;
-                }
-                else if (epitaphObject is EpitaphBarrier barrier)
-                {
-                    result = barrier.UnlockCost;
-                }
-            }
-            return result;
+            return new List<CDataSoulOrdealItem>();
         }
 
         public bool IsSectionUnlocked(Character character, uint epitaphId)

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -28,8 +28,14 @@ namespace Arrowgene.Ddon.GameServer.Characters
          * A QuestScheduleId should always get us back to a unique quest object.
          * A QuestId can return us a list of related QuestScheduleIds which all use the same QuestId.
          */
-        private static Dictionary<uint, Quest> gQuests = new Dictionary<uint, Quest>();
-        private static readonly Dictionary<QuestId, HashSet<uint>> gVariantQuests = new();
+        private static Dictionary<uint, Quest> gQuests = new();
+        private static Dictionary<QuestId, HashSet<uint>> gVariantQuests = new();
+
+        // Prevents two concurrent JSON reloads from interleaving their swaps.
+        // Readers never acquire this lock; they are safe because the swap replaces
+        // collection references rather than mutating live collections, so any reader
+        // that captured a reference before the swap iterates the old, immutable dict.
+        private static readonly object _reloadLock = new();
 
         private static Dictionary<QuestType, Dictionary<uint, HashSet<uint>>> QuestByStageNo = new();
         private static Dictionary<QuestAreaId, HashSet<QuestId>> gWorldQuests = new Dictionary<QuestAreaId, HashSet<QuestId>>();
@@ -50,52 +56,49 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         private static void AddQuestToCategory(Quest quest)
         {
-            if (!gVariantQuests.ContainsKey(quest.QuestId))
-            {
-                gVariantQuests[quest.QuestId] = new HashSet<uint>();
-            }
-            gVariantQuests[quest.QuestId].Add(quest.QuestScheduleId);
+            AddQuestToCollections(quest, gVariantQuests, QuestByStageNo, gWorldQuests, gAdventureGuideCategories, gAreaTrialRanks);
+        }
 
-            if ((quest.QuestType == QuestType.Tutorial) || (quest.QuestType == QuestType.Substory))
+        // Populates the supplied index collections with the quest. Callers pass either the
+        // live static dicts (initial load / scripted hotload) or freshly allocated locals
+        // (JSON hotload build-then-swap path).
+        private static void AddQuestToCollections(
+            Quest quest,
+            Dictionary<QuestId, HashSet<uint>> variantQuests,
+            Dictionary<QuestType, Dictionary<uint, HashSet<uint>>> questByStageNo,
+            Dictionary<QuestAreaId, HashSet<QuestId>> worldQuests,
+            Dictionary<QuestAdventureGuideCategory, HashSet<uint>> adventureGuideCategories,
+            Dictionary<QuestAreaId, Dictionary<uint, uint>> areaTrialRanks)
+        {
+            if (!variantQuests.ContainsKey(quest.QuestId))
+                variantQuests[quest.QuestId] = new HashSet<uint>();
+            variantQuests[quest.QuestId].Add(quest.QuestScheduleId);
+
+            if (quest.QuestType == QuestType.Tutorial || quest.QuestType == QuestType.Substory)
             {
                 uint stageNo = (uint)StageManager.ConvertIdToStageNo(quest.StageId);
-
-                if (!QuestByStageNo.ContainsKey(quest.QuestType))
-                {
-                    QuestByStageNo[quest.QuestType] = new();
-                }
-
-                var questDict = QuestByStageNo[quest.QuestType];
+                if (!questByStageNo.ContainsKey(quest.QuestType))
+                    questByStageNo[quest.QuestType] = new();
+                var questDict = questByStageNo[quest.QuestType];
                 if (!questDict.ContainsKey(stageNo))
-                {
                     questDict[stageNo] = new HashSet<uint>();
-                }
                 questDict[stageNo].Add(quest.QuestScheduleId);
             }
             else if (quest.QuestType == QuestType.World)
             {
-                if (!gWorldQuests.ContainsKey(quest.QuestAreaId))
-                {
-                    gWorldQuests[quest.QuestAreaId] = new HashSet<QuestId>();
-                }
-                gWorldQuests[quest.QuestAreaId].Add(quest.QuestId);
+                if (!worldQuests.ContainsKey(quest.QuestAreaId))
+                    worldQuests[quest.QuestAreaId] = new HashSet<QuestId>();
+                worldQuests[quest.QuestAreaId].Add(quest.QuestId);
             }
 
-            if (!gAdventureGuideCategories.ContainsKey(quest.AdventureGuideCategory))
-            {
-                gAdventureGuideCategories[quest.AdventureGuideCategory] = new HashSet<uint>();
-            }
-            gAdventureGuideCategories[quest.AdventureGuideCategory].Add(quest.QuestScheduleId);
+            if (!adventureGuideCategories.ContainsKey(quest.AdventureGuideCategory))
+                adventureGuideCategories[quest.AdventureGuideCategory] = new HashSet<uint>();
+            adventureGuideCategories[quest.AdventureGuideCategory].Add(quest.QuestScheduleId);
 
             // Build a ranking list for quests for area trials
             // TODO: This should probably be done in quest scripts, but who wants to rewrite 70+ quests?
             if (quest.AdventureGuideCategory == QuestAdventureGuideCategory.AreaTrialOrMission)
             {
-                if (!gAreaTrialRanks.ContainsKey(quest.QuestAreaId))
-                {
-                    gAreaTrialRanks[quest.QuestAreaId] = new Dictionary<uint, uint>();
-                }
-
                 // Search all process states for a CheckAreaRank command rather than assuming
                 // it is always the very first command - JSON quests and scripted .csx quests
                 // serialize their process state lists differently, so .First() is unreliable.
@@ -114,9 +117,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
                             {
                                 requiredRank = (uint)cmd.Param02;
                                 if (areaId == QuestAreaId.None)
-                                {
                                     areaId = (QuestAreaId)cmd.Param01;
-                                }
                                 found = true;
                                 break;
                             }
@@ -128,11 +129,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
                 if (found)
                 {
-                    if (!gAreaTrialRanks.ContainsKey(areaId))
-                    {
-                        gAreaTrialRanks[areaId] = new Dictionary<uint, uint>();
-                    }
-                    gAreaTrialRanks[areaId][quest.QuestScheduleId] = requiredRank;
+                    if (!areaTrialRanks.ContainsKey(areaId))
+                        areaTrialRanks[areaId] = new Dictionary<uint, uint>();
+                    areaTrialRanks[areaId][quest.QuestScheduleId] = requiredRank;
                 }
             }
         }
@@ -246,6 +245,57 @@ namespace Arrowgene.Ddon.GameServer.Characters
             ComputeSubstoryLookups(server);
         }
 
+        public static void ReloadJsonQuests(DdonGameServer server)
+        {
+            Logger.Info($"Hotloading JSON quests...");
+
+            // Build entirely new index collections without touching live state.
+            // Scripted quests are preserved by copying them from a snapshot of the
+            // current live collections; JSON quests are discarded and rebuilt from
+            // the freshly loaded asset data.
+            var newQuests = new Dictionary<uint, Quest>();
+            var newVariantQuests = new Dictionary<QuestId, HashSet<uint>>();
+            var newQuestByStageNo = new Dictionary<QuestType, Dictionary<uint, HashSet<uint>>>();
+            var newWorldQuests = new Dictionary<QuestAreaId, HashSet<QuestId>>();
+            var newAdventureGuideCategories = new Dictionary<QuestAdventureGuideCategory, HashSet<uint>>();
+            var newAreaTrialRanks = new Dictionary<QuestAreaId, Dictionary<uint, uint>>();
+
+            // Snapshot current reference so we iterate a stable collection.
+            var currentQuests = gQuests;
+            foreach (var (scheduleId, quest) in currentQuests)
+            {
+                if (quest.QuestSource == QuestSource.Json)
+                    continue;
+                newQuests[scheduleId] = quest;
+                AddQuestToCollections(quest, newVariantQuests, newQuestByStageNo, newWorldQuests, newAdventureGuideCategories, newAreaTrialRanks);
+            }
+
+            foreach (var questAsset in server.AssetRepository.QuestAssets.Quests)
+            {
+                var quest = GenericQuest.FromAsset(server, questAsset);
+                newQuests[quest.QuestScheduleId] = quest;
+                if (quest.Enabled)
+                    AddQuestToCollections(quest, newVariantQuests, newQuestByStageNo, newWorldQuests, newAdventureGuideCategories, newAreaTrialRanks);
+            }
+
+            // Atomically swap all references under a lock to prevent two concurrent
+            // reloads from interleaving. Readers never acquire this lock; they are
+            // safe because swapping the reference (not mutating the dict) means any
+            // reader that already holds a reference to the old collection will
+            // finish iterating it without a "Collection was modified" exception.
+            lock (_reloadLock)
+            {
+                gQuests = newQuests;
+                gVariantQuests = newVariantQuests;
+                QuestByStageNo = newQuestByStageNo;
+                gWorldQuests = newWorldQuests;
+                gAdventureGuideCategories = newAdventureGuideCategories;
+                gAreaTrialRanks = newAreaTrialRanks;
+            }
+
+            Logger.Info($"JSON quest file reloaded. {server.AssetRepository.QuestAssets.Quests.Count} JSON quests total in memory.");
+        }
+
         public static void LoadLightQuests(DdonGameServer server)
         {
             foreach(var quest in server.LightQuestManager.ReadQuests(true))
@@ -282,12 +332,8 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public static HashSet<QuestId> GetWorldQuestIdsByAreaId(QuestAreaId areaId)
         {
-            if (!gWorldQuests.ContainsKey(areaId))
-            {
-                return new HashSet<QuestId>();
-            }
-
-            return gWorldQuests[areaId];
+            var snapshot = gWorldQuests;
+            return snapshot.TryGetValue(areaId, out var ids) ? ids : new HashSet<QuestId>();
         }
 
         public static Quest GetQuestByBoardId(ulong boardId)
@@ -298,16 +344,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public static HashSet<uint> GetQuestByStageNo(QuestType questType, uint stageNo)
         {
-            if (!QuestByStageNo.ContainsKey(questType))
-            {
+            var snapshot = QuestByStageNo;
+            if (!snapshot.TryGetValue(questType, out var byStage))
                 return new();
-            }
-
-            if (!QuestByStageNo[questType].ContainsKey(stageNo))
-            {
-                return new();
-            }
-            return QuestByStageNo[questType][stageNo];
+            return byStage.TryGetValue(stageNo, out var ids) ? ids : new();
         }
 
         public static bool IsVariantQuest(QuestId baseQuestId)
@@ -317,17 +357,12 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public static Quest GetQuestByScheduleId(uint questScheduleId)
         {
-            if (!gQuests.ContainsKey(questScheduleId))
-            {
-                if (!KnownBadQuestScheduleIds.Contains(questScheduleId) && !IsBoardQuest(questScheduleId))
-                {
-                    Logger.Error($"GetQuestByScheduleId: Invalid questScheduleId {questScheduleId}");
-                }
-
-                return null;
-            }
-
-            return gQuests[questScheduleId];
+            var snapshot = gQuests;
+            if (snapshot.TryGetValue(questScheduleId, out var quest))
+                return quest;
+            if (!KnownBadQuestScheduleIds.Contains(questScheduleId) && !IsBoardQuest(questScheduleId))
+                Logger.Error($"GetQuestByScheduleId: Invalid questScheduleId {questScheduleId}");
+            return null;
         }
 
         public static Quest GetQuestByQuestId(QuestId questId)
@@ -351,27 +386,22 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
         public static HashSet<uint> GetQuestScheduleIdsForQuestId(QuestId questId)
         {
-            if (gVariantQuests.ContainsKey(questId))
-            {
-                return gVariantQuests[questId];
-            }
-            return new HashSet<uint>();
+            var snapshot = gVariantQuests;
+            return snapshot.TryGetValue(questId, out var ids) ? ids : new HashSet<uint>();
         }
 
         public static Quest RollQuestForQuestId(QuestId questId)
         {
             var quests = GetQuestScheduleIdsForQuestId(questId);
             var questScheduleId = quests.ElementAt(Random.Shared.Next(0, quests.Count));
-            return gQuests[questScheduleId];
+            var snapshot = gQuests;
+            return snapshot.TryGetValue(questScheduleId, out var quest) ? quest : null;
         }
 
         public static HashSet<uint> GetQuestsByAdventureGuideCategory(QuestAdventureGuideCategory category)
         {
-            if (!gAdventureGuideCategories.ContainsKey(category))
-            {
-                return new();
-            }
-            return gAdventureGuideCategories[category].ToHashSet();
+            var snapshot = gAdventureGuideCategories;
+            return snapshot.TryGetValue(category, out var ids) ? ids.ToHashSet() : new();
         }
 
         public static bool IsQuestEnabled(uint questScheduleId)

--- a/Arrowgene.Ddon.GameServer/DdonGameServer.cs
+++ b/Arrowgene.Ddon.GameServer/DdonGameServer.cs
@@ -163,6 +163,8 @@ namespace Arrowgene.Ddon.GameServer
             WorldQuestManager.Initialize();
             GpCourseManager.EvaluateCourses();
 
+            AssetRepository.AssetChanged += OnAssetChanged;
+
             if (ServerUtils.IsHeadServer(this))
             {
                 ScheduleManager.StartServerTasks();
@@ -171,6 +173,19 @@ namespace Arrowgene.Ddon.GameServer
             LoadChatHandler();
             LoadPacketHandler();
             base.Start();
+        }
+
+        private void OnAssetChanged(object sender, AssetChangedEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case AssetRepository.QuestAssestKey:
+                    QuestManager.ReloadJsonQuests(this);
+                    break;
+                case AssetRepository.EpitaphAssestKey:
+                    Logger.Info("Epitaph trial JSON directory changed, hotloaded.");
+                    break;
+            }
         }
 
         protected override void ClientConnected(GameClient client)

--- a/Arrowgene.Ddon.Shared/Asset/EpitaphTrialAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/EpitaphTrialAsset.cs
@@ -202,6 +202,7 @@ namespace Arrowgene.Ddon.Shared.Asset
 
         public StageLayoutId OmLayoutId { get; set; }
         public uint PosId { get; set; }
+        public string SourceFile { get; set; }
         public List<EpitaphTrialOption> Options { get; set; }
         public List<CDataSoulOrdealItem> UnlockCost { get; set; }
         public List<(StageLayoutId StageId, uint PosId)> Unlocks { get; set; }

--- a/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
+++ b/Arrowgene.Ddon.Shared/Asset/QuestAsset.cs
@@ -61,6 +61,7 @@ namespace Arrowgene.Ddon.Shared.Asset
         public bool OverrideEnemySpawn { get; set; }
         public bool EnableCancel { get; set; }
         public QuestSource QuestSource { get; set; }
+        public string SourceFile { get; set; }
 
         public List<QuestPointReward> PointRewards { get; set; }
 

--- a/Arrowgene.Ddon.Shared/AssetReader/EpitaphTrialAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/EpitaphTrialAssetDeserializer.cs
@@ -6,21 +6,86 @@ using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 
 namespace Arrowgene.Ddon.Shared.AssetReader
 {
-    public class EpitaphTrialAssetDeserializer
+    public class EpitaphTrialAssetDeserializer : IDirectoryAssetHandler
     {
         private static readonly ILogger Logger = LogProvider.Logger(typeof(EpitaphTrialAssetDeserializer));
 
         private AssetCommonDeserializer _CommonEnemyDeserializer;
         private QuestDropItemAsset _QuestDrops;
+        private readonly EpitaphTrialAsset _liveAsset;
 
-        public EpitaphTrialAssetDeserializer(AssetCommonDeserializer commonEnemyDeserializer, QuestDropItemAsset questDrops)
+        public EpitaphTrialAssetDeserializer(AssetCommonDeserializer commonEnemyDeserializer, QuestDropItemAsset questDrops, EpitaphTrialAsset liveAsset)
         {
             _CommonEnemyDeserializer = commonEnemyDeserializer;
             _QuestDrops = questDrops;
+            _liveAsset = liveAsset;
+        }
+
+        public string DirectoryKey => AssetRepository.EpitaphAssestKey;
+        public string Filter => "*.json";
+        public object LiveAsset => _liveAsset;
+
+        public bool OnFileChanged(string filePath)
+        {
+            var freshEntry = new EpitaphTrialAsset();
+            if (!LoadTrialFromFile(filePath, freshEntry))
+                return false;
+
+            var newTrials = BuildTrialsExcluding(filePath);
+            foreach (var (k, v) in freshEntry.Trials)
+            {
+                if (!newTrials.ContainsKey(k))
+                    newTrials[k] = new List<EpitaphTrial>();
+                newTrials[k].AddRange(v);
+            }
+
+            var newObjects = BuildObjectsExcluding(filePath);
+            foreach (var (k, v) in freshEntry.EpitahObjects)
+                newObjects[k] = v;
+
+            _liveAsset.Trials = newTrials;
+            _liveAsset.EpitahObjects = newObjects;
+            return true;
+        }
+
+        public void OnFileRemoved(string filePath)
+        {
+            _liveAsset.Trials = BuildTrialsExcluding(filePath);
+            _liveAsset.EpitahObjects = BuildObjectsExcluding(filePath);
+        }
+
+        private Dictionary<StageLayoutId, List<EpitaphTrial>> BuildTrialsExcluding(string filePath)
+        {
+            var result = new Dictionary<StageLayoutId, List<EpitaphTrial>>();
+            foreach (var (stageId, list) in _liveAsset.Trials)
+            {
+                var kept = list.Where(t => t.SourceFile != filePath).ToList();
+                if (kept.Count > 0)
+                    result[stageId] = kept;
+            }
+            return result;
+        }
+
+        private Dictionary<uint, EpitaphObject> BuildObjectsExcluding(string filePath)
+        {
+            var result = new Dictionary<uint, EpitaphObject>();
+            foreach (var (id, obj) in _liveAsset.EpitahObjects)
+            {
+                bool fromFile = obj switch
+                {
+                    EpitaphTrial t => t.SourceFile == filePath,
+                    EpitaphTrialOption opt => opt.Parent.SourceFile == filePath,
+                    _ => false
+                };
+                if (!fromFile)
+                    result[id] = obj;
+            }
+            return result;
         }
 
         public bool LoadTrialsFromDirectory(string path, EpitaphTrialAsset trialAssets)
@@ -35,34 +100,41 @@ namespace Arrowgene.Ddon.Shared.AssetReader
             Logger.Info($"Reading epitaph road trial files from {path}");
             foreach (var file in info.EnumerateFiles())
             {
-                Logger.Info($"{file.FullName}");
+                LoadTrialFromFile(file.FullName, trialAssets);
+            }
 
-                string json = Util.ReadAllText(file.FullName);
-                JsonDocument document = JsonDocument.Parse(json);
+            return true;
+        }
 
-                var assetData = new EpitaphTrial();
-                if (!ParseTrial(assetData, document.RootElement))
+        public bool LoadTrialFromFile(string filePath, EpitaphTrialAsset trialAssets)
+        {
+            Logger.Info($"{filePath}");
+
+            string json = Util.ReadAllText(filePath);
+            JsonDocument document = JsonDocument.Parse(json);
+
+            var assetData = new EpitaphTrial() { SourceFile = filePath };
+            if (!ParseTrial(assetData, document.RootElement))
+            {
+                Logger.Error($"Unable to parse '{filePath}'. Skipping.");
+                return false;
+            }
+
+            if (!trialAssets.Trials.ContainsKey(assetData.OmLayoutId))
+            {
+                trialAssets.Trials[assetData.OmLayoutId] = new List<EpitaphTrial>();
+            }
+
+            trialAssets.Trials[assetData.OmLayoutId].Add(assetData);
+            trialAssets.EpitahObjects[assetData.EpitaphId] = assetData;
+
+            foreach (var option in assetData.Options)
+            {
+                if (trialAssets.EpitahObjects.ContainsKey(option.EpitaphId))
                 {
-                    Logger.Error($"Unable to parse '{file.FullName}'. Skipping.");
-                    continue;
+                    Logger.Error($"Multiple Epitaph trials options have TrialId={option.EpitaphId}");
                 }
-
-                if (!trialAssets.Trials.ContainsKey(assetData.OmLayoutId))
-                {
-                    trialAssets.Trials[assetData.OmLayoutId] = new List<EpitaphTrial>();
-                }
-
-                trialAssets.Trials[assetData.OmLayoutId].Add(assetData);
-                trialAssets.EpitahObjects[assetData.EpitaphId] = assetData;
-
-                foreach (var option in assetData.Options)
-                {
-                    if (trialAssets.EpitahObjects.ContainsKey(option.EpitaphId))
-                    {
-                        Logger.Error($"Multiple Epitaph trials options have TrialId={option.EpitaphId}");
-                    }
-                    trialAssets.EpitahObjects[option.EpitaphId] = option;
-                }
+                trialAssets.EpitahObjects[option.EpitaphId] = option;
             }
 
             return true;

--- a/Arrowgene.Ddon.Shared/AssetReader/IDirectoryAssetHandler.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/IDirectoryAssetHandler.cs
@@ -1,0 +1,11 @@
+namespace Arrowgene.Ddon.Shared.AssetReader
+{
+    public interface IDirectoryAssetHandler
+    {
+        string DirectoryKey { get; }
+        string Filter { get; }
+        object LiveAsset { get; }
+        bool OnFileChanged(string filePath);
+        void OnFileRemoved(string filePath);
+    }
+}

--- a/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
+++ b/Arrowgene.Ddon.Shared/AssetReader/QuestAssetDeserializer.cs
@@ -11,22 +11,43 @@ using System.Text.Json;
 
 namespace Arrowgene.Ddon.Shared.AssetReader
 {
-    public class QuestAssetDeserializer
+    public class QuestAssetDeserializer : IDirectoryAssetHandler
     {
         private static readonly ILogger Logger = LogProvider.Logger(typeof(QuestAssetDeserializer));
 
         private QuestDropItemAsset _QuestDrops;
         private AssetCommonDeserializer _CommonEnemyDeserializer;
         private Dictionary<QuestId, uint> _QuestScheduleIdAsset;
+        private readonly QuestAsset _liveAsset;
 
-        public QuestAssetDeserializer(AssetCommonDeserializer commonEnemyDeserializer, QuestDropItemAsset questDrops, Dictionary<QuestId, uint> scheduleIdAsset)
+        public QuestAssetDeserializer(AssetCommonDeserializer commonEnemyDeserializer, QuestDropItemAsset questDrops, Dictionary<QuestId, uint> scheduleIdAsset, QuestAsset liveAsset)
         {
             _QuestDrops = questDrops;
             _CommonEnemyDeserializer = commonEnemyDeserializer;
             _QuestScheduleIdAsset = scheduleIdAsset;
+            _liveAsset = liveAsset;
 
             // Force this class to be invoked so we can look up flags during deserialization
             QuestFlags.InvokeTypeInitializer();
+        }
+
+        public string DirectoryKey => AssetRepository.QuestAssestKey;
+        public string Filter => "*.json";
+        public object LiveAsset => _liveAsset;
+
+        public bool OnFileChanged(string filePath)
+        {
+            var freshEntry = new QuestAsset();
+            if (!LoadQuestFromFile(filePath, freshEntry))
+                return false;
+            OnFileRemoved(filePath);
+            _liveAsset.Quests.AddRange(freshEntry.Quests);
+            return true;
+        }
+
+        public void OnFileRemoved(string filePath)
+        {
+            _liveAsset.Quests.RemoveAll(q => q.SourceFile == filePath);
         }
 
         public bool LoadQuestsFromDirectory(string path, QuestAsset questAssets)
@@ -41,38 +62,45 @@ namespace Arrowgene.Ddon.Shared.AssetReader
             Logger.Info($"Reading quest files from {path}");
             foreach (var file in info.EnumerateFiles())
             {
-                Logger.Info($"{file.FullName}");
-
-                string json = Util.ReadAllText(file.FullName);
-                JsonDocument document = JsonDocument.Parse(json);
-
-                var jQuest = document.RootElement;
-                if (!Enum.TryParse(jQuest.GetProperty("state_machine").GetString(), true, out QuestStateMachineType questStateMachineType))
-                {
-                    Logger.Error($"Expected key 'state_machine' not in the root of the document. Unable to parse {file.FullName}.");
-                    continue;
-                }
-
-                if (questStateMachineType != QuestStateMachineType.GenericStateMachine)
-                {
-                    Logger.Error($"Unsupported QuestStateMachineType '{questStateMachineType}'. Unable to parse {file.FullName}.");
-                    continue;
-                }
-
-                QuestAssetData assetData = new QuestAssetData()
-                {
-                    QuestSource = QuestSource.Json
-                };
-
-                if (!ParseQuest(assetData, jQuest))
-                {
-                    Logger.Error($"Unable to parse '{file.FullName}'. Skipping.");
-                    continue;
-                }
-
-                questAssets.Quests.Add(assetData);
+                LoadQuestFromFile(file.FullName, questAssets);
             }
 
+            return true;
+        }
+
+        public bool LoadQuestFromFile(string filePath, QuestAsset questAssets)
+        {
+            Logger.Info($"{filePath}");
+
+            string json = Util.ReadAllText(filePath);
+            JsonDocument document = JsonDocument.Parse(json);
+
+            var jQuest = document.RootElement;
+            if (!Enum.TryParse(jQuest.GetProperty("state_machine").GetString(), true, out QuestStateMachineType questStateMachineType))
+            {
+                Logger.Error($"Expected key 'state_machine' not in the root of the document. Unable to parse {filePath}.");
+                return false;
+            }
+
+            if (questStateMachineType != QuestStateMachineType.GenericStateMachine)
+            {
+                Logger.Error($"Unsupported QuestStateMachineType '{questStateMachineType}'. Unable to parse {filePath}.");
+                return false;
+            }
+
+            QuestAssetData assetData = new QuestAssetData()
+            {
+                QuestSource = QuestSource.Json,
+                SourceFile = filePath
+            };
+
+            if (!ParseQuest(assetData, jQuest))
+            {
+                Logger.Error($"Unable to parse '{filePath}'. Skipping.");
+                return false;
+            }
+
+            questAssets.Quests.Add(assetData);
             return true;
         }
 

--- a/Arrowgene.Ddon.Shared/AssetRepository.cs
+++ b/Arrowgene.Ddon.Shared/AssetRepository.cs
@@ -248,11 +248,121 @@ namespace Arrowgene.Ddon.Shared
             // This must be set before calling QuestAssetDeserializer and EpitaphTrialAssetDeserializer
             var commonEnemyDeserializer = new AssetCommonDeserializer(this.NamedParamAsset);
 
-            var questAssetDeserializer = new QuestAssetDeserializer(commonEnemyDeserializer, QuestDropItemAsset, QuestScheduleIdAsset);
+            var questAssetDeserializer = new QuestAssetDeserializer(commonEnemyDeserializer, QuestDropItemAsset, QuestScheduleIdAsset, QuestAssets);
             questAssetDeserializer.LoadQuestsFromDirectory(Path.Combine(_directory.FullName, QuestAssestKey), QuestAssets);
+            RegisterDirectoryWatcher(questAssetDeserializer);
 
-            var epitaphTrialDeserializer = new EpitaphTrialAssetDeserializer(commonEnemyDeserializer, QuestDropItemAsset);
+            var epitaphTrialDeserializer = new EpitaphTrialAssetDeserializer(commonEnemyDeserializer, QuestDropItemAsset, EpitaphTrialAssets);
             epitaphTrialDeserializer.LoadTrialsFromDirectory(Path.Combine(_directory.FullName, EpitaphAssestKey), EpitaphTrialAssets);
+            RegisterDirectoryWatcher(epitaphTrialDeserializer);
+        }
+
+        private void RegisterDirectoryWatcher(IDirectoryAssetHandler handler)
+        {
+            string dirPath = Path.Combine(_directory.FullName, handler.DirectoryKey);
+            if (_fileSystemWatchers.ContainsKey(handler.DirectoryKey) || !Directory.Exists(dirPath))
+                return;
+
+            // One lock per directory: serializes concurrent watcher callbacks and holds
+            // through OnAssetChanged so downstream consumers (e.g. QuestManager.ReloadJsonQuests)
+            // cannot read the live asset list while a callback is still mutating it.
+            var handlerLock = new object();
+            var debounceTimers = new Dictionary<string, Timer>();
+            const int DebounceMs = 200;
+
+            void scheduleChange(string fullPath)
+            {
+                lock (handlerLock)
+                {
+                    if (debounceTimers.TryGetValue(fullPath, out var existing))
+                    {
+                        existing.Change(DebounceMs, Timeout.Infinite);
+                    }
+                    else
+                    {
+                        debounceTimers[fullPath] = new Timer(_ =>
+                        {
+                            lock (handlerLock)
+                                debounceTimers.Remove(fullPath);
+                            ReloadWithRetry(fullPath, () =>
+                            {
+                                lock (handlerLock)
+                                {
+                                    if (handler.OnFileChanged(fullPath))
+                                        OnAssetChanged(handler.DirectoryKey, handler.LiveAsset);
+                                }
+                            });
+                        }, null, DebounceMs, Timeout.Infinite);
+                    }
+                }
+            }
+
+            void handleDelete(string fullPath)
+            {
+                lock (handlerLock)
+                {
+                    if (debounceTimers.TryGetValue(fullPath, out var timer))
+                    {
+                        timer.Dispose();
+                        debounceTimers.Remove(fullPath);
+                    }
+                    handler.OnFileRemoved(fullPath);
+                    OnAssetChanged(handler.DirectoryKey, handler.LiveAsset);
+                }
+            }
+
+            bool matchesFilter(string path)
+            {
+                if (handler.Filter == "*" || handler.Filter == "*.*")
+                    return true;
+                if (handler.Filter.StartsWith("*."))
+                    return path.EndsWith(handler.Filter[1..], StringComparison.OrdinalIgnoreCase);
+                return string.Equals(Path.GetFileName(path), handler.Filter, StringComparison.OrdinalIgnoreCase);
+            }
+
+            FileSystemWatcher watcher = new FileSystemWatcher(dirPath, handler.Filter);
+            watcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime;
+            watcher.Changed += (s, e) => scheduleChange(e.FullPath);
+            watcher.Created += (s, e) => scheduleChange(e.FullPath);
+            watcher.Deleted += (s, e) => handleDelete(e.FullPath);
+            watcher.Renamed += (s, e) =>
+            {
+                if (matchesFilter(e.OldFullPath))
+                    handleDelete(e.OldFullPath);
+                if (matchesFilter(e.FullPath))
+                    scheduleChange(e.FullPath);
+            };
+            watcher.EnableRaisingEvents = true;
+            _fileSystemWatchers.Add(handler.DirectoryKey, watcher);
+        }
+
+        private void ReloadWithRetry(string filePath, Action action)
+        {
+            int attempts = 0;
+            while (true)
+            {
+                try
+                {
+                    action();
+                    break;
+                }
+                catch (IOException ex)
+                {
+                    attempts++;
+                    Logger.Info($"Attempt {attempts} to reload '{filePath}' unsuccessful.");
+                    if (attempts > 10)
+                    {
+                        Logger.Write(LogLevel.Error, $"Failed to reload '{filePath}' after {attempts} attempts. Giving up.", ex);
+                        break;
+                    }
+                    Thread.Sleep(1000);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Write(LogLevel.Error, $"Failed to reload '{filePath}' due to a parse error. Live data is unchanged.", ex);
+                    break;
+                }
+            }
         }
 
         private void RegisterAsset<T>(Action<T> onLoadAction, string key, IAssetDeserializer<T> readerWriter)


### PR DESCRIPTION
When a JSON file under Assets/quests/ or Assets/epitaph/ is saved, created, renamed, or deleted at runtime, only that file is reloaded.

- Add IDirectoryAssetHandler so each deserializer owns its reload logic, keeping AssetRepository generic.
- Debounce watcher events with a trailing-edge timer per path so rapid editor saves collapse into one reload.
- Build-then-swap on EpitaphTrialAsset dictionaries so concurrent readers always see a stable snapshot.
- Remove _jsonQuestScheduleIds; QuestManager.ReloadJsonQuests now identifies JSON quests by QuestSource.Json.
- Fix ContainsKey + [] TOCTOU races in QuestManager and EpitaphRoadManager by capturing dict references into locals and using TryGetValue.

When developing quests use the chat command `/quest reload` to force the client to fetch the latest quest state from the server.