### PR TITLE
Enable Server to connect to different Postgres DB Ports.

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -101,7 +101,7 @@ public static class DdonDatabaseBuilder
 
     private static DdonPostgresDb BuildPostgres(DatabaseSetting settings)
     {
-        DdonPostgresDb db = new(settings.Host, settings.User, settings.Password, settings.Database, settings.WipeOnStartup, settings.BufferSize, settings.NoResetOnClose, settings.EnablePooling, settings.EnableTracing, settings.MaxAutoPrepare);
+        DdonPostgresDb db = new(settings.Host, settings.Port, settings.User, settings.Password, settings.Database, settings.WipeOnStartup, settings.BufferSize, settings.NoResetOnClose, settings.EnablePooling, settings.EnableTracing, settings.MaxAutoPrepare);
         if (db.CreateDatabase())
         {
             string schemaFilePath = Path.Combine(settings.DatabaseFolder, DefaultSchemaFile);

--- a/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
+++ b/Arrowgene.Ddon.Database/Sql/DdonPostgresDb.cs
@@ -14,10 +14,10 @@ public partial class DdonPostgresDb : DdonSqlDb
     private readonly string _connectionString;
     private NpgsqlDataSource _dataSource;
 
-    public DdonPostgresDb(string host, string user, string password, string database, bool wipeOnStartup, uint bufferSize, bool noResetOnClose, bool enablePooling,
+    public DdonPostgresDb(string host, short port, string user, string password, string database, bool wipeOnStartup, uint bufferSize, bool noResetOnClose, bool enablePooling,
         bool enableTracing, uint maxAutoPrepare)
     {
-        _connectionString = BuildConnectionString(host, user, password, database, bufferSize, noResetOnClose, enablePooling, enableTracing, maxAutoPrepare);
+        _connectionString = BuildConnectionString(host, port, user, password, database, bufferSize, noResetOnClose, enablePooling, enableTracing, maxAutoPrepare);
         if (wipeOnStartup) Logger.Info("WipeOnStartup is currently not supported.");
     }
 
@@ -65,12 +65,13 @@ public partial class DdonPostgresDb : DdonSqlDb
         _dataSource.Dispose();
     }
 
-    private string BuildConnectionString(string host, string user, string password, string database, uint bufferSize, bool noResetOnClose, bool enablePooling, bool enableTracing,
+    private string BuildConnectionString(string host, short port, string user, string password, string database, uint bufferSize, bool noResetOnClose, bool enablePooling, bool enableTracing,
         uint maxAutoPrepare)
     {
         NpgsqlConnectionStringBuilder builder = new()
         {
             Host = host,
+            Port = port,
             Username = user,
             Password = password,
             Database = database,


### PR DESCRIPTION
A small code fix to have the Server be able to connect to a Postgres DB on a non-default port.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
