### PR TITLE
[Draft] Feature/Online Status Sync

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 62;
+    public const uint Version = 63;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_synconlinestatus.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_synconlinestatus.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "ddon_character_common"
+ADD COLUMN "saved_online_status" INTEGER NOT NULL DEFAULT 1;

--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -61,7 +61,8 @@ CREATE TABLE IF NOT EXISTS "ddon_character_common"
     "character_common_id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     "job"                 SMALLINT                          NOT NULL,
     "hide_equip_head"     BOOLEAN                           NOT NULL,
-    "hide_equip_lantern"  BOOLEAN                           NOT NULL
+    "hide_equip_lantern"  BOOLEAN                           NOT NULL,
+    "saved_online_status" INTEGER                           NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS "ddon_character"

--- a/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/DdonSqlDbCharacterCommon.cs
@@ -15,7 +15,7 @@ public partial class DdonSqlDb : SqlDb
 
     private static readonly string[] CharacterCommonFields = new[]
     {
-        "job", "hide_equip_head", "hide_equip_lantern"
+        "job", "hide_equip_head", "hide_equip_lantern", "saved_online_status"
     };
 
     private static readonly string[] CDataEditInfoFields = new[]
@@ -431,6 +431,7 @@ public partial class DdonSqlDb : SqlDb
         common.HideEquipHead = GetBoolean(reader, "hide_equip_head");
         common.HideEquipLantern = GetBoolean(reader, "hide_equip_lantern");
         common.JewelrySlotNum = 0;
+        common.SavedOnlineStatus = (OnlineStatus)GetByte(reader, "saved_online_status");
 
         common.EditInfo.Sex = GetByte(reader, "sex");
         common.EditInfo.Voice = GetByte(reader, "voice");
@@ -532,6 +533,7 @@ public partial class DdonSqlDb : SqlDb
         AddParameter(command, "@job", (byte)common.Job);
         AddParameter(command, "@hide_equip_head", common.HideEquipHead);
         AddParameter(command, "@hide_equip_lantern", common.HideEquipLantern);
+        AddParameter(command, "@saved_online_status", (byte)common.SavedOnlineStatus);
         // CDataEditInfoFields
         AddParameter(command, "@sex", common.EditInfo.Sex);
         AddParameter(command, "@voice", common.EditInfo.Voice);

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000063_SyncOnlineStatusMigration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000063_SyncOnlineStatusMigration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class SyncOnlineStatusMigration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 62;
+        public uint To => 63;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/migration_synconlinestatus.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -5,6 +5,7 @@ using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Model.Quest;
+using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Logging;
 using System;
 using System.Collections.Generic;
@@ -95,6 +96,18 @@ namespace Arrowgene.Ddon.GameServer.Characters
 
                 return character;
             });
+        }
+
+        public static OnlineStatus GetDefaultOnlineStatus(Character character)
+        {
+            return character.SavedOnlineStatus switch
+            {
+                OnlineStatus.Online => OnlineStatus.Online,
+                OnlineStatus.Offline => OnlineStatus.Offline,
+                OnlineStatus.Leaving => OnlineStatus.Leaving,
+                OnlineStatus.Busy => OnlineStatus.Busy,
+                _ => OnlineStatus.Online
+            };
         }
 
         /**
@@ -375,6 +388,17 @@ namespace Arrowgene.Ddon.GameServer.Characters
             {
                 memberClient.Send(charUpdateNtc);
             }
+
+            Server.RpcManager.AnnounceOthers(
+                "internal/command",
+                RpcInternalCommand.NotifyOnlineStatusChanged,
+                new RpcOnlineStatusData()
+                {
+                    CharacterId = character.CharacterId,
+                    ServerId = (ushort)Server.Id,
+                    OnlineStatus = onlineStatus
+                }
+            );
         }
 
         public uint GetMaxAugmentAllocation(CharacterCommon character)

--- a/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/CharacterManager.cs
@@ -43,6 +43,8 @@ namespace Arrowgene.Ddon.GameServer.Characters
                     return null;
                 }
 
+                character.OnlineStatus = character.SavedOnlineStatus;
+
                 character.Server = Server.AssetRepository.ServerList.Where(server => server.Id == Server.Id).Single().ToCDataGameServerListInfo();
                 
                 // Apply Emblem stats before setting up character equipment

--- a/Arrowgene.Ddon.GameServer/Characters/ClanManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ClanManager.cs
@@ -473,11 +473,11 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 }
                 else
                 {
-                    var channelId = Server.RpcManager.FindPlayerById(memberInfo.CharacterId);
-                    if (channelId > 0)
+                    var presence = Server.RpcManager.FindPlayerPresenceById(memberInfo.CharacterId);
+                    if (presence.ChannelId > 0)
                     {
-                        member.CharacterListElement.OnlineStatus = OnlineStatus.Online;
-                        member.CharacterListElement.ServerId = channelId;
+                        member.CharacterListElement.OnlineStatus = presence.OnlineStatus;
+                        member.CharacterListElement.ServerId = presence.ChannelId;
                     }
                     else
                     {

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterCommunityCharacterStatusGetHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterCommunityCharacterStatusGetHandler.cs
@@ -37,11 +37,11 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 }
                 else
                 {
-                    var matchServer = Server.RpcManager.FindPlayerById(character.CommunityCharacterBaseInfo.CharacterId);
-                    if (matchServer != 0)
+                    var presence = Server.RpcManager.FindPlayerPresenceById(character.CommunityCharacterBaseInfo.CharacterId);
+                    if (presence.ChannelId != 0)
                     {
-                        character.OnlineStatus = OnlineStatus.Online; // TODO
-                        character.ServerId = matchServer;
+                        character.OnlineStatus = presence.OnlineStatus;
+                        character.ServerId = presence.ChannelId;
                     }
                     else
                     {

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterSetOnlineStatusHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterSetOnlineStatusHandler.cs
@@ -1,5 +1,6 @@
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
+using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -12,12 +13,23 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
+        private static bool IsPersistentOnlineStatus(OnlineStatus status)
+        {
+            return status == OnlineStatus.Online
+                || status == OnlineStatus.Offline
+                || status == OnlineStatus.Leaving
+                || status == OnlineStatus.Busy;
+        }
 
         public override S2CCharacterSetOnlineStatusRes Handle(GameClient client, C2SCharacterSetOnlineStatusReq request)
         {
-            client.Character.OnlineStatus = request.OnlineStatus;
+            Server.CharacterManager.UpdateOnlineStatus(client, client.Character, request.OnlineStatus);
 
-            // TODO: Figure out request.IsSaveSetting
+            if (request.IsSaveSetting && IsPersistentOnlineStatus(request.OnlineStatus))
+            {
+                client.Character.SavedOnlineStatus = request.OnlineStatus;
+                Server.Database.UpdateCharacterCommonBaseInfo(client.Character);
+            }
 
             return new S2CCharacterSetOnlineStatusRes()
             {

--- a/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/CharacterSwitchGameModeHandler.cs
@@ -37,6 +37,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var acquirableAbilities = client.Character.AcquirableAbilities;
             var dispelSeals = client.Character.DispelSeals;
             var msgSetList = client.Character.MsgSetList;
+            var onlineStatus = client.Character.OnlineStatus;
+            var savedOnlineStatus = client.Character.SavedOnlineStatus;
 
             var serverInfo = client.Character.Server;
 
@@ -74,7 +76,8 @@ namespace Arrowgene.Ddon.GameServer.Handler
             client.Character.BbmProgress = bbmProgress;
             client.Character.WalletPointList = walletPointList;
             client.Character.ReleasedWarpPoints = warpPointList;
-            client.Character.OnlineStatus = OnlineStatus.Online;
+            client.Character.OnlineStatus = onlineStatus;
+            client.Character.SavedOnlineStatus = savedOnlineStatus;
             client.Character.ClanId = clanId;
             client.Character.ClanName = clanName;
             client.Character.AchievementStatus = achievements.AchievementStatus;

--- a/Arrowgene.Ddon.GameServer/Handler/ConnectionLogoutHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/ConnectionLogoutHandler.cs
@@ -16,7 +16,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
         public override S2CConnectionLogoutRes Handle(GameClient client, C2SConnectionLogoutReq request)
         {
             S2CConnectionLogoutRes res = new S2CConnectionLogoutRes();
-            client.Character.OnlineStatus = OnlineStatus.Offline;
+            Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Offline);
             return res;
         }
     }

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemLeaveHandler.cs
@@ -21,18 +21,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-        private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
-        {
-            return client.Character.SavedOnlineStatus switch
-            {
-                OnlineStatus.Online => OnlineStatus.Online,
-                OnlineStatus.Offline => OnlineStatus.Offline,
-                OnlineStatus.Leaving => OnlineStatus.Leaving,
-                OnlineStatus.Busy => OnlineStatus.Busy,
-                _ => OnlineStatus.Online
-            };
-        }
-
         public override S2CEntryBoardEntryBoardItemLeaveRes Handle(GameClient client, C2SEntryBoardEntryBoardItemLeaveReq request)
         {
             var data = Server.BoardManager.GetGroupDataForCharacter(client.Character);
@@ -45,7 +33,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     if (memberClient != null)
                     {
                         memberClient.Send(new S2CEntryBoardEntryBoardItemLeaveNtc());
-                        Server.CharacterManager.UpdateOnlineStatus(memberClient, memberClient.Character, GetDefaultOnlineStatus(memberClient));
+                        Server.CharacterManager.UpdateOnlineStatus(memberClient, memberClient.Character, CharacterManager.GetDefaultOnlineStatus(memberClient.Character));
                     }
                 }
             }
@@ -80,7 +68,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 Server.BoardManager.RemoveCharacterFromGroup(client.Character);
                 Server.BoardManager.RestartRecruitment(data.EntryItem.Id);
 
-                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, GetDefaultOnlineStatus(client));
+                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, CharacterManager.GetDefaultOnlineStatus(client.Character));
             }
 
             return new S2CEntryBoardEntryBoardItemLeaveRes();

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardEntryBoardItemLeaveHandler.cs
@@ -21,6 +21,18 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
+        private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
+        {
+            return client.Character.SavedOnlineStatus switch
+            {
+                OnlineStatus.Online => OnlineStatus.Online,
+                OnlineStatus.Offline => OnlineStatus.Offline,
+                OnlineStatus.Leaving => OnlineStatus.Leaving,
+                OnlineStatus.Busy => OnlineStatus.Busy,
+                _ => OnlineStatus.Online
+            };
+        }
+
         public override S2CEntryBoardEntryBoardItemLeaveRes Handle(GameClient client, C2SEntryBoardEntryBoardItemLeaveReq request)
         {
             var data = Server.BoardManager.GetGroupDataForCharacter(client.Character);
@@ -33,7 +45,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     if (memberClient != null)
                     {
                         memberClient.Send(new S2CEntryBoardEntryBoardItemLeaveNtc());
-                        Server.CharacterManager.UpdateOnlineStatus(client, memberClient.Character, OnlineStatus.Online);
+                        Server.CharacterManager.UpdateOnlineStatus(memberClient, memberClient.Character, GetDefaultOnlineStatus(memberClient));
                     }
                 }
             }
@@ -68,7 +80,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 Server.BoardManager.RemoveCharacterFromGroup(client.Character);
                 Server.BoardManager.RestartRecruitment(data.EntryItem.Id);
 
-                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Online);
+                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, GetDefaultOnlineStatus(client));
             }
 
             return new S2CEntryBoardEntryBoardItemLeaveRes();

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardItemKickHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardItemKickHandler.cs
@@ -16,6 +16,18 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
+        private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
+        {
+            return client.Character.SavedOnlineStatus switch
+            {
+                OnlineStatus.Online => OnlineStatus.Online,
+                OnlineStatus.Offline => OnlineStatus.Offline,
+                OnlineStatus.Leaving => OnlineStatus.Leaving,
+                OnlineStatus.Busy => OnlineStatus.Busy,
+                _ => OnlineStatus.Online
+            };
+        }
+
         public override S2CEntryBoardItemKickRes Handle(GameClient client, C2SEntryBoardItemKickReq request)
         {
             var data = Server.BoardManager.RecreateGroup(client.Character);
@@ -48,7 +60,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             kickedMemberClient.Send(new S2CEntryBoardEntryBoardItemLeaveNtc());
             
             Server.BoardManager.RemoveCharacterFromGroup(kickedMemberClient.Character);
-            Server.CharacterManager.UpdateOnlineStatus(kickedMemberClient, kickedMemberClient.Character, OnlineStatus.Online);
+            Server.CharacterManager.UpdateOnlineStatus(kickedMemberClient, kickedMemberClient.Character, GetDefaultOnlineStatus(kickedMemberClient));
 
             return new S2CEntryBoardItemKickRes();
         }

--- a/Arrowgene.Ddon.GameServer/Handler/EntryBoardItemKickHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/EntryBoardItemKickHandler.cs
@@ -1,3 +1,4 @@
+using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
@@ -14,18 +15,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public EntryBoardItemKickHandler(DdonGameServer server) : base(server)
         {
-        }
-
-        private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
-        {
-            return client.Character.SavedOnlineStatus switch
-            {
-                OnlineStatus.Online => OnlineStatus.Online,
-                OnlineStatus.Offline => OnlineStatus.Offline,
-                OnlineStatus.Leaving => OnlineStatus.Leaving,
-                OnlineStatus.Busy => OnlineStatus.Busy,
-                _ => OnlineStatus.Online
-            };
         }
 
         public override S2CEntryBoardItemKickRes Handle(GameClient client, C2SEntryBoardItemKickReq request)
@@ -60,7 +49,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
             kickedMemberClient.Send(new S2CEntryBoardEntryBoardItemLeaveNtc());
             
             Server.BoardManager.RemoveCharacterFromGroup(kickedMemberClient.Character);
-            Server.CharacterManager.UpdateOnlineStatus(kickedMemberClient, kickedMemberClient.Character, GetDefaultOnlineStatus(kickedMemberClient));
+            Server.CharacterManager.UpdateOnlineStatus(kickedMemberClient, kickedMemberClient.Character, CharacterManager.GetDefaultOnlineStatus(kickedMemberClient.Character));
 
             return new S2CEntryBoardItemKickRes();
         }

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyJoinHandler.cs
@@ -21,7 +21,9 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
         public override S2CLobbyJoinRes Handle(GameClient client, C2SLobbyJoinReq request)
         {
-            client.Character.OnlineStatus = OnlineStatus.Online;
+            var ownOnlineStatus = client.Character.SavedOnlineStatus;
+
+            client.Character.OnlineStatus = ownOnlineStatus;
 
             // Notify new player of already present players
             S2CUserListJoinNtc alreadyPresentUsersNtc = new S2CUserListJoinNtc();
@@ -40,7 +42,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                             PawnId = 0,
                             Unk0 = 1,
                             Unk1 = 0,
-                            OnlineStatus = OnlineStatus.Online
+                            OnlineStatus = otherClient.Character.OnlineStatus
                         }
                     );
                 }
@@ -60,7 +62,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                     ClanName = client.Character.ClanName.ShortName,
                     Unk0 = 1, // Platform PC?
                     Unk1 = 0,
-                    OnlineStatus = OnlineStatus.Online  // OnlineStatus?
+                    OnlineStatus = ownOnlineStatus
                 },
             };
 

--- a/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyJoinHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/LobbyLobbyJoinHandler.cs
@@ -6,6 +6,7 @@ using Arrowgene.Ddon.Server;
 using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Entity.Structure;
 using Arrowgene.Ddon.Shared.Model;
+using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Logging;
 
 namespace Arrowgene.Ddon.GameServer.Handler
@@ -24,6 +25,31 @@ namespace Arrowgene.Ddon.GameServer.Handler
             var ownOnlineStatus = client.Character.SavedOnlineStatus;
 
             client.Character.OnlineStatus = ownOnlineStatus;
+
+            Server.RpcManager.UpdatePlayerList();
+
+            foreach (var element in Server.RpcManager.GetTrackedCharacterListElement())
+            {
+                if (element.CommunityCharacterBaseInfo.CharacterId == client.Character.CharacterId)
+                {
+                    continue;
+                }
+
+                var ntc = new S2CCharacterCommunityCharacterStatusUpdateNtc();
+                ntc.UpdateCharacterList.Add(element);
+                client.Send(ntc);
+            }
+
+            Server.RpcManager.AnnounceOthers(
+                "internal/command",
+                RpcInternalCommand.NotifyOnlineStatusChanged,
+                new RpcOnlineStatusData()
+                {
+                    CharacterId = client.Character.CharacterId,
+                    ServerId = (ushort)Server.Id,
+                    OnlineStatus = client.Character.OnlineStatus
+                }
+            );
 
             // Notify new player of already present players
             S2CUserListJoinNtc alreadyPresentUsersNtc = new S2CUserListJoinNtc();

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
@@ -20,18 +20,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-        private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
-        {
-            return client.Character.SavedOnlineStatus switch
-            {
-                OnlineStatus.Online => OnlineStatus.Online,
-                OnlineStatus.Offline => OnlineStatus.Offline,
-                OnlineStatus.Leaving => OnlineStatus.Leaving,
-                OnlineStatus.Busy => OnlineStatus.Busy,
-                _ => OnlineStatus.Online
-            };
-        }
-
         public override S2CPartyPartyChangeLeaderRes Handle(GameClient client, C2SPartyPartyChangeLeaderReq request)
         {
             S2CPartyPartyChangeLeaderRes res = new S2CPartyPartyChangeLeaderRes();
@@ -71,7 +59,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if (party.MemberCount() == 1)
             {
-                Server.CharacterManager.UpdateOnlineStatus(currentLeader.Client, currentLeader.Client.Character, GetDefaultOnlineStatus(currentLeader.Client));
+                Server.CharacterManager.UpdateOnlineStatus(currentLeader.Client, currentLeader.Client.Character, CharacterManager.GetDefaultOnlineStatus(currentLeader.Client.Character));
             }
             else
             {

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyChangeLeaderHandler.cs
@@ -20,6 +20,18 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
+        private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
+        {
+            return client.Character.SavedOnlineStatus switch
+            {
+                OnlineStatus.Online => OnlineStatus.Online,
+                OnlineStatus.Offline => OnlineStatus.Offline,
+                OnlineStatus.Leaving => OnlineStatus.Leaving,
+                OnlineStatus.Busy => OnlineStatus.Busy,
+                _ => OnlineStatus.Online
+            };
+        }
+
         public override S2CPartyPartyChangeLeaderRes Handle(GameClient client, C2SPartyPartyChangeLeaderReq request)
         {
             S2CPartyPartyChangeLeaderRes res = new S2CPartyPartyChangeLeaderRes();
@@ -59,7 +71,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
 
             if (party.MemberCount() == 1)
             {
-                Server.CharacterManager.UpdateOnlineStatus(currentLeader.Client, currentLeader.Client.Character, OnlineStatus.Online);
+                Server.CharacterManager.UpdateOnlineStatus(currentLeader.Client, currentLeader.Client.Character, GetDefaultOnlineStatus(currentLeader.Client));
             }
             else
             {

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
@@ -15,18 +15,6 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
-         private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
-         {
-            return client.Character.SavedOnlineStatus switch
-            {
-                OnlineStatus.Online => OnlineStatus.Online,
-                OnlineStatus.Offline => OnlineStatus.Offline,
-                OnlineStatus.Leaving => OnlineStatus.Leaving,
-                OnlineStatus.Busy => OnlineStatus.Busy,
-                _ => OnlineStatus.Online
-            };
-        }
-
         public override S2CPartyPartyLeaveRes Handle(GameClient client, C2SPartyPartyLeaveReq request)
         {
             PartyGroup party = client.Party
@@ -41,7 +29,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 if (!data.IsInRecreate)
                 {
                     Server.BoardManager.RemoveCharacterFromGroup(client.Character);
-                    Server.CharacterManager.UpdateOnlineStatus(client, client.Character, GetDefaultOnlineStatus(client));
+                    Server.CharacterManager.UpdateOnlineStatus(client, client.Character, CharacterManager.GetDefaultOnlineStatus(client.Character));
 
                     if (BoardManager.BoardIdIsExm(party.ContentId))
                     {
@@ -55,12 +43,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
-                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, GetDefaultOnlineStatus(client));
+                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, CharacterManager.GetDefaultOnlineStatus(client.Character));
             }
 
             if (party.MemberCount() == 1 && party.Leader != null && !BoardManager.BoardIdIsExm(party.ContentId))
             {
-                Server.CharacterManager.UpdateOnlineStatus(party.Leader.Client, party.Leader.Client.Character, GetDefaultOnlineStatus(party.Leader.Client));
+                Server.CharacterManager.UpdateOnlineStatus(party.Leader.Client, party.Leader.Client.Character, CharacterManager.GetDefaultOnlineStatus(party.Leader.Client.Character));
             }
 
             S2CPartyPartyLeaveNtc partyLeaveNtc = new S2CPartyPartyLeaveNtc();

--- a/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
+++ b/Arrowgene.Ddon.GameServer/Handler/PartyPartyLeaveHandler.cs
@@ -15,6 +15,18 @@ namespace Arrowgene.Ddon.GameServer.Handler
         {
         }
 
+         private static OnlineStatus GetDefaultOnlineStatus(GameClient client)
+         {
+            return client.Character.SavedOnlineStatus switch
+            {
+                OnlineStatus.Online => OnlineStatus.Online,
+                OnlineStatus.Offline => OnlineStatus.Offline,
+                OnlineStatus.Leaving => OnlineStatus.Leaving,
+                OnlineStatus.Busy => OnlineStatus.Busy,
+                _ => OnlineStatus.Online
+            };
+        }
+
         public override S2CPartyPartyLeaveRes Handle(GameClient client, C2SPartyPartyLeaveReq request)
         {
             PartyGroup party = client.Party
@@ -29,7 +41,7 @@ namespace Arrowgene.Ddon.GameServer.Handler
                 if (!data.IsInRecreate)
                 {
                     Server.BoardManager.RemoveCharacterFromGroup(client.Character);
-                    Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Online);
+                    Server.CharacterManager.UpdateOnlineStatus(client, client.Character, GetDefaultOnlineStatus(client));
 
                     if (BoardManager.BoardIdIsExm(party.ContentId))
                     {
@@ -43,12 +55,12 @@ namespace Arrowgene.Ddon.GameServer.Handler
             }
             else
             {
-                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, OnlineStatus.Online);
+                Server.CharacterManager.UpdateOnlineStatus(client, client.Character, GetDefaultOnlineStatus(client));
             }
 
             if (party.MemberCount() == 1 && party.Leader != null && !BoardManager.BoardIdIsExm(party.ContentId))
             {
-                Server.CharacterManager.UpdateOnlineStatus(party.Leader.Client, party.Leader.Client.Character, OnlineStatus.Online);
+                Server.CharacterManager.UpdateOnlineStatus(party.Leader.Client, party.Leader.Client.Character, GetDefaultOnlineStatus(party.Leader.Client));
             }
 
             S2CPartyPartyLeaveNtc partyLeaveNtc = new S2CPartyPartyLeaveNtc();

--- a/Arrowgene.Ddon.GameServer/RpcManager.cs
+++ b/Arrowgene.Ddon.GameServer/RpcManager.cs
@@ -284,6 +284,72 @@ namespace Arrowgene.Ddon.GameServer
             return 0;
         }
     
+        public (ushort ChannelId, OnlineStatus OnlineStatus) FindPlayerPresenceById(uint characterId)
+        {
+            lock (CharacterTrackingMap)
+            {
+                foreach ((ushort channelId, var channelMembers) in CharacterTrackingMap)
+                {
+                    if (channelMembers.TryGetValue(characterId, out var player))
+                    {
+                        return (channelId, player.OnlineStatus);
+                    }
+                }
+            }
+
+            return (0, OnlineStatus.Offline);
+        }
+
+        public CDataCharacterListElement GetTrackedCharacterListElement(uint characterId)
+        {
+            lock (CharacterTrackingMap)
+            {
+                foreach ((ushort channelId, var channelMembers) in CharacterTrackingMap)
+                {
+                    lock (channelMembers)
+                    {
+                        if (channelMembers.TryGetValue(characterId, out var player))
+                        {
+                            return new CDataCharacterListElement()
+                            {
+                                CommunityCharacterBaseInfo = player.CommunityCharacterBaseInfo,
+                                ServerId = channelId,
+                                OnlineStatus = player.OnlineStatus,
+                            };
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        public List<CDataCharacterListElement> GetTrackedCharacterListElement()
+        {
+            List<CDataCharacterListElement> results = [];
+
+            lock (CharacterTrackingMap)
+            {
+                foreach ((ushort channelId, var channelMembers) in CharacterTrackingMap)
+                {
+                    lock (channelMembers)
+                    {
+                        foreach (var player in channelMembers.Values)
+                        {
+                            results.Add(new CDataCharacterListElement()
+                            {
+                                CommunityCharacterBaseInfo = player.CommunityCharacterBaseInfo,
+                                ServerId = channelId,
+                                OnlineStatus = player.OnlineStatus,
+                            });
+                        }
+                    }
+                }
+            }
+
+            return results;
+        }
+
         public void AnnouncePlayerList(Character exception = null)
         {
             UpdatePlayerList(exception);
@@ -293,9 +359,46 @@ namespace Arrowgene.Ddon.GameServer
         public void UpdatePlayerList(Character exception = null)
         {
             var trackingData = Server.Database.SelectCharacterTrackingList();
+
             foreach (var item in trackingData)
             {
-                CharacterTrackingMap[item.Key] = new RpcTrackingMap(item.Key, [.. item.Value.Where(x => x.CharacterId != exception?.CharacterId)]);
+                ushort channelId = item.Key;
+
+                var newMap = new RpcTrackingMap(channelId, [.. item.Value.Where(x => x.CharacterId != exception?.CharacterId)]);
+
+                if (CharacterTrackingMap.TryGetValue(channelId, out var oldMap))
+                {
+                    foreach (var characterData in newMap.Values)
+                    {
+                        if (oldMap.TryGetValue(characterData.CharacterId, out var oldCharacterData))
+                        {
+                            characterData.OnlineStatus = oldCharacterData.OnlineStatus;
+                        }
+                    }
+                }
+
+                CharacterTrackingMap[channelId] = newMap;
+            }
+        }
+
+        public void UpdateRemoteOnlineStatus(uint characterId, ushort serverId, OnlineStatus onlineStatus)
+        {
+            lock (CharacterTrackingMap)
+            {
+                if (!CharacterTrackingMap.ContainsKey(serverId))
+                {
+                    return;
+                }
+
+                var channelMembers = CharacterTrackingMap[serverId];
+
+                lock (channelMembers)
+                {
+                    if (channelMembers.TryGetValue(characterId, out var characterData))
+                    {
+                        characterData.OnlineStatus = onlineStatus;
+                    }
+                }
             }
         }
 

--- a/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
+++ b/Arrowgene.Ddon.Rpc.Web/Route/Internal/CommandRoute.cs
@@ -2,6 +2,7 @@ using Arrowgene.Ddon.GameServer;
 using Arrowgene.Ddon.GameServer.Characters;
 using Arrowgene.Ddon.Rpc.Command;
 using Arrowgene.Ddon.Server;
+using Arrowgene.Ddon.Shared.Entity.PacketStructure;
 using Arrowgene.Ddon.Shared.Model.Quest;
 using Arrowgene.Ddon.Shared.Model.Rpc;
 using Arrowgene.Logging;
@@ -31,6 +32,7 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                 {
                     RpcInternalCommand.Ping => HandlePing(),
                     RpcInternalCommand.NotifyPlayerList => HandleNotifyPlayerList(gameServer),
+                    RpcInternalCommand.NotifyOnlineStatusChanged => HandleNotifyOnlineStatusChanged(gameServer),
                     RpcInternalCommand.NotifyClanQuestCompletion => HandleNotifyClanQuestCompletion(gameServer),
                     RpcInternalCommand.EpitaphRoadWeeklyReset => HandleEpitaphRoadWeeklyReset(gameServer),
                     RpcInternalCommand.KickInternal => HandleKickInternal(gameServer),
@@ -50,6 +52,36 @@ namespace Arrowgene.Ddon.Rpc.Web.Route.Internal
                 return new RpcCommandResult(this, true)
                 {
                     Message = $"Ping {_entry.Origin}"
+                };
+            }
+
+            private RpcCommandResult HandleNotifyOnlineStatusChanged(DdonGameServer gameServer)
+            {
+                RpcOnlineStatusData data = _entry.GetData<RpcOnlineStatusData>();
+
+                gameServer.RpcManager.UpdatePlayerList();
+
+                gameServer.RpcManager.UpdateRemoteOnlineStatus(data.CharacterId, data.ServerId, data.OnlineStatus);
+
+                var characterListElement = gameServer.RpcManager.GetTrackedCharacterListElement(data.CharacterId);
+
+                if (characterListElement != null)
+                {
+                    var ntc = new S2CCharacterCommunityCharacterStatusUpdateNtc();
+                    ntc.UpdateCharacterList.Add(characterListElement);
+
+                    foreach (var localClient in gameServer.ClientLookup.GetAll())
+                    {
+                        if (localClient.Character != null)
+                        {
+                            localClient.Send(ntc);
+                        }
+                    }
+                }
+
+                return new RpcCommandResult(this, true)
+                {
+                    Message = $"NotifyOnlineStatusChanged CharacterId {data.CharacterId} Status {data.OnlineStatus}"
                 };
             }
 

--- a/Arrowgene.Ddon.Shared/Model/CharacterCommon.cs
+++ b/Arrowgene.Ddon.Shared/Model/CharacterCommon.cs
@@ -52,6 +52,7 @@ namespace Arrowgene.Ddon.Shared.Model
         public List<Ability> LearnedAbilities { get; set; } = [];
         public Dictionary<JobId, List<Ability?>> EquippedAbilitiesDictionary { get; set; }
         public OnlineStatus OnlineStatus { get; set; } = OnlineStatus.Offline;
+        public OnlineStatus SavedOnlineStatus { get; set; } = OnlineStatus.Online;
         public CDataOrbGainExtendParam ExtendedParams { get; set; } = new();
         public Dictionary<JobId, CDataOrbGainExtendParam> ExtendedJobParams { get; set; } = [];
         public Dictionary<JobId, HashSet<uint>> ReleasedExtendedJobParams { get; set; } = [];

--- a/Arrowgene.Ddon.Shared/Model/Rpc/RpcCharacterData.cs
+++ b/Arrowgene.Ddon.Shared/Model/Rpc/RpcCharacterData.cs
@@ -10,6 +10,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
             LastName = string.Empty;
             ClanName = string.Empty;
             ClanShortName = string.Empty;
+            OnlineStatus = OnlineStatus.Offline;
         }
 
         public RpcCharacterData(Character character)
@@ -20,6 +21,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
             ClanName = character.ClanName.Name;
             ClanShortName = character.ClanName.ShortName;
             ClanId = character.ClanId;
+            OnlineStatus = character.OnlineStatus;
         }
 
         public uint CharacterId { get; set; }
@@ -28,6 +30,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
         public string LastName { get; set; }
         public string ClanName { get; set; }
         public string ClanShortName { get; set; }
+        public OnlineStatus OnlineStatus { get; set; }
 
         public CDataCommunityCharacterBaseInfo CommunityCharacterBaseInfo
         {

--- a/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Rpc/RpcInternalCommand.cs
@@ -6,6 +6,7 @@ namespace Arrowgene.Ddon.Shared.Model.Rpc
         Ping, // null
 
         NotifyPlayerList, // List<RpcCharacterData>
+        NotifyOnlineStatusChanged, // RpcOnlineStatusData
         NotifyClanQuestCompletion, //RpcQuestCompletionData
 
         KickInternal, // int

--- a/Arrowgene.Ddon.Shared/Model/Rpc/RpcOnlineStatusData.cs
+++ b/Arrowgene.Ddon.Shared/Model/Rpc/RpcOnlineStatusData.cs
@@ -1,0 +1,11 @@
+using Arrowgene.Ddon.Shared.Model;
+
+namespace Arrowgene.Ddon.Shared.Model.Rpc
+{
+    public class RpcOnlineStatusData
+    {
+        public uint CharacterId { get; set; }
+        public ushort ServerId { get; set; }
+        public OnlineStatus OnlineStatus { get; set; }
+    }
+}


### PR DESCRIPTION
Currently a Draft:

This PR aims to improve the "Online Status" Feature, so that the various Online Status Modes work as intended.
It also adds back the "Player has logged in." message to the Chat Box, when a Player logs in.
RPC Support has been added as well.

It has not been fully tested against all possible cases where the "Online Status" will be requested by other Players, so this needs more testing as well.

Additionally, this PR aims to add proper "Player Search" across Channels. Same for Pawn Search.

# Checklist:
- [X] The project compiles
- [X] The PR targets `develop` branch
