### PR TITLE
Quest locks for caution spots

### DIFF
--- a/Arrowgene.Ddon.GameServer/Enemies/Generators/CautionSpotEnemyGenerator.cs
+++ b/Arrowgene.Ddon.GameServer/Enemies/Generators/CautionSpotEnemyGenerator.cs
@@ -25,10 +25,15 @@ namespace Arrowgene.Ddon.GameServer.Enemies.Generators
                 var areaRank = server.AreaRankManager.GetEffectiveRank(client.Party.Leader.Client.Character, match.AreaId);
                 if (areaRank >= match.RequiredAreaRank)
                 {
+                    if (match.QuestUnlockId != QuestId.None && !client.Character.HasQuestCompleted(match.QuestUnlockId))
+                    {
+                        continue;
+                    }
+
                     cautionSpots.Add(match);
                 }
             }
-            
+
             if (cautionSpots.Count > 0)
             {
                 instancedEnemySet.AddRange(cautionSpots[0].GetInstanceEnemies());

--- a/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IMonsterSpotInfo.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Interfaces/IMonsterSpotInfo.cs
@@ -12,6 +12,7 @@ namespace Arrowgene.Ddon.GameServer.Scripting.Interfaces
         public abstract QuestAreaId AreaId { get; }
         public virtual bool CautionPlayer { get; } = true;
         public abstract uint RequiredAreaRank { get; }
+        public virtual QuestId QuestUnlockId { get; } = QuestId.None;
         protected Dictionary<uint, List<InstancedEnemy>> Enemies { get; set; }
 
         public IMonsterSpotInfo()

--- a/Arrowgene.Ddon.GameServer/Scripting/Modules/MonsterCautionSpotModule.cs
+++ b/Arrowgene.Ddon.GameServer/Scripting/Modules/MonsterCautionSpotModule.cs
@@ -37,6 +37,11 @@ namespace Arrowgene.Ddon.GameServer.Scripting
             }
 
             var leaderClient = party.Leader.Client;
+            if (cautionSpot.QuestUnlockId != QuestId.None && !leaderClient.Character.HasQuestCompleted(cautionSpot.QuestUnlockId))
+            {
+                return false;
+            }
+
             return server.AreaRankManager.GetEffectiveRank(leaderClient.Character, areaId) >= cautionSpot.RequiredAreaRank;
         }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_deserted_village_of_denisyr.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_deserted_village_of_denisyr.csx
@@ -1,29 +1,26 @@
-// Deserted Village of Denisyr — stageid461 GroupId8 MaxPos9 (positions 0-9)
-// Rathnite Foothills, Lv83, AR3
+/**
+ * @brief Enemy Spot in "Rathnite Foothills" for "Deserted Village of Denisyr"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.RathniteFoothills.AsStageLayoutId(8);
     public override QuestAreaId AreaId => QuestAreaId.RathniteFoothills;
-    public override uint RequiredAreaRank => 3;
+    public override uint RequiredAreaRank => 2;
+    public override QuestId QuestUnlockId => QuestId.RathniteFoothillsRescueRequest;
 
     public override void Initialize()
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.BluntSoldierDwarfOrc, 83, 0),
-            LibDdon.Enemy.CreateAuto(EnemyId.BluntSoldierDwarfOrc, 83, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.BluntSoldierDwarfOrc, 83, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.BluntSoldierDwarfOrc, 83, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 83, 4),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 83, 5),
-            LibDdon.Enemy.CreateAuto(EnemyId.RangedSoldierDwarfOrc, 83, 6),
-            LibDdon.Enemy.CreateAuto(EnemyId.SquadLeaderDwarfOrc, 83, 7),
-            LibDdon.Enemy.CreateAuto(EnemyId.SquadLeaderDwarfOrc, 83, 8),
-            LibDdon.Enemy.CreateAuto(EnemyId.SquadLeaderDwarfOrc, 83, 9),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 83, 4200, 4),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 83, 4200, 5),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 83, 4200, 6),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 83, 4200, 7),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 83, 4200, 8),
         };
-
 
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
             .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
@@ -54,36 +51,6 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             .AddDrop(ItemId.GustyWindsStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GustyWindsStone, 1, 1, DropRate.VERY_RARE);
         enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStone, 1, 1, DropRate.VERY_RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStone, 1, 1, DropRate.VERY_RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStone, 1, 1, DropRate.VERY_RARE);
-        enemies[7].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[8]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStone, 1, 1, DropRate.VERY_RARE);
-        enemies[8].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[9]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GustyWindsStone, 1, 1, DropRate.VERY_RARE);
-        enemies[9].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_dewdrop_crater.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_dewdrop_crater.csx
@@ -1,31 +1,31 @@
-// Dewdrop Crater — stageid462 GroupId6 MaxPos8 (positions 0-8)
-// Rathnite Foothills Lakeside, Lv83, AR3
+/**
+ * @brief Enemy Spot in "Rathnite Foothills Lakeside" for "Dewdrop Crater"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.RathniteFoothillsLakeside0.AsStageLayoutId(6);
     public override QuestAreaId AreaId => QuestAreaId.RathniteFoothills;
-    public override uint RequiredAreaRank => 3;
+    public override uint RequiredAreaRank => 5;
+    public override QuestId QuestUnlockId => QuestId.RathniteFoothillsPreventEnemyAttack;
 
     public override void Initialize()
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGrimwargLightArmor, 83, 0),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGrimwargLightArmor, 83, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGrimwargLightArmor, 83, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGrimwargLightArmor, 83, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.WarReadyGrimwargLightArmor, 83, 4),
-            LibDdon.Enemy.CreateAuto(EnemyId.Chimera0, 83, 5, isBoss: true),
-            LibDdon.Enemy.CreateAuto(EnemyId.Chimera0, 83, 6, isBoss: true),
+            LibDdon.Enemy.Create(EnemyId.Chimera0, 83, 105000, 0)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 83, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 83, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 83, 4200, 3),
         };
 
-
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemihumanCutterStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemihumanCutterStone , 1, 1, DropRate.VERY_RARE);
+            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.DemihumanCutterStoneShard, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.DemihumanCutterStone , 1, 1, DropRate.RARE);
         enemies[0].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
@@ -45,24 +45,6 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             .AddDrop(ItemId.DemihumanCutterStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.DemihumanCutterStone , 1, 1, DropRate.VERY_RARE);
         enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemihumanCutterStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemihumanCutterStone , 1, 1, DropRate.VERY_RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.DemihumanCutterStoneShard, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.DemihumanCutterStone , 1, 1, DropRate.RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.DemihumanCutterStoneShard, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.DemihumanCutterStone , 1, 1, DropRate.RARE);
-        enemies[6].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_feryana_border_checkpoint.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_feryana_border_checkpoint.csx
@@ -1,26 +1,25 @@
-// Feryana Border Checkpoint — stageid462 GroupId32 MaxPos6 (positions 0-6)
-// Rathnite Foothills Lakeside, Lv83, AR3
+/**
+ * @brief Enemy Spot in "Rathnite Foothills Lakeside" for "Feryana Border Checkpoint"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.RathniteFoothillsLakeside0.AsStageLayoutId(32);
+    public override StageLayoutId StageLayoutId => Stage.RathniteFoothillsLakeside0.AsStageLayoutId(31);
     public override QuestAreaId AreaId => QuestAreaId.RathniteFoothills;
-    public override uint RequiredAreaRank => 3;
+    public override uint RequiredAreaRank => 5;
+    public override QuestId QuestUnlockId => QuestId.RathniteFoothillsPursueAndDefeatEnemies;
 
     public override void Initialize()
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.BlackGriffin0, 83, 0, isBoss: true),
-            LibDdon.Enemy.CreateAuto(EnemyId.HeavySoldierDwarfOrc, 83, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.HeavySoldierDwarfOrc, 83, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.HeavySoldierDwarfOrc, 83, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.HeavySoldierDwarfOrc, 83, 4),
-            LibDdon.Enemy.CreateAuto(EnemyId.HeavySoldierDwarfOrc, 83, 5),
-            LibDdon.Enemy.CreateAuto(EnemyId.HeavySoldierDwarfOrc, 83, 6),
+            LibDdon.Enemy.Create(EnemyId.BlackGriffin0, 83, 105000, 0)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 83, 4200, 1),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 83, 4200, 2),
         };
-
 
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
             .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.UNCOMMON)
@@ -39,30 +38,6 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
         enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.DemonExpellerStone, 1, 1, DropRate.VERY_RARE);
-        enemies[6].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_former_rest_station.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/18_rathnite_foothills/ar03_former_rest_station.csx
@@ -1,27 +1,29 @@
-// Former Rest Station — stageid461 GroupId9 MaxPos7 (positions 0-7)
-// Rathnite Foothills, Lv83, AR3
+/**
+ * @brief Enemy Spot in "Rathnite Foothills" for "Former Rest Station"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.RathniteFoothills.AsStageLayoutId(9);
     public override QuestAreaId AreaId => QuestAreaId.RathniteFoothills;
-    public override uint RequiredAreaRank => 3;
+    public override uint RequiredAreaRank => 2;
+    public override QuestId QuestUnlockId => QuestId.RathniteFoothillsLiberationArmySupport;
 
     public override void Initialize()
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.SlingGrimGoblinOilFlask, 83, 0),
-            LibDdon.Enemy.CreateAuto(EnemyId.SlingGrimGoblinOilFlask, 83, 1),
-            LibDdon.Enemy.CreateAuto(EnemyId.SlingGrimGoblinOilFlask, 83, 2),
-            LibDdon.Enemy.CreateAuto(EnemyId.GoblinShaman, 83, 3),
-            LibDdon.Enemy.CreateAuto(EnemyId.GoblinShaman, 83, 4),
-            LibDdon.Enemy.CreateAuto(EnemyId.GoblinShaman, 83, 5),
-            LibDdon.Enemy.CreateAuto(EnemyId.Behemoth0, 83, 6, isBoss: true),
-            LibDdon.Enemy.CreateAuto(EnemyId.GoblinShaman, 83, 5),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 80, 4200, 0),
+            LibDdon.Enemy.Create(EnemyId.Behemoth0, 80, 105000, 1)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 80, 4200, 2),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 80, 4200, 3),
+            LibDdon.Enemy.Create(EnemyId.GoblinShaman, 80, 4200, 4),
+            LibDdon.Enemy.Create(EnemyId.GoblinShaman, 80, 4200, 5),
+            LibDdon.Enemy.Create(EnemyId.SlingGrimGoblinOilFlask, 80, 4200, 6),
         };
-
 
         var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
             .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
@@ -30,9 +32,9 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         enemies[0].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.AnimalHunterStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.AnimalHunterStone, 1, 1, DropRate.VERY_RARE);
+            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.AnimalHunterStoneShard, 1, 1, DropRate.UNCOMMON)
+            .AddDrop(ItemId.AnimalHunterStone, 1, 1, DropRate.RARE);
         enemies[1].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
@@ -60,16 +62,10 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         enemies[5].SetDropsTable(dropsTable);
 
         dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.AnimalHunterStoneShard, 1, 1, DropRate.UNCOMMON)
-            .AddDrop(ItemId.AnimalHunterStone, 1, 1, DropRate.RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
             .AddDrop(ItemId.BeastLuringMeat, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.AnimalHunterStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.AnimalHunterStone, 1, 1, DropRate.VERY_RARE);
-        enemies[7].SetDropsTable(dropsTable);
+        enemies[6].SetDropsTable(dropsTable);
 
         AddEnemies(enemies);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar03_demon_army_relay_station.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar03_demon_army_relay_station.csx
@@ -1,12 +1,15 @@
-// Demon Army Relay Station — stageid463 GroupId1 MaxPos8 (positions 0-8)
-// Monster Caution Spot — Feryana Wilderness, Lv88, AR0
+/**
+ * @brief Enemy Spot in "Feryana Wilderness" for "Demon Army Relay Station"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(1);
     public override QuestAreaId AreaId => QuestAreaId.FeryanaWilderness;
-    public override uint RequiredAreaRank => 3;
+    public override uint RequiredAreaRank => 5;
+    public override QuestId QuestUnlockId => QuestId.FeryanaWildernessPursueAndDefeatEnemies;
 
     public override void Initialize()
     {
@@ -14,7 +17,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         {
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 0),
             LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 88, 105000, 1)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 2),
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 3),
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 8),

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_gate_camp.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_gate_camp.csx
@@ -1,12 +1,15 @@
-// Gate Camp — stageid463 GroupId80 MaxPos4 (positions 0-4)
-// Monster Caution Spot — Feryana Wilderness, Lv88, AR0
+/**
+ * @brief Enemy Spot in "Feryana Wilderness" for "Gate Camp"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(80);
     public override QuestAreaId AreaId => QuestAreaId.FeryanaWilderness;
-    public override uint RequiredAreaRank => 5;
+    public override uint RequiredAreaRank => 2;
+    public override QuestId QuestUnlockId => QuestId.FeryanaWildernessRescueRequest;
 
     public override void Initialize()
     {
@@ -16,7 +19,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 1),
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 88, 4200, 2),
             LibDdon.Enemy.Create(EnemyId.WarReadyGoremanticoreLightArmor, 88, 105000, 3)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
         };
 
         // Available Items (4): BattleArmorFragment, UnrefinedAlloyLump, GiantKillerStoneShard, GiantKillerStone

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_wailing_wetland.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar05_wailing_wetland.csx
@@ -1,25 +1,28 @@
-// Wailing Wetland — stageid463 GroupId2 MaxPos8 (positions 0-8)
-// Monster Caution Spot — Feryana Wilderness, Lv88, AR0
+/**
+ * @brief Enemy Spot in "Feryana Wilderness" for "Wailing Wetland"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(2);
     public override QuestAreaId AreaId => QuestAreaId.FeryanaWilderness;
-    public override uint RequiredAreaRank => 5;
+    public override uint RequiredAreaRank => 2;
+    public override QuestId QuestUnlockId => QuestId.FeryanaWildernessLiberationArmySupport;
 
     public override void Initialize()
     {
         var enemies = new List<InstancedEnemy>()
         {
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 88, 4200, 0)
-				.SetInfectionType(3),
+                .SetInfectionType(3),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 88, 4200, 1)
-				.SetInfectionType(3),
+                .SetInfectionType(3),
             LibDdon.Enemy.Create(EnemyId.Lindwurm0, 88, 105000, 2)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 88, 4200, 3)
-				.SetInfectionType(3),
+                .SetInfectionType(3),
         };
 
         // Available Items (5): FeryanaSweetMushroom, ScarredLizardscalePelt, UnrefinedAlloyLump, UndeadDestroyerStoneShard, UndeadDestroyerStone

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar07_silver_hermits_stronghold.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/19_feryana_wilderness/ar07_silver_hermits_stronghold.csx
@@ -1,12 +1,15 @@
-// Silver Hermit's Stronghold — stageid463 GroupId8 MaxPos3 (positions 0-3)
-// Monster Caution Spot — Feryana Wilderness, Lv88, AR0
+/**
+ * @brief Enemy Spot in "Feryana Wilderness" for "Silver Hermit's Stronghold"
+ */
+
 #load "libs.csx"
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
     public override StageLayoutId StageLayoutId => Stage.FeryanaWilderness.AsStageLayoutId(8);
     public override QuestAreaId AreaId => QuestAreaId.FeryanaWilderness;
-    public override uint RequiredAreaRank => 7;
+    public override uint RequiredAreaRank => 5;
+    public override QuestId QuestUnlockId => QuestId.FeryanaWildernessPreventEnemyAttack;
 
     public class NamedParamId
     {
@@ -19,7 +22,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
         {
             LibDdon.Enemy.Create(EnemyId.Goremanticore, 88, 105000, 0)
                 .SetNamedEnemyParams(NamedParamId.BrutalHermit)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
             LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 1),
             LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 2),
             LibDdon.Enemy.Create(EnemyId.SnowHarpy, 88, 4200, 3),

--- a/Arrowgene.Ddon.Scripts/scripts/chat_commands/chain.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/chat_commands/chain.csx
@@ -1,0 +1,66 @@
+public class ChatCommand : IChatCommand
+{
+    public override AccountStateType AccountState => AccountStateType.GameMaster;
+    public override string CommandName => "chain";
+    public override string HelpText => "usage: `/chain [chainNumber]` - Updates the chain dungeon UI";
+
+    public override void Execute(DdonGameServer server, string[] command, GameClient client, ChatMessage message, List<ChatResponse> responses)
+    {
+        uint chainNumber = 0;
+
+        if (command.Length == 0)
+        {
+            responses.Add(ChatResponse.CommandError(client, "No arguments provided."));
+            return;
+        }
+
+        if (command.Length >= 1)
+        {
+            if (UInt32.TryParse(command[0], out uint parsedChain) && parsedChain >= 0 && parsedChain <= 15)
+            {
+                chainNumber = parsedChain;
+            }
+            else
+            {
+                responses.Add(ChatResponse.CommandError(client, $"Invalid chain number"));
+                return;
+            }
+        }
+
+        uint chestNumber = 0;
+
+        if (chainNumber >= 5 && chainNumber <= 9)
+        {
+            chestNumber = 1;
+        }
+        else if (chainNumber >= 10 && chainNumber <= 14)
+        {
+            chestNumber = 2;
+        }
+        else if (chainNumber == 15)
+        {
+            chestNumber = 3;
+        }
+
+        responses.Add(ChatResponse.ServerMessage(client, $"Chain number = {chainNumber}, unlocked chests = {chestNumber}"));
+
+        S2CSituationDataUpdateObjectivesNtc ntc = new S2CSituationDataUpdateObjectivesNtc()
+        {
+            Unk0 = false, // mission complete
+            Unk1 = 0, // final objective?
+            Unk2 = chainNumber,
+            Unk3 = 15, // max chains
+            Unk4 = chestNumber,
+            Unk5 = 3, // max chests
+            ObjectiveList = new()
+            {
+                new CDataSituationObjective() { Unk0 = 63, Unk1 = 196610, Message = "A minor abnormality has occurred" },
+                new CDataSituationObjective() { Unk0 = 65, Unk1 = 393225, Message = "A minor abnormality has occurred" },
+                new CDataSituationObjective() { Unk0 = 68, Unk1 = 851973, Message = "A minor abnormality has occurred" },
+                new CDataSituationObjective() { Unk0 = 68, Unk1 = 851974, Message = "A minor abnormality has occurred" }
+            }
+        };
+        client.Send(ntc);
+    }
+}
+return new ChatCommand();

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestId.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestId.cs
@@ -152,6 +152,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         LivingWithThePartnerPawn = 60200000,
         SkillAugmentationGuidanceOfARenewedWhiteDragon = 60200001,
         RoadToMastery = 60200014,
+        SupremeRadiance = 60200004,
         SpiritLancerTacticsTrialASpiritLance = 60200050,
         SeekingTheMasterSpiritLancer = 60200051,
 
@@ -229,6 +230,33 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         SummerBeachFestival1 = 60200033,
         SummerBeachFestival2 = 60200034,
         SummerBeachFestivalDecorations = 60200035,
+
+        // Episodic Personal Quests
+        WhoIsTheBest = 60200200,
+        StoryOfMayleafAndTheSongbird = 60200201,
+        KlausAndJoseph = 60200202,
+        LeosLegacy = 60200203,
+
+        // Rathnite Personal Quests
+        RathniteFoothillsRescueRequest = 60318001,
+        RathniteFoothillsLiberationArmySupport = 60318002,
+        RathniteFoothillsPursueAndDefeatEnemies = 60318003,
+        RathniteFoothillsPreventEnemyAttack = 60318004,
+        DemonArmyTankCatoblepas = 60318011,
+
+        // Feryana Personal Quests
+        FeryanaWildernessPursueAndDefeatEnemies = 60319001,
+        FeryanaWildernessLiberationArmySupport = 60319002,
+        FeryanaWildernessRescueRequest = 60319003,
+        FeryanaWildernessPreventEnemyAttack = 60319004,
+        IntoTheAncientDarkness = 60319011,
+
+        // Megadosys Personal Quests
+        MegadosysPlateauRescueRequest = 60320001,
+        MegadosysPlateauLiberationArmySupport = 60320002,
+        MegadosysPlateauPursueAndDefeatEnemies = 60320003,
+        MegadosysPlateauPreventEnemyAttack = 60320004,
+        TheRulerOverwhelmedByPower = 60320011,
 
         // Substory Quests
         TasteOfBitterMemories = 10300100,


### PR DESCRIPTION
Allows locking Caution Spots behind quest completion by adding a QuestUnlockId field (virtual, defaults to none) to check against, then locks all applicable Season 3.0 and 3.1 caution spots so they cannot spawn until their required quest is cleared, and reviews the affected Rathnite spots, updating enemy position, composition, and layout ID when needed.
QuestId.cs was updated with a few new entries, including the required quests for the spots.

Also adds /chain as a chat command, meant to be used inside Chain Dungeons to update objective data.