### PR TITLE
MSQ Thinking of A Friend Update

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000019.json
@@ -112,15 +112,34 @@
                     "message_id": 8203
                 },
                 {
-                    "type": "IsStageNo",
+                    "type": "Raw",
                     "checkpoint": true,
                     "announce_type": "Update",
+                    "hand_items": [
+                        {"id": 7578, "amount": 1, "comment": "Lake Cera Detached Pavillion Key"}
+                    ],
+                    "check_commands": [
+                        {"type": "HasUsedKey", "Param1": 100, "Param2": 3, "Param3": 1, "Param4": 70002001}
+                    ]
+                },
+                {
+                    "type": "IsStageNo",
+                    "checkpoint": true,
                     "stage_id": {
-                        "id": 61
+                        "id": 81
                     },
                     "contents_release": [
                         {"flag_info": "Lestania.TempleOfPurificationSouthChamber"}
+                    ],
+                    "consume_items": [
+                        {"id": 7578, "amount": 1, "comment": "Lake Cera Detached Pavillion Key"}
                     ]
+                },
+                {
+                    "type": "IsStageNo",
+                    "stage_id": {
+                        "id": 61
+                    }
                 },
                 {
                     "type": "TalkToNpc",


### PR DESCRIPTION
- The player now acquires a "Lake Cera Detached Pavillion Key" after talking to Leo.
- "Lake Cera Detached Pavillion Key" is now used to unlock the Temple of Purification South Chamber door.
- After unlocking the door, the quest now checks if you're inside the South Chamber before sending you to Zoma. https://youtu.be/xqWi8caTM4A?t=504 (check the minimap)