### PR TITLE
Check command 235: IsPartyMemberWearingSummerAttire 

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -2774,9 +2774,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
 
             /** @brief Checks if any party member has an item from the list at PTR_LAB_02141040[itemListIdx]. */
-            public static CDataQuestCommand IsPartyMemberHasItem(int itemListIdx, int param02 = 0, int param03 = 0, int param04 = 0)
+            public static CDataQuestCommand IsPartyMemberWearingSummerAttire(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsPartyMemberHasItem, Param01 = itemListIdx, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsPartyMemberWearingSummerAttire, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Returns bit 20 of the substory state word at ctx+0x5c+0x20c. */

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
@@ -861,10 +861,10 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdIsPartyMemberHasItem(this QuestBlock questBlock, int itemListIdx, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdIsPartyMemberWearingSummerAttire(this QuestBlock questBlock, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsPartyMemberHasItem(itemListIdx);
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsPartyMemberWearingSummerAttire();
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
@@ -780,9 +780,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdIsPartyMemberHasItem(this List<CDataQuestCommand> checkCommands, int itemListIdx)
+        public static List<CDataQuestCommand> AddCheckCmdIsPartyMemberWearingSummerAttire(this List<CDataQuestCommand> checkCommands)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsPartyMemberHasItem(itemListIdx));
+            checkCommands.Add(QuestManager.CheckCommand.IsPartyMemberWearingSummerAttire());
             return checkCommands;
         }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200033.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200033.csx
@@ -45,47 +45,11 @@ public class ScriptedQuest : IQuest
     protected override void InitializeBlocks()
     {
         var process0 = AddNewProcess(0);
-
-        var equipItems = new List<ItemId>
-        {
-            ItemId.VividGreenSwimsuitTop,
-            ItemId.VividGreenSwimsuitBottom,
-            ItemId.IndigoBlueSwimsuitTop,
-            ItemId.IndigoBlueSwimsuitBottom,
-            ItemId.BluishPurpleSwimsuitTop,
-            ItemId.BluishPurpleSwimsuitBottom,
-            ItemId.NightBlackSwimsuitTop,
-            ItemId.NightBlackSwimsuitBottom,
-            ItemId.SilverGraySwimsuitTop,
-            ItemId.SilverGraySwimsuitBottom,
-            ItemId.SettingSunSwimsuitTop,
-            ItemId.SettingSunSwimsuitBottom,
-            ItemId.AlluringSwimsuitTopGlitteringGold,
-            ItemId.AlluringSwimsuitBottomGlitteringGold,
-            ItemId.AlluringSwimsuitTopVividGreen,
-            ItemId.AlluringSwimsuitTopIndigoBlue,
-            ItemId.AlluringSwimsuitTopBluishPurple,
-            ItemId.AlluringSwimsuitTopSilverGray,
-            ItemId.AlluringSwimsuitTopSettingSun,
-            ItemId.AlluringSwimsuitBottomVividGreen,
-            ItemId.AlluringSwimsuitBottomIndigoBlue,
-            ItemId.AlluringSwimsuitBottomBluishPurple,
-            ItemId.AlluringSwimsuitBottomNightBlack,
-            ItemId.AlluringSwimsuitBottomSilverGray,
-            ItemId.AlluringSwimsuitBottomSettingSun,
-            ItemId.StrongBanded0,
-            ItemId.FishermansPants0,
-            ItemId.CoquettishBacks0,
-        };
-
         process0.AddNewNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, 1, 0, NpcId.Ray1, 25550)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.RayAndSamantha0)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.RayAndSamantha1);
-        var block = process0.AddRawBlock(QuestAnnounceType.Accept);
-        for (var i = 0; i < equipItems.Count; i++)
-        {
-            block = block.AddCheckCmdIsEquip(equipItems[i], i);
-        }
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddCheckCmdIsPartyMemberWearingSummerAttire();
         process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, 1, 0, NpcId.Ray1, 25552);
         process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.BreyaCoast);
         process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.BreyaCoast, 1, 1, NpcId.Ray1, 25554);

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -375,10 +375,10 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         IsSubstoryStateBit19 = 234, // 0x00636980 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Iterates up to 15 party members and checks main/hired pawn item lists against an item ID list
-        /// at PTR_LAB_02141040[itemListIdx] via FUN_004dadf0/FUN_004df8d0. Returns 1 if any match found.
+        /// Checks if party members are wearing summer attire on their clothing/legwear slots. Doesn't seem to check pawn gear?
+        /// Iterates party equipment and checks against an item ID list at PTR_LAB_02141040. Returns 1 if any match found. 
         /// </summary>
-        IsPartyMemberHasItem = 235, // 0x006369F0 (cQuestProcess* this, s32 itemListIdx, s32 param02, s32 param03, s32 param04)
+        IsPartyMemberWearingSummerAttire = 235, // 0x006369F0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Returns bit 20 of the substory state word at this→substory+0x20c.

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -4190,7 +4190,7 @@ IsTutorialSequenceActive(int param01 = 0, int param02 = 0, int param03 = 0, int 
 IsSubstoryStateBit19(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### IsPartyMemberHasItem (235)
+### IsPartyMemberWearingSummerAttire (235)
 
 | Field | Value |
 |-------|-------|
@@ -4200,11 +4200,14 @@ IsSubstoryStateBit19(int param01 = 0, int param02 = 0, int param03 = 0, int para
 
 ```
 /**
- * @brief Checks if any party member (up to 15) has an item matching a list entry.
- * Checks both main pawn and hired pawn item lists.
- * @param itemListIdx Index into the item ID list at PTR_LAB_02141040
+ * @brief Checks if party members are wearing summer attire on their clothing/legwear slots. Doesn't seem to check pawn gear.
+ * Iterates party equipment and checks against an item ID list at PTR_LAB_02141040. Returns 1 if any match found. 
+ * Equipment list:
+ * 14151-14162, 17954-17955, 19135-19146: Various Swimsuits
+ * 507, 2119, 3142, 4165, 5188: Fisherman's Pants
+ * 995, 2607, 3630, 4653, 5676, 8708-8712, 8723-8727 - Various lingeries
  */
-IsPartyMemberHasItem(int itemListIdx, int param02 = 0, int param03 = 0, int param04 = 0);
+IsPartyMemberWearingSummerAttire(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsSubstoryStateBit20 (236)


### PR DESCRIPTION
Renames IsPartyMemberHasItem to IsPartyMemberWearingSummerAttire, updates command parameters (uses none), adds a list of valid equipment to the reference doc.

(Really, Capcom?)