### PR TITLE
Command updates: 235, 236, 253

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -2773,16 +2773,16 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsSubstoryStateBit19, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Checks if any party member has an item from the list at PTR_LAB_02141040[itemListIdx]. */
-            public static CDataQuestCommand IsPartyMemberWearingSummerAttire(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks player equipment against a seasonal gear item list. 0 = Summer, 1 = Christmas. */
+            public static CDataQuestCommand IsEquipSeasonal(int listNo, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsPartyMemberWearingSummerAttire, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsEquipSeasonal, Param01 = listNo, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Returns bit 20 of the substory state word at ctx+0x5c+0x20c. */
-            public static CDataQuestCommand IsSubstoryStateBit20(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks if player has performed a limit break on an equipment. */
+            public static CDataQuestCommand DoLimitBreak(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsSubstoryStateBit20, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.DoLimitBreak, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Returns bit 21 of the substory state word at ctx+0x5c+0x20c. */
@@ -2875,10 +2875,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsWildHuntEnemyFound, Param01 = flagNo, Param02 = param02, Param03 = param03, Param04 = markerFlag };
             }
 
-            /** @brief Checks if contents/dungeon mode is active (area context mode 0xc, byte at +0x3b non-zero). */
-            public static CDataQuestCommand IsContentsModeStateFlag(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks if player has accepted and cleared a wild hunt quest. */
+            public static CDataQuestCommand IsWildHuntClear(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsContentsModeStateFlag, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsWildHuntClear, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Checks if a quest layout's HP-lost% <= hpLostPct (i.e., layout HP >= threshold). */

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
@@ -861,17 +861,17 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdIsPartyMemberWearingSummerAttire(this QuestBlock questBlock, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdIsEquipSeasonal(this QuestBlock questBlock, int listNo, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsPartyMemberWearingSummerAttire();
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsEquipSeasonal(listNo);
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdIsSubstoryStateBit20(this QuestBlock questBlock, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdDoLimitBreak(this QuestBlock questBlock, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsSubstoryStateBit20();
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdDoLimitBreak();
             return questBlock;
         }
 
@@ -973,10 +973,10 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdIsContentsModeStateFlag(this QuestBlock questBlock, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdIsWildHuntClear(this QuestBlock questBlock, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsContentsModeStateFlag();
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsWildHuntClear();
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
@@ -780,15 +780,15 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdIsPartyMemberWearingSummerAttire(this List<CDataQuestCommand> checkCommands)
+        public static List<CDataQuestCommand> AddCheckCmdIsEquipSeasonal(this List<CDataQuestCommand> checkCommands, int listNo)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsPartyMemberWearingSummerAttire());
+            checkCommands.Add(QuestManager.CheckCommand.IsEquipSeasonal(listNo));
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdIsSubstoryStateBit20(this List<CDataQuestCommand> checkCommands)
+        public static List<CDataQuestCommand> AddCheckCmdDoLimitBreak(this List<CDataQuestCommand> checkCommands)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsSubstoryStateBit20());
+            checkCommands.Add(QuestManager.CheckCommand.DoLimitBreak());
             return checkCommands;
         }
 
@@ -876,9 +876,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdIsContentsModeStateFlag(this List<CDataQuestCommand> checkCommands)
+        public static List<CDataQuestCommand> AddCheckCmdIsWildHuntClear(this List<CDataQuestCommand> checkCommands)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsContentsModeStateFlag());
+            checkCommands.Add(QuestManager.CheckCommand.IsWildHuntClear());
             return checkCommands;
         }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q61000000.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q61000000.csx
@@ -1,0 +1,51 @@
+/**
+ * @brief Information on Wild Hunt
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => (QuestId)61000000; // Schedule ID:
+    public override ushort RecommendedLevel => 100;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => false;
+    public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+    public override bool Enabled => false;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(70));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheNewGeneration));
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.RoadToMastery));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.MandragoraPottedPlant3Passport, 1);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear(QuestId.RoadToMastery);
+        process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Lisa, 31111);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.TheWhiteDragonTemple0, NpcId.Lisa, 31157);
+        process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
+            .AddResultCmdQstTalkChg(NpcId.Lisa, 31113)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.WildHuntQuests, TutorialId.WildHuntBasics)
+            .AddCheckCmdIsWildHuntClear();
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Update, Stage.TheWhiteDragonTemple0, NpcId.Lisa, 31156);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.WildHunt, TutorialId.WildHuntAdditionalNotes);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300003.csx
@@ -31,9 +31,10 @@ public class ScriptedQuest : IQuest
     {
         var process0 = AddNewProcess(0);
         process0.AddNpcTalkAndOrderBlock(Stage.CraftRoom, NpcId.Craig0, 26368);
-        process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.CraftRoom, false)
+        process0.AddRawBlock(QuestAnnounceType.Accept)
             .AddResultCmdTutorialDialog(TutorialId.LimitBreakingArms)
-            .AddAnnotation("TODO: Detect weapon has been limit broken");
+            .AddResultCmdQstTalkChg(NpcId.Craig0, 26369)
+            .AddCheckCmdDoLimitBreak();
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.CraftRoom, NpcId.Craig0, 26370);
         process0.AddProcessEndBlock(true);
     }

--- a/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200033.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/seasonal_events/summer/2018/q60200033.csx
@@ -49,7 +49,7 @@ public class ScriptedQuest : IQuest
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.RayAndSamantha0)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.RayAndSamantha1);
         process0.AddRawBlock(QuestAnnounceType.Accept)
-			.AddCheckCmdIsPartyMemberWearingSummerAttire();
+			.AddCheckCmdIsEquipSeasonal(0);
         process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, 1, 0, NpcId.Ray1, 25552);
         process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.BreyaCoast);
         process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.BreyaCoast, 1, 1, NpcId.Ray1, 25554);

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -375,15 +375,15 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         IsSubstoryStateBit19 = 234, // 0x00636980 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Checks if party members are wearing summer attire on their clothing/legwear slots. Doesn't seem to check pawn gear?
-        /// Iterates party equipment and checks against an item ID list at PTR_LAB_02141040. Returns 1 if any match found. 
+        /// Iterates 15 player equipment slots and checks against a seasonal item ID list (param01). Returns 1 if any match is found.
+        /// 0 = Summer, 1 = Christmas. Lists are not comprehensive.
         /// </summary>
-        IsPartyMemberWearingSummerAttire = 235, // 0x006369F0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        IsEquipSeasonal = 235, // 0x006369F0 (cQuestProcess* this, s32 listNo, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Returns bit 20 of the substory state word at this→substory+0x20c.
+        /// Checks if player has performed a limit break on an equipment (notice bit 20).
         /// </summary>
-        IsSubstoryStateBit20 = 236, // 0x00636B10 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        DoLimitBreak = 236, // 0x00636B10 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Returns bit 21 of the substory state word at this→substory+0x20c.
@@ -493,10 +493,10 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         IsWildHuntEnemyFound = 252, // 0x006376E0 (cQuestProcess* this, s32 flagNo, s32 param02_unused, s32 param03_unused, s32 markerFlag)
 
         /// <summary>
-        /// Checks if contents/dungeon mode is active. Calls FUN_00bdee50(0xc) to get area context (mode 0xc),
+        /// Checks if player has accepted and cleared a wild hunt quest. Calls FUN_00bdee50(0xc) to get area context (mode 0xc),
         /// reads byte at +0x3b; returns true if non-zero.
         /// </summary>
-        IsContentsModeStateFlag = 253, // 0x00637820 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        IsWildHuntClear = 253, // 0x00637820 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         Padding254 = 254, // 0x00637860 stub/nop - always returns 0
 

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -3648,7 +3648,7 @@ SetEnemyExpeditionState(int mode, int param02 = 0, int param03 = 0, int param04 
  * Updates the purpose message of the quest.
  * @note Seen inside chain dungeon packet capture
  * Sends world-manager NPC messages 0x25f and 0x260.
- * @param 
+ * @param
  */
 EndContentsPurposePhaseChange(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
@@ -4190,27 +4190,25 @@ IsTutorialSequenceActive(int param01 = 0, int param02 = 0, int param03 = 0, int 
 IsSubstoryStateBit19(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### IsPartyMemberWearingSummerAttire (235)
+### IsEquipSeasonal (235)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x006369F0` |
 | Table index | 235 |
-| Key callees | `FUN_00b956a0` (iterate up to 15 party members), `FUN_004dadf0` / `FUN_004df8d0` (check item lists), item ID list at `PTR_LAB_02141040[itemListIdx]` |
+| Key callees | `FUN_00b956a0` (iterate up to 15 equipment slots), `FUN_004dadf0` / `FUN_004df8d0` (check item lists), item ID list at `PTR_LAB_02141040[itemListIdx]` |
 
 ```
 /**
- * @brief Checks if party members are wearing summer attire on their clothing/legwear slots. Doesn't seem to check pawn gear.
- * Iterates party equipment and checks against an item ID list at PTR_LAB_02141040. Returns 1 if any match found. 
- * Equipment list:
- * 14151-14162, 17954-17955, 19135-19146: Various Swimsuits
- * 507, 2119, 3142, 4165, 5188: Fisherman's Pants
- * 995, 2607, 3630, 4653, 5676, 8708-8712, 8723-8727 - Various lingeries
+ * @brief Iterates 15 player equipment slots and checks against a seasonal item ID list (param01). Returns 1 if any match is found.
+ * 0 = Summer, 1 = Christmas. Lists are not comprehensive.
+ * Summer equipment ID list: 14151-14162, 17954-17955, 19135-19146, 507, 2119, 3142, 4165, 5188, 995, 2607, 3630, 4653, 5676, 8708-8712, 8723-8727
+ * Christmas equipment ID list: 19568, 19570, 19572, 19574, 19576, 19578, 19580, 19582, 19584, 19586, 19588, 19590, 16788-16799
  */
-IsPartyMemberWearingSummerAttire(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+IsEquipSeasonal(int listNo = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### IsSubstoryStateBit20 (236)
+### DoLimitBreak (236)
 
 | Field | Value |
 |-------|-------|
@@ -4220,9 +4218,10 @@ IsPartyMemberWearingSummerAttire(int param01 = 0, int param02 = 0, int param03 =
 
 ```
 /**
- * @brief Returns bit 20 of the substory state word at *(cQuestProcess+0x5c)+0x20c.
+ * @brief Checks if player has performed a limit break on an equipment.
+ * @brief Equipping limit broken equipment does not quality; the command checks notice bit 20 that signals the limit break action.
  */
-IsSubstoryStateBit20(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+DoLimitBreak(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsSubstoryStateBit21 (237)
@@ -4374,7 +4373,7 @@ IsTriggerFlagSetAndClear(int param01 = 0, int param02 = 0, int param03 = 0, int 
 ChainNotLess(int chainNo, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### IsContentsModeStateFlag (253)
+### IsWildHuntClear (253)
 
 | Field | Value |
 |-------|-------|
@@ -4384,10 +4383,11 @@ ChainNotLess(int chainNo, int param02 = 0, int param03 = 0, int param04 = 0);
 
 ```
 /**
- * @brief Checks if contents/dungeon mode is currently active.
+ * @brief Checks if player has accepted and cleared a wild hunt quest.
  * Reads byte at +0x3b from the mode-0xc area context; returns true if non-zero.
+ * Does not actually check for the accept (progression may be added to the database), only for the notice at quest completion moment.
  */
-IsContentsModeStateFlag(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+IsWildHuntClear(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsQuestLayoutHpNotGreater (255)
@@ -4446,17 +4446,18 @@ IsExtremeMissionClear(int questId, int param02_unused = 0, int param03_unused = 
 
 ```
 /**
- * @brief Kill-group completion check, gated on content mode. Verifies content mode via counter equality
+ * @brief Kill-group completion check, gated on content mode. Verifies content mode via counter equality.
+ * Content guard is also present in several transition check commands: most likely a player readiness check.
  * (ctx+0x4654 == ctx+0x45cc) and FUN_009d07f0(). If not in content mode and this+0x82 != 0, returns early.
- * Delegates to FUN_0063a5e0 which iterates the kill-group list, matches flagNo at entry+0x14,
+ * Calls check command IsKilledTargetEnemySetGroup (FUN_0063a5e0) which iterates the kill-group list, matches flagNo at entry+0x14,
  * checks entry+0x18 (valid byte) and entry+4 == 0 (all kills done).
  * The marker vs no-marker distinction (vs ID 243) is a runtime property of this+0x82, not code structure.
  * @note "mode=15" is not a literal constant in the code.
  * @note 5 total parameters (not 4).
  * @param flagNo  Kill-group flag identifier
- * @param param03 Passed to FUN_0063a5e0
- * @param param04 Passed to FUN_0063a5e0
- * @param param05 Passed to FUN_0063a5e0
+ * @param param03 Passed to IsKilledTargetEnemySetGroup
+ * @param param04 Passed to IsKilledTargetEnemySetGroup
+ * @param param05 Passed to IsKilledTargetEnemySetGroup
  */
 IsKilledTargetEnemySetGroupMode15(int flagNo, int param03 = 0, int param04 = 0, int param05 = 0);
 ```
@@ -4516,7 +4517,7 @@ IsContentsTimerBElapsed(int timerNo, int param02_unused = 0, int param03_unused 
 
 ```
 /**
- * @brief Direct thunk to FUN_0063a5e0 with no content-mode guard (unlike IDs 242/243).
+ * @brief Direct thunk to IsKilledTargetEnemySetGroup (FUN_0063a5e0) with no content-mode guard (unlike IDs 242/243).
  * Iterates the kill-group list on this, finds entry matching flagNo at entry+0x14,
  * checks entry+0x18 (valid) and entry+4 == 0 (kill complete). Only flagNo is used.
  * @note Formerly named "IsKilledTargetEnemySetGroupInRadius". Previous description "shape type 4 radius"
@@ -4557,7 +4558,7 @@ IsContentsTimerAZero(int timerNo, int param02_unused = 0, int param03_unused = 0
 | Table index | 252 |
 | System | **Wild Hunt** (`cMobHuntQuestManager` — "MobHunt" is the internal engine name for Wild Hunt) |
 | Key callees | `FUN_00a39f80(entry)` reads `entry+0x14` (flag ID); `FUN_00a3c2b0(sub)` reads `sub+4` (em ID field 1); `FUN_00a3a000(sub)` reads `sub+8` (em ID field 2); `FUN_00636c20(id1, id2, -1, param04)` — generic OM enemy discovered-state checker |
-| Kill state | vtable+0x2ec returns `0xc` (killed); fallback via `FUN_00c82ac0` |
+| Kill state | vtable+0x2ec returns `0xc` (found); fallback via `FUN_00c82ac0` |
 
 ```
 /**


### PR DESCRIPTION
Renames the following check commands:

- 235: IsPartyMemberWearingSummerAttire to IsEquipSeasonal. Accepts param1 again. Param1 changes which seasonal gear is being checked against (0 = summer, 1 = christmas). Summer quest updated.
- 236: IsSubstoryStateBit20 to DoLimitBreak. Updates quest Custom-Made Workshop 2: Limit Break to use the command.
- 253: IsContentsModeStateFlag to IsWildHuntClear. Adds quest Information on Wild Hunt to the disabled folder.