### PR TITLE
Check command 239: GetDominionPoint

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/ItemManager.cs
@@ -78,6 +78,9 @@ namespace Arrowgene.Ddon.GameServer.Characters
             {ItemId.SilverTicket, (WalletType.SilverTickets, 1) },
             {ItemId.CustomMadeServiceTicket, (WalletType.CustomMadeServiceTickets, 1) },
             {ItemId.GoldenGemstone, (WalletType.GoldenGemstones, 1) },
+            {ItemId.DominionPoint0, (WalletType.DominionPoints, 1) },
+            {ItemId.DominionPoint1, (WalletType.DominionPoints, 10) },
+            {ItemId.DominionPoint2, (WalletType.DominionPoints, 100) },
             // TODO: Find all items that add wallet points
         };
 

--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -2797,10 +2797,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.GetHighOrb, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Returns bit 23 of the substory state word at ctx+0x5c+0x20c. */
-            public static CDataQuestCommand IsSubstoryStateBit23(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Checks if player has obtained a Dominion Point from any source (notice bit 23). Quantity does not matter. */
+            public static CDataQuestCommand GetDominionPoint(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.IsSubstoryStateBit23, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestCheckCommand.GetDominionPoint, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Directly jumps to IsReleaseWarpPointAnyone, but cannot place quest markers. */

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockCheckCmdExtension.cs
@@ -889,10 +889,10 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddCheckCmdIsSubstoryStateBit23(this QuestBlock questBlock, int commandListIndex = 0)
+        public static QuestBlock AddCheckCmdGetDominionPoint(this QuestBlock questBlock, int commandListIndex = 0)
         {
             ValidateIndexAndUpdateCommandList(questBlock.CheckCommands, commandListIndex);
-            questBlock.CheckCommands[commandListIndex].AddCheckCmdIsSubstoryStateBit23();
+            questBlock.CheckCommands[commandListIndex].AddCheckCmdGetDominionPoint();
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestCheckCommandExtension.cs
@@ -804,9 +804,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return checkCommands;
         }
 
-        public static List<CDataQuestCommand> AddCheckCmdIsSubstoryStateBit23(this List<CDataQuestCommand> checkCommands)
+        public static List<CDataQuestCommand> AddCheckCmdGetDominionPoint(this List<CDataQuestCommand> checkCommands)
         {
-            checkCommands.Add(QuestManager.CheckCommand.IsSubstoryStateBit23());
+            checkCommands.Add(QuestManager.CheckCommand.GetDominionPoint());
             return checkCommands;
         }
 

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestCheckCommand.cs
@@ -395,9 +395,9 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         GetHighOrb = 238, // 0x00636BA0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
-        /// Returns bit 23 of the substory state word at this→substory+0x20c.
+        /// Checks if player has obtained a Dominion Point from any source (notice bit 23). Quantity does not matter.
         /// </summary>
-        IsSubstoryStateBit23 = 239, // 0x00636BD0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        GetDominionPoint = 239, // 0x00636BD0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         /// <summary>
         /// Directly jumps to IsReleaseWarpPointAnyone, but cannot place quest markers.

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -4255,7 +4255,7 @@ DoExtremeSynthesis(int param01 = 0, int param02 = 0, int param03 = 0, int param0
 IsSubstoryStateBit22(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### IsSubstoryStateBit23 (239)
+### GetDominionPoint (239)
 
 | Field | Value |
 |-------|-------|
@@ -4265,9 +4265,10 @@ IsSubstoryStateBit22(int param01 = 0, int param02 = 0, int param03 = 0, int para
 
 ```
 /**
- * @brief Returns bit 23 of the substory state word at *(cQuestProcess+0x5c)+0x20c.
+ * @brief Checks if player has obtained a Dominion Point from any source (notice bit 23). Quantity does not matter.
+ * @brief High Orbs already in the player's wallet do not count: they must obtain orbs from a new source.
  */
-IsSubstoryStateBit23(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+GetDominionPoint(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### IsReleaseWarpPointAnyoneNoMarker (240)


### PR DESCRIPTION
Renames check command 239 from IsSubstoryStateBit23 to GetDominionPoint.
Adds entries to ItemManager.cs allowing Dominion Points to be added to the player's wallet upon consuming the item.