### PR TITLE
Result command 130: EndChain

### DIFF
--- a/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/QuestManager.cs
@@ -3965,10 +3965,10 @@ namespace Arrowgene.Ddon.GameServer.Characters
                 return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.TriggerSubstoryEndSequence, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
-            /** @brief Checks if a pawn has OM state == 4 and a specific animation condition via FUN_0087dc50. */
-            public static CDataQuestCommand CheckSubstoryCondition(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+            /** @brief Sends packet 63.5.16 (C2S_CHAIN_DUNGEON_END_CHAIN_NTC) kickstarting the rewards phase of chain dungeons. */
+            public static CDataQuestCommand EndChain(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
             {
-                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.CheckSubstoryCondition, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
+                return new CDataQuestCommand() { Command = (ushort)QuestResultCommand.EndChain, Param01 = param01, Param02 = param02, Param03 = param03, Param04 = param04 };
             }
 
             /** @brief Controls pawn expedition. mode=1: starts; mode=2: stops. */

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestBlockResultCmdExtension.cs
@@ -446,9 +446,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return questBlock;
         }
 
-        public static QuestBlock AddResultCmdCheckSubstoryCondition(this QuestBlock questBlock, int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+        public static QuestBlock AddResultCmdEndChain(this QuestBlock questBlock)
         {
-            questBlock.ResultCommands.AddResultCmdCheckSubstoryCondition(param01, param02, param03, param04);
+            questBlock.ResultCommands.AddResultCmdEndChain();
             return questBlock;
         }
 

--- a/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
+++ b/Arrowgene.Ddon.GameServer/Quests/Extensions/QuestResultCommandExtension.cs
@@ -449,9 +449,9 @@ namespace Arrowgene.Ddon.GameServer.Quests.Extensions
             return resultCommands;
         }
 
-        public static List<CDataQuestCommand> AddResultCmdCheckSubstoryCondition(this List<CDataQuestCommand> resultCommands, int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0)
+        public static List<CDataQuestCommand> AddResultCmdEndChain(this List<CDataQuestCommand> resultCommands)
         {
-            resultCommands.Add(QuestManager.ResultCommand.CheckSubstoryCondition(param01, param02, param03, param04));
+            resultCommands.Add(QuestManager.ResultCommand.EndChain());
             return resultCommands;
         }
 

--- a/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
+++ b/Arrowgene.Ddon.Shared/Entity/EntitySerializer.cs
@@ -477,6 +477,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new CDataStageInfo.Serializer());
             Create(new CDataStageLayoutEnemyPresetEnemyInfoClient.Serializer());
             Create(new CDataStageLayoutId.Serializer());
+            Create(new CDataStageLayoutInfo.Serializer());
             Create(new CDataStageTicketDungeonCategory.Serializer());
             Create(new CDataStageTicketDungeonCategoryInfo.Serializer());
             Create(new CDataStageTicketDungeonItemInfo.Serializer());
@@ -587,6 +588,8 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new C2SBlackListRemoveBlackListReq.Serializer());
 
             Create(new C2SCertClientChallengeReq.Serializer());
+
+            Create(new C2SChainDungeonEndChainNtc.Serializer());
 
             Create(new C2SCharacterCharacterDeadNtc.Serializer());
             Create(new C2SCharacterCharacterDownCancelNtc.Serializer());
@@ -1851,6 +1854,7 @@ namespace Arrowgene.Ddon.Shared.Entity
             Create(new S2C_63_0_16_NTC.Serializer());
             Create(new S2C_63_10_16_NTC.Serializer());
             Create(new C2S_63_11_16_NTC.Serializer());
+            Create(new S2CChainDungeonRewardChestAppearNtc.Serializer());
             Create(new S2C_63_7_16_NTC.Serializer());
             Create(new S2C_BATTLE_71_13_16_NTC.Serializer());
             Create(new S2C_SEASON_62_22_16_NTC.Serializer());

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SChainDungeonEndChainNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/C2SChainDungeonEndChainNtc.cs
@@ -1,0 +1,27 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Network;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class C2SChainDungeonEndChainNtc : IPacketStructure
+    {
+        public PacketId Id => PacketId.C2S_CHAIN_DUNGEON_END_CHAIN_NTC;
+
+        public C2SChainDungeonEndChainNtc()
+        {
+        }
+
+        public class Serializer : PacketEntitySerializer<C2SChainDungeonEndChainNtc>
+        {
+            public override void Write(IBuffer buffer, C2SChainDungeonEndChainNtc obj)
+            {
+            }
+
+            public override C2SChainDungeonEndChainNtc Read(IBuffer buffer)
+            {
+                C2SChainDungeonEndChainNtc obj = new C2SChainDungeonEndChainNtc();
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CChainDungeonRewardChestAppearNtc.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2CChainDungeonRewardChestAppearNtc.cs
@@ -1,0 +1,34 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Entity.Structure;
+using Arrowgene.Ddon.Shared.Network;
+using System.Collections.Generic;
+
+namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
+{
+    public class S2CChainDungeonRewardChestAppearNtc : ServerResponse
+    {
+        public override PacketId Id => PacketId.S2C_CHAIN_DUNGEON_REWARD_CHEST_APPEAR_NTC;
+
+        public S2CChainDungeonRewardChestAppearNtc()
+        {
+            RewardChestList = new List<CDataStageLayoutInfo>();
+        }
+
+        public List<CDataStageLayoutInfo> RewardChestList { get; set; }
+
+        public class Serializer : PacketEntitySerializer<S2CChainDungeonRewardChestAppearNtc>
+        {
+            public override void Write(IBuffer buffer, S2CChainDungeonRewardChestAppearNtc obj)
+            {
+                WriteEntityList(buffer, obj.RewardChestList);
+            }
+
+            public override S2CChainDungeonRewardChestAppearNtc Read(IBuffer buffer)
+            {
+                S2CChainDungeonRewardChestAppearNtc obj = new S2CChainDungeonRewardChestAppearNtc();
+                obj.RewardChestList = ReadEntityList<CDataStageLayoutInfo>(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_63_7_16_NTC.cs
+++ b/Arrowgene.Ddon.Shared/Entity/PacketStructure/S2C_63_7_16_NTC.cs
@@ -1,6 +1,5 @@
 using Arrowgene.Buffers;
 using Arrowgene.Ddon.Shared.Entity.Structure;
-using Arrowgene.Ddon.Shared.Model;
 using Arrowgene.Ddon.Shared.Network;
 using System.Collections.Generic;
 
@@ -12,10 +11,10 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
 
         public S2C_63_7_16_NTC()
         {
-            Unk0List = new List<CDataS2C_63_7_16>();
+            Unk0List = new List<CDataStageLayoutInfo>();
         }
-    
-        public List<CDataS2C_63_7_16> Unk0List {  get; set; }
+
+        public List<CDataStageLayoutInfo> Unk0List {  get; set; }
 
         public class Serializer : PacketEntitySerializer<S2C_63_7_16_NTC>
         {
@@ -27,35 +26,7 @@ namespace Arrowgene.Ddon.Shared.Entity.PacketStructure
             public override S2C_63_7_16_NTC Read(IBuffer buffer)
             {
                 S2C_63_7_16_NTC obj = new S2C_63_7_16_NTC();
-                obj.Unk0List = ReadEntityList<CDataS2C_63_7_16>(buffer);
-                return obj;
-            }
-        }
-    }
-
-    public class CDataS2C_63_7_16
-    {
-        public CDataS2C_63_7_16()
-        {
-            LayoutId = new CDataStageLayoutId();
-        }
-
-        public CDataStageLayoutId LayoutId { get; set; }
-        public uint Unk0 { get; set; }
-
-        public class Serializer : EntitySerializer<CDataS2C_63_7_16>
-        {
-            public override void Write(IBuffer buffer, CDataS2C_63_7_16 obj)
-            {
-                WriteEntity(buffer, obj.LayoutId);
-                WriteUInt32(buffer, obj.Unk0);
-            }
-
-            public override CDataS2C_63_7_16 Read(IBuffer buffer)
-            {
-                CDataS2C_63_7_16 obj = new CDataS2C_63_7_16();
-                obj.LayoutId = ReadEntity<CDataStageLayoutId>(buffer);
-                obj.Unk0 = ReadUInt32(buffer);
+                obj.Unk0List = ReadEntityList<CDataStageLayoutInfo>(buffer);
                 return obj;
             }
         }

--- a/Arrowgene.Ddon.Shared/Entity/Structure/CDataStageLayoutInfo.cs
+++ b/Arrowgene.Ddon.Shared/Entity/Structure/CDataStageLayoutInfo.cs
@@ -1,0 +1,33 @@
+using Arrowgene.Buffers;
+using Arrowgene.Ddon.Shared.Model.Quest;
+
+namespace Arrowgene.Ddon.Shared.Entity.Structure
+{
+    public class CDataStageLayoutInfo
+    {
+        public CDataStageLayoutInfo()
+        {
+            LayoutId = new CDataStageLayoutId();
+        }
+
+        public CDataStageLayoutId LayoutId { get; set; }
+        public uint PosId { get; set; }
+
+        public class Serializer : EntitySerializer<CDataStageLayoutInfo>
+        {
+            public override void Write(IBuffer buffer, CDataStageLayoutInfo obj)
+            {
+                WriteEntity(buffer, obj.LayoutId);
+                WriteUInt32(buffer, obj.PosId);
+            }
+
+            public override CDataStageLayoutInfo Read(IBuffer buffer)
+            {
+                CDataStageLayoutInfo obj = new CDataStageLayoutInfo();
+                obj.LayoutId = ReadEntity<CDataStageLayoutId>(buffer);
+                obj.PosId = ReadUInt32(buffer);
+                return obj;
+            }
+        }
+    }
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_1.json
@@ -86,7 +86,7 @@
       "message_id": 11156
     },
     {
-      "type": "DeliverItems",
+      "type": "NewDeliverItems",
       "stage_id": {
         "id": 1,
         "group_id": 1,

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_2.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q20030000_2.json
@@ -86,7 +86,7 @@
       "message_id": 11156
     },
     {
-      "type": "DeliverItems",
+      "type": "NewDeliverItems",
       "stage_id": {
         "id": 1,
         "group_id": 1,

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestResultCommand.cs
@@ -264,9 +264,11 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
         Padding129 = 129, // 0x00634690 stub/nop - always returns 0
 
         /// <summary>
-        /// Checks if a pawn has OM state == 4 and a specific animation condition via FUN_0087dc50.
+        /// Sends packet 63.5.16 (C2S_CHAIN_DUNGEON_END_CHAIN_NTC) kickstarting the rewards phase of chain dungeons.
+        /// In the dumps, packet was responded by 63.2.16 (situation data update) and 63.6.16 (spawns chests based on progress tracked by 63.2.16).
+        /// Should have conditions: OM state == 4 and a specific animation condition via FUN_0087dc50, but always sends the packet regardless?
         /// </summary>
-        CheckSubstoryCondition = 130, // 0x006346B0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
+        EndChain = 130, // 0x006346B0 (cQuestProcess* this, s32 param01, s32 param02, s32 param03, s32 param04)
 
         Padding131 = 131, // 0x00634720 stub/nop - always returns 0
         Padding132 = 132, // 0x00634750 stub/nop - always returns 0

--- a/Arrowgene.Ddon.Shared/Network/PacketId.cs
+++ b/Arrowgene.Ddon.Shared/Network/PacketId.cs
@@ -2006,8 +2006,8 @@ namespace Arrowgene.Ddon.Shared.Network
         public static readonly PacketId S2C_63_1_16_NTC = new PacketId(63, 1, 16, "S2C_63_1_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_63_2_16_NTC = new PacketId(63, 2, 16, "S2C_63_2_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_63_3_16_NTC = new PacketId(63, 3, 16, "S2C_63_3_16_NTC", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_63_5_16_NTC = new PacketId(63, 5, 16, "S2C_63_5_16_NTC", ServerType.Game, PacketSource.Server);
-        public static readonly PacketId S2C_63_6_16_NTC = new PacketId(63, 6, 16, "S2C_63_6_16_NTC", ServerType.Game, PacketSource.Server);
+        public static readonly PacketId C2S_CHAIN_DUNGEON_END_CHAIN_NTC = new PacketId(63, 5, 16, "C2S_CHAIN_DUNGEON_END_CHAIN_NTC", ServerType.Game, PacketSource.Client);
+        public static readonly PacketId S2C_CHAIN_DUNGEON_REWARD_CHEST_APPEAR_NTC = new PacketId(63, 6, 16, "S2C_CHAIN_DUNGEON_REWARD_CHEST_APPEAR_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_63_7_16_NTC = new PacketId(63, 7, 16, "S2C_63_7_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId S2C_63_10_16_NTC = new PacketId(63, 10, 16, "S2C_63_10_16_NTC", ServerType.Game, PacketSource.Server);
         public static readonly PacketId C2S_63_11_16_NTC = new PacketId(63, 11, 16, "S2C_63_11_16_NTC", ServerType.Game, PacketSource.Server);
@@ -3938,8 +3938,8 @@ namespace Arrowgene.Ddon.Shared.Network
             AddPacketIdEntry(packetIds, S2C_63_1_16_NTC);
             AddPacketIdEntry(packetIds, S2C_63_2_16_NTC);
             AddPacketIdEntry(packetIds, S2C_63_3_16_NTC);
-            AddPacketIdEntry(packetIds, S2C_63_5_16_NTC);
-            AddPacketIdEntry(packetIds, S2C_63_6_16_NTC);
+            AddPacketIdEntry(packetIds, C2S_CHAIN_DUNGEON_END_CHAIN_NTC);
+            AddPacketIdEntry(packetIds, S2C_CHAIN_DUNGEON_REWARD_CHEST_APPEAR_NTC);
             AddPacketIdEntry(packetIds, S2C_63_7_16_NTC);
             AddPacketIdEntry(packetIds, S2C_63_10_16_NTC);
             AddPacketIdEntry(packetIds, C2S_63_11_16_NTC);

--- a/docs/quests/quest_command_reference.md
+++ b/docs/quests/quest_command_reference.md
@@ -3658,19 +3658,21 @@ SetEnemyExpeditionState(int mode, int param02 = 0, int param03 = 0, int param04 
 EndContentsPurposePhaseChange(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
-### CheckSubstoryCondition (130)
+### EndChain (130)
 
 | Field | Value |
 |-------|-------|
 | Address | `0x006346B0` |
 | Table index | 130 |
-| Key callees | `FUN_0087dc50()` — checks pawn OM state == 4 and animation condition |
+| Key callees | `FUN_0087dc50()` — checks OM state == 4 and animation condition |
 
 ```
 /**
- * @brief Checks if a pawn has OM state == 4 and a specific animation condition (via FUN_0087dc50).
+ * Sends packet 63.5.16 (C2S_CHAIN_DUNGEON_END_CHAIN_NTC) kickstarting the rewards phase of chain dungeons.
+ * In the dumps, packet was responded by 63.2.16 (situation data update) and 63.6.16 (spawns chests based on progress tracked by 63.2.16).
+ * Should have conditions: OM state == 4 and a specific animation condition via FUN_0087dc50, but always sends the packet regardless?
  */
-CheckSubstoryCondition(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
+EndChain(int param01 = 0, int param02 = 0, int param03 = 0, int param04 = 0);
 ```
 
 ### SetPawnExpeditionFlag (133)


### PR DESCRIPTION
- Renames result command 130 from CheckSubstoryCondition to EndChain
- Adds structure CDataStageLayoutInfo.cs
- Renames packet S2C_63_5_16_NTC to C2S_CHAIN_DUNGEON_END_CHAIN_NTC and packet S2C_63_6_16_NTC to S2C_CHAIN_DUNGEON_REWARD_CHEST_APPEAR_NTC
- S2C_63_7_16_NTC now uses CDataStageLayoutInfo