### PR TITLE
Update schema_sqlite.sql to match PR #1080

### DIFF
--- a/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/schema_sqlite.sql
@@ -795,6 +795,7 @@ CREATE TABLE IF NOT EXISTS "ddon_bbm_progress"
     "tier"             INTEGER             NOT NULL,
     "killed_death"     BOOLEAN             NOT NULL,
     "last_ticket_time" INTEGER             NOT NULL,
+    "is_paid_reset"    BOOLEAN             NOT NULL DEFAULT 0,
     CONSTRAINT "fk_ddon_bbm_progress_character_id" FOREIGN KEY ("character_id") REFERENCES "ddon_character" ("character_id") ON DELETE CASCADE
 );
 


### PR DESCRIPTION
Update DB schema to match migration changes in PR #1080 so new databases don't throw errors on character creation.

Currently, on a fresh database a column is missing in the schema, resulting in an S-1 error during character creation due to the server failing to set up your BBM progress. The client soft-locks and has to be forcibly shut down.

# Checklist:
- [x] The project compiles
- [x] The PR targets `develop` branch
