### PR TITLE
Caution spot updates

### DIFF
--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar02_hidden_beach.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar02_hidden_beach.csx
@@ -23,19 +23,19 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.RogueFighter, 10, 100, 0)
+            LibDdon.Enemy.Create(EnemyId.RogueFighter, 10, 62, 17)
                 .SetDropsTable(dropsTable)
                 .SetHmPresetNo(HmPresetId.RogueFighter)
                 .SetNamedEnemyParams(NamedParamId.HiddenBeachRogue),
-            LibDdon.Enemy.Create(EnemyId.RogueSeeker, 10, 100, 1)
+            LibDdon.Enemy.Create(EnemyId.RogueSeeker, 10, 62, 18)
                 .SetDropsTable(dropsTable)
                 .SetHmPresetNo(HmPresetId.RogueSeeker)
                 .SetNamedEnemyParams(NamedParamId.HiddenBeachRogue),
-            LibDdon.Enemy.Create(EnemyId.RogueHunter, 10, 100, 2)
+            LibDdon.Enemy.Create(EnemyId.RogueHunter, 10, 62, 19)
                 .SetDropsTable(dropsTable)
                 .SetHmPresetNo(HmPresetId.RogueHunter)
                 .SetNamedEnemyParams(NamedParamId.HiddenBeachRogue),
-            LibDdon.Enemy.Create(EnemyId.RogueMage, 10, 100, 3)
+            LibDdon.Enemy.Create(EnemyId.RogueMage, 10, 62, 20)
                 .SetDropsTable(dropsTable)
                 .SetHmPresetNo(HmPresetId.RogueMage)
                 .SetNamedEnemyParams(NamedParamId.HiddenBeachRogue),

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar03_birdcall_rock.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar03_birdcall_rock.csx
@@ -23,13 +23,21 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 384, 1)
+            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 52, 10)
                 .SetDropsTable(namedEnemyDrops)
                 .SetNamedEnemyParams(NamedParamId.MotherHarpy),
-            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 276, 0),
-            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 276, 2),
-            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 276, 3),
-            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 276, 4),
+            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 52, 11)
+                .SetDropsTable(namedEnemyDrops)
+                .SetNamedEnemyParams(NamedParamId.MotherHarpy),
+            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 52, 12)
+                .SetDropsTable(namedEnemyDrops)
+                .SetNamedEnemyParams(NamedParamId.MotherHarpy),
+            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 52, 13)
+                .SetDropsTable(namedEnemyDrops)
+                .SetNamedEnemyParams(NamedParamId.MotherHarpy),
+            LibDdon.Enemy.Create(EnemyId.Harpy, 13, 52, 14)
+                .SetDropsTable(namedEnemyDrops)
+                .SetNamedEnemyParams(NamedParamId.MotherHarpy),
         });
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar05_goblin_camp.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar05_goblin_camp.csx
@@ -28,7 +28,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var namedEnemyDrops = LibDdon.Enemy.GetDropsTable(EnemyId.HobgoblinLeader, 20).Clone()
+        var namedEnemyDrops = LibDdon.Enemy.GetDropsTable(EnemyId.HobgoblinLeader, 19).Clone()
             .AddDrop(ItemId.BronzeScale0, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.HematiteSand, 1, 3, DropRate.VERY_COMMON)
             .AddDrop(ItemId.LeatherCord, 1, 1, DropRate.UNCOMMON)
@@ -36,20 +36,14 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.HobgoblinLeader, 20, 706, 2)
+            LibDdon.Enemy.Create(EnemyId.HobgoblinLeader, 19, 105, 0)
                 .SetDropsTable(namedEnemyDrops)
                 .SetNamedEnemyParams(NamedParamId.GyumulTheSpikedHorn),
-            CreateRandomHobgoblin(18, 510, 0)
+            CreateRandomHobgoblin(18, 96, 1)
                 .SetNamedEnemyParams(NamedParamId.GyumulsMinion),
-            CreateRandomHobgoblin(18, 510, 1)
+            CreateRandomHobgoblin(18, 96, 2)
                 .SetNamedEnemyParams(NamedParamId.GyumulsMinion),
-            CreateRandomHobgoblin(18, 510, 3)
-                .SetNamedEnemyParams(NamedParamId.GyumulsMinion),
-            CreateRandomHobgoblin(18, 510, 4)
-                .SetNamedEnemyParams(NamedParamId.GyumulsMinion),
-            CreateRandomHobgoblin(18, 510, 5)
-                .SetNamedEnemyParams(NamedParamId.GyumulsMinion),
-            CreateRandomHobgoblin(18, 510, 6)
+            CreateRandomHobgoblin(18, 96, 3)
                 .SetNamedEnemyParams(NamedParamId.GyumulsMinion),
         });
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar07_deserted_village_of_ruflow.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar07_deserted_village_of_ruflow.csx
@@ -24,11 +24,17 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.Wight0, 23, 874, 0)
+            LibDdon.Enemy.Create(EnemyId.Wight0, 23, 1336, 3)
                 .SetIsBoss(true)
                 .SetScale(115)
                 .SetDropsTable(namedEnemyDrops)
                 .SetNamedEnemyParams(NamedParamId.SpecterOfRuflow)
+                .SetSpawnTime(GameTimeManager.NightTime),
+            LibDdon.Enemy.Create(EnemyId.SkeletonKnight, 21, 95, 4)
+                .SetNamedEnemyParams(NamedParamId.FormerVillager)
+                .SetSpawnTime(GameTimeManager.NightTime),
+            LibDdon.Enemy.Create(EnemyId.SkeletonKnight, 21, 95, 5)
+                .SetNamedEnemyParams(NamedParamId.FormerVillager)
                 .SetSpawnTime(GameTimeManager.NightTime),
         });
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar07_deserted_village_of_ruflow_2.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar07_deserted_village_of_ruflow_2.csx
@@ -1,0 +1,47 @@
+/**
+ * @brief Enemy Spot in "Breya Coast" for "Deserted Village of Ruflow"
+ */
+
+#load "libs.csx"
+
+public class MonsterSpotInfo : IMonsterSpotInfo
+{
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(104);
+    public override QuestAreaId AreaId => QuestAreaId.BreyaCoast;
+    public override bool CautionPlayer => false;
+    public override uint RequiredAreaRank => 7;
+
+    public class NamedParamId
+    {
+        public const uint FormerVillager = 204; // Former Villager
+    }
+
+    public override void Initialize()
+    {
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.Skeleton, 20, 73, 4)
+                .SetNamedEnemyParams(NamedParamId.FormerVillager)
+                .SetSpawnTime(GameTimeManager.NightTime)
+				.SetStartThinkTblNo(8)
+				.SetIsManualSet(true),
+            LibDdon.Enemy.Create(EnemyId.Skeleton, 20, 73, 5)
+                .SetNamedEnemyParams(NamedParamId.FormerVillager)
+                .SetSpawnTime(GameTimeManager.NightTime)
+				.SetStartThinkTblNo(8)
+				.SetIsManualSet(true),
+            LibDdon.Enemy.Create(EnemyId.Skeleton, 20, 73, 6)
+                .SetNamedEnemyParams(NamedParamId.FormerVillager)
+                .SetSpawnTime(GameTimeManager.NightTime)
+				.SetStartThinkTblNo(8)
+				.SetIsManualSet(true),
+            LibDdon.Enemy.Create(EnemyId.Skeleton, 20, 73, 7)
+                .SetNamedEnemyParams(NamedParamId.FormerVillager)
+                .SetSpawnTime(GameTimeManager.NightTime)
+				.SetStartThinkTblNo(8)
+				.SetIsManualSet(true),
+        });
+    }
+}
+
+return new MonsterSpotInfo();

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar08_blue_claw_beach.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/02_breya_coast/ar08_blue_claw_beach.csx
@@ -6,7 +6,7 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(103);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(98);
     public override QuestAreaId AreaId => QuestAreaId.BreyaCoast;
     public override uint RequiredAreaRank => 8;
 
@@ -25,7 +25,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.ArmoredCyclops, 27, 1126, 0)
+            LibDdon.Enemy.Create(EnemyId.ArmoredCyclops, 27, 2756, 2)
                 .SetIsBoss(true)
                 .SetScale(135)
                 .SetDropsTable(namedEnemyDrops)

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/06_mysree_grove/ar03_inias_wetlands.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/06_mysree_grove/ar03_inias_wetlands.csx
@@ -6,7 +6,7 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(147);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(142);
     public override QuestAreaId AreaId => QuestAreaId.MysreeGrove;
     public override uint RequiredAreaRank => 3;
 
@@ -23,16 +23,13 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.BlueNewt, 35, 0)
+            LibDdon.Enemy.Create(EnemyId.BlueNewt, 35, 173, 10)
                 .SetDropsTable(dropsTable)
                 .SetNamedEnemyParams(NamedParamId.CobaltNewt),
-            LibDdon.Enemy.CreateAuto(EnemyId.BlueNewt, 35, 1)
+            LibDdon.Enemy.Create(EnemyId.BlueNewt, 35, 173, 11)
                 .SetDropsTable(dropsTable)
                 .SetNamedEnemyParams(NamedParamId.CobaltNewt),
-            LibDdon.Enemy.CreateAuto(EnemyId.BlueNewt, 35, 2)
-                .SetDropsTable(dropsTable)
-                .SetNamedEnemyParams(NamedParamId.CobaltNewt),
-            LibDdon.Enemy.CreateAuto(EnemyId.BlueNewt, 35, 3)
+            LibDdon.Enemy.Create(EnemyId.BlueNewt, 35, 173, 12)
                 .SetDropsTable(dropsTable)
                 .SetNamedEnemyParams(NamedParamId.CobaltNewt),
         };

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/06_mysree_grove/ar09_the_giants_bed.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/06_mysree_grove/ar09_the_giants_bed.csx
@@ -19,7 +19,7 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         var enemies = new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.MoleTroll0, 43, 2)
+            LibDdon.Enemy.Create(EnemyId.MoleTroll0, 43, 4080, 2)
                 .SetIsBoss(true)
                 .SetNamedEnemyParams(NamedParamId.JotunTheReturned),
         };

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar02_twin_wheel_valley.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar02_twin_wheel_valley.csx
@@ -12,7 +12,6 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public class NamedParamId
     {
-        public const uint MergodaPatrolCorps = 251; // Mergoda Patrol Corps
         public const uint MergodaFemaleOfficer = 252; // Mergoda Female Officer
     }
 
@@ -20,11 +19,10 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.Witch, 47, 0, isBoss: true)
+            LibDdon.Enemy.Create(EnemyId.Witch, 47, 3024, 1)
+                .SetIsBoss(true)
                 .SetNamedEnemyParams(NamedParamId.MergodaFemaleOfficer)
                 .AddDrop(ItemId.CrestOfGreaterMagick0, 1, 3, DropRate.UNCOMMON),
-            LibDdon.Enemy.CreateAuto(EnemyId.AlchemizedSkeleton, 46, 1)
-                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
         });
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar02_twin_wheel_valley_2.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar02_twin_wheel_valley_2.csx
@@ -1,0 +1,39 @@
+/**
+ * @brief Enemy Spot in "Zandora Wastelands" for "Twin Wheel Valley"
+ */
+
+#load "libs.csx"
+
+public class MonsterSpotInfo : IMonsterSpotInfo
+{
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(362);
+    public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
+    public override bool CautionPlayer => false;
+    public override uint RequiredAreaRank => 2;
+
+    public class NamedParamId
+    {
+        public const uint MergodaPatrolCorps = 251; // Mergoda Patrol Corps
+    }
+
+    public override void Initialize()
+    {
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.AlchemizedSkeleton, 46, 444, 6)
+                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
+            LibDdon.Enemy.Create(EnemyId.AlchemizedSkeleton, 46, 444, 7)
+                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
+            LibDdon.Enemy.Create(EnemyId.AlchemizedSkeleton, 46, 444, 8)
+                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
+            LibDdon.Enemy.Create(EnemyId.AlchemizedSkeleton, 46, 444, 9)
+                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
+            LibDdon.Enemy.Create(EnemyId.AlchemizedSkeleton, 46, 444, 10)
+                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
+            LibDdon.Enemy.Create(EnemyId.AlchemizedSkeleton, 46, 444, 11)
+                .SetNamedEnemyParams(NamedParamId.MergodaPatrolCorps),
+        });
+    }
+}
+
+return new MonsterSpotInfo();

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt.csx
@@ -6,26 +6,22 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(360);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(439);
     public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
     public override uint RequiredAreaRank => 4;
 
     public class NamedParamId
     {
         public const uint RustedIronGiantWarrior = 249; // Rusted Iron Giant Warrior
-        public const uint RustedAlchemizedGoblin = 250; // Rusted Alchemized Goblin
     }
 
     public override void Initialize()
     {
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.DamnedGolem, 49, 2, isBoss: true)
+            LibDdon.Enemy.Create(EnemyId.DamnedGolem, 49, 4617, 1)
+                .SetIsBoss(true)
                 .SetNamedEnemyParams(NamedParamId.RustedIronGiantWarrior),
-            LibDdon.Enemy.CreateAuto(EnemyId.DamnedGoblin, 49, 0)
-                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
-            LibDdon.Enemy.CreateAuto(EnemyId.DamnedSlingGoblinFlask, 49, 1)
-                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
         });
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt_2.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt_2.csx
@@ -1,0 +1,32 @@
+/**
+ * @brief Enemy Spot in "Zandora Wastelands" for "Banded Haunt"
+ */
+
+#load "libs.csx"
+
+public class MonsterSpotInfo : IMonsterSpotInfo
+{
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(431);
+    public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
+    public override uint RequiredAreaRank => 4;
+
+    public class NamedParamId
+    {
+        public const uint RustedAlchemizedGoblin = 250; // Rusted Alchemized Goblin
+    }
+
+    public override void Initialize()
+    {
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.DamnedGoblin, 49, 236, 3)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedGoblin, 49, 236, 4)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedGoblin, 49, 236, 5)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+        });
+    }
+}
+
+return new MonsterSpotInfo();

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt_3.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt_3.csx
@@ -1,0 +1,32 @@
+/**
+ * @brief Enemy Spot in "Zandora Wastelands" for "Banded Haunt"
+ */
+
+#load "libs.csx"
+
+public class MonsterSpotInfo : IMonsterSpotInfo
+{
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(437);
+    public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
+    public override uint RequiredAreaRank => 4;
+
+    public class NamedParamId
+    {
+        public const uint RustedAlchemizedGoblin = 250; // Rusted Alchemized Goblin
+    }
+
+    public override void Initialize()
+    {
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.DamnedGoblin, 49, 236, 3)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedGoblin, 49, 236, 4)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedGoblin, 49, 236, 5)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+        });
+    }
+}
+
+return new MonsterSpotInfo();

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt_4.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar04_banded_haunt_4.csx
@@ -1,0 +1,36 @@
+/**
+ * @brief Enemy Spot in "Zandora Wastelands" for "Banded Haunt"
+ */
+
+#load "libs.csx"
+
+public class MonsterSpotInfo : IMonsterSpotInfo
+{
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(438);
+    public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
+    public override uint RequiredAreaRank => 4;
+
+    public class NamedParamId
+    {
+        public const uint RustedAlchemizedGoblin = 250; // Rusted Alchemized Goblin
+    }
+
+    public override void Initialize()
+    {
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.DamnedSlingGoblinFlask, 49, 236, 5)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedSlingGoblinFlask, 49, 236, 6)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedSlingGoblinFlask, 49, 236, 7)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedSlingGoblinFlask, 49, 236, 8)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+            LibDdon.Enemy.Create(EnemyId.DamnedSlingGoblinFlask, 49, 236, 9)
+                .SetNamedEnemyParams(NamedParamId.RustedAlchemizedGoblin),
+        });
+    }
+}
+
+return new MonsterSpotInfo();

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar05_south_mergoda_ruins_2.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar05_south_mergoda_ruins_2.csx
@@ -6,7 +6,7 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(410);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(409);
     public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
     public override uint RequiredAreaRank => 5;
 
@@ -31,14 +31,27 @@ public class MonsterSpotInfo : IMonsterSpotInfo
                 .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian0)
                 .AddDrop(ItemId.HighVitalityRing, 1, 1, DropRate.RARE)
                 .AddDrop(ItemId.SacredTreeRing, 1, 1, DropRate.VERY_RARE),
-            LibDdon.Enemy.Create(EnemyId.BandedFighter, 48, 238, 1)
-                .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian0)
+            LibDdon.Enemy.Create(EnemyId.BandedHunter, 48, 238, 1)
+                .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian2)
                 .AddDrop(ItemId.HighVitalityRing, 1, 1, DropRate.RARE)
                 .AddDrop(ItemId.SacredTreeRing, 1, 1, DropRate.VERY_RARE),
             LibDdon.Enemy.Create(EnemyId.BandedMage, 48, 238, 2)
                 .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian5)
                 .AddDrop(ItemId.HighVitalityRing, 1, 1, DropRate.RARE)
                 .AddDrop(ItemId.SacredTreeRing, 1, 1, DropRate.VERY_RARE),
+            LibDdon.Enemy.Create(EnemyId.BandedHealer, 48, 238, 3)
+                .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian3)
+                .AddDrop(ItemId.HighVitalityRing, 1, 1, DropRate.RARE)
+                .AddDrop(ItemId.SacredTreeRing, 1, 1, DropRate.VERY_RARE),
+            LibDdon.Enemy.Create(EnemyId.BandedFighter, 48, 238, 4)
+                .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian0)
+                .AddDrop(ItemId.HighVitalityRing, 1, 1, DropRate.RARE)
+                .AddDrop(ItemId.SacredTreeRing, 1, 1, DropRate.VERY_RARE),
+            LibDdon.Enemy.Create(EnemyId.BandedHunter, 48, 238, 5)
+                .SetNamedEnemyParams(NamedParamId.ZandoraBarbarian2)
+                .AddDrop(ItemId.HighVitalityRing, 1, 1, DropRate.RARE)
+                .AddDrop(ItemId.SacredTreeRing, 1, 1, DropRate.VERY_RARE),
+
         });
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar08_orc_remnants_camp.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar08_orc_remnants_camp.csx
@@ -21,24 +21,20 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.GeneralOrc, 56, 3)
-                .SetNamedEnemyParams(NamedParamId.OrcRemnants1)
+            LibDdon.Enemy.Create(EnemyId.GeneralOrc, 56, 1526, 0)
+                .SetNamedEnemyParams(NamedParamId.OrcGeneralRemnant)
                 .AddDrop(ItemId.RousingSteak, 1, 3, DropRate.UNCOMMON),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcBattler, 56, 0)
+            LibDdon.Enemy.Create(EnemyId.OrcBattler, 56, 356, 1)
+                .SetRepopConditions(1, 10)
                 .SetNamedEnemyParams(NamedParamId.OrcRemnants0),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcBattler, 56, 1)
+            LibDdon.Enemy.Create(EnemyId.OrcBattler, 56, 356, 2)
+                .SetRepopConditions(1, 10)
                 .SetNamedEnemyParams(NamedParamId.OrcRemnants0),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcBattler, 56, 2)
-                .SetNamedEnemyParams(NamedParamId.OrcRemnants0),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcBattler, 56, 4)
-                .SetNamedEnemyParams(NamedParamId.OrcRemnants0),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcTrooper, 56, 5)
+            LibDdon.Enemy.Create(EnemyId.OrcTrooper, 56, 307, 3)
+                .SetRepopConditions(1, 10)
                 .SetNamedEnemyParams(NamedParamId.OrcRemnants1),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcTrooper, 56, 6)
-                .SetNamedEnemyParams(NamedParamId.OrcRemnants1),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcTrooper, 56, 8)
-                .SetNamedEnemyParams(NamedParamId.OrcRemnants1),
-            LibDdon.Enemy.CreateAuto(EnemyId.OrcTrooper, 56, 9)
+            LibDdon.Enemy.Create(EnemyId.OrcTrooper, 56, 307, 4)
+                .SetRepopConditions(1, 10)
                 .SetNamedEnemyParams(NamedParamId.OrcRemnants1),
         });
     }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar09_black_abyss_valley.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar09_black_abyss_valley.csx
@@ -6,7 +6,7 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(373);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(375);
     public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
     public override uint RequiredAreaRank => 9;
 
@@ -19,7 +19,8 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.Nightmare, 58, 0, isBoss: true)
+            LibDdon.Enemy.Create(EnemyId.Nightmare, 58, 8831, 1)
+                .SetIsBoss(true)
                 .SetNamedEnemyParams(NamedParamId.WailingMora)
                 .AddDrop(ItemId.TitanBracelet, 1, 1, DropRate.RARE)
                 .AddDrop(ItemId.MephistoBracelet, 1, 1, DropRate.RARE)

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar12_fanatics_hiding_ground.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/10_zandora_wastelands/ar12_fanatics_hiding_ground.csx
@@ -6,7 +6,7 @@
 
 public class MonsterSpotInfo : IMonsterSpotInfo
 {
-    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(364);
+    public override StageLayoutId StageLayoutId => Stage.Lestania.AsStageLayoutId(361);
     public override QuestAreaId AreaId => QuestAreaId.ZandoraWastelands;
     public override uint RequiredAreaRank => 12;
 
@@ -19,7 +19,8 @@ public class MonsterSpotInfo : IMonsterSpotInfo
     {
         AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.CreateAuto(EnemyId.BlackGriffin0, 70, 0, isBoss: true)
+            LibDdon.Enemy.Create(EnemyId.BlackGriffin0, 70, 6840, 6)
+                .SetIsBoss(true)
                 .SetNamedEnemyParams(NamedParamId.BlackSeaEagleOfTheRuinedSite)
         });
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q60020001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q60020001.json
@@ -46,7 +46,7 @@
                     "comment": "Hidden Beach Rogue (Fighter)",
                     "enemy_id": "0x011000",
                     "level": 11,
-                    "exp": 55,
+                    "exp": 62,
                     "named_enemy_params_id": 195,
                     "hm_present_no": 45
                 },
@@ -54,7 +54,7 @@
                     "comment": "Hidden Beach Rogue (Seeker)",
                     "enemy_id": "0x011001",
                     "level": 11,
-                    "exp": 55,
+                    "exp": 62,
                     "named_enemy_params_id": 195,
                     "hm_present_no": 46
                 },
@@ -62,7 +62,7 @@
                     "comment": "Hidden Beach Rogue (Hunter)",
                     "enemy_id": "0x011002",
                     "level": 11,
-                    "exp": 55,
+                    "exp": 62,
                     "named_enemy_params_id": 195,
                     "hm_present_no": 47
                 },
@@ -70,7 +70,7 @@
                     "comment": "Hidden Beach Rogue (Mage)",
                     "enemy_id": "0x011005",
                     "level": 11,
-                    "exp": 55,
+                    "exp": 62,
                     "named_enemy_params_id": 195,
                     "hm_present_no": 50
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q60060002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q60060002.json
@@ -33,8 +33,9 @@
         {
             "stage_id": {
                 "id": 1,
-                "group_id": 146
+                "group_id": 138
             },
+            "starting_index": 2,
             "enemies": [
                 {
                     "comment": "Jotun the Returned (Mole Troll)",
@@ -42,7 +43,7 @@
                     "level": 43,
                     "is_boss": true,
                     "named_enemy_params_id": 232,
-                    "exp_scheme": "automatic"
+                    "exp": 4080
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q60210000.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q60210000.json
@@ -43,7 +43,7 @@
                     "level": 70,
                     "is_boss": true,
                     "named_enemy_params_id": 901,
-                    "exp_scheme": "automatic"
+                    "exp": 6840
                 }
             ]
         }


### PR DESCRIPTION
Updates most Breya Coast and Zandora Wastelands and two Mysree Grove caution spots to make them more accurate to retail. Some caution spots had to be broken into several files to make use of multiple groups (notably, Banded Haunt uses four groups).

Also fixes Mysree Grove AR10 trial so two Jotuns should no longer spawn.