### PR TITLE
S2.0 MSQ review

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020010.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020010.json
@@ -50,36 +50,51 @@
                 "id": 335,
                 "group_id": 3
             },
+            "starting_index": 13,
             "enemies": [
                 {
                     "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 55,
-                    "exp": 6476,
+                    "exp": 320,
                     "named_enemy_params_id": 920
                 },
                 {
                     "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 55,
-                    "exp": 6476,
+                    "exp": 320,
                     "named_enemy_params_id": 920
                 },
                 {
                     "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 55,
-                    "exp": 6476,
+                    "exp": 320,
                     "named_enemy_params_id": 920
                 },
                 {
                     "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 55,
-                    "exp": 6476,
+                    "exp": 320,
+                    "named_enemy_params_id": 920
+                },
+                {
+                    "comment": "Infected Hobgoblin",
+                    "enemy_id": "0x010160",
+                    "level": 55,
+                    "exp": 320,
                     "named_enemy_params_id": 920
                 }
             ]
+        },
+        {
+            "stage_id": {
+                "id": 335,
+                "group_id": 5
+            },
+            "enemies": []
         }
     ],
     "processes": [
@@ -116,6 +131,7 @@
                         "group_id": 1
                     },
                     "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 2762, "comment": "Spawns Gurdolin - Audience Chamber"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"}
                     ],
                     "npc_id": "Joseph",
@@ -130,12 +146,13 @@
                         "group_id": 1,
                         "layer_no": 1
                     },
-                    "flags": [
-                        {"type": "QstLayout", "action": "Set", "value": 2762, "comment": "Spawns Gurdolin, Lise and Elliot"},
-                        {"type": "QstLayout", "action": "Set", "value": 2640, "comment": "Spawns Gurdolin, Lise and Elliot"}
-                    ],
                     "npc_id": "Gurdolin3",
-                    "message_id": 14938
+                    "message_id": 14938,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16175, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16176, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 1, "Param2": 14937, "comment": "White Dragon"}
+                    ]
                 },
                 {
                     "type": "PartyGather",
@@ -152,6 +169,9 @@
                     "flags": [
                         {"type": "QstLayout", "action": "Set", "value": 2641, "comment": "Spawns Fabio, Gerd and Gurdolin in Breya Coast"},
                         {"type": "QstLayout", "action": "Set", "value": 2977, "comment": "Spawns dead infected monster"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16177, "comment": "Gurdolin"}
                     ]
                 },
                 {
@@ -182,15 +202,23 @@
                         "layer_no": 1
                     },
                     "flags": [
-                        {"type": "QstLayout", "action": "Set", "value": 2642, "comment": "Gurdolin"}
+                        {"type": "QstLayout", "action": "Set", "value": 2642, "comment": "Gurdolin - Bloodbane Isle"},
+                        {"type": "QstLayout", "action": "Clear", "value": 2762, "comment": "Gurdolin - Audience Chamber"},
+                        {"type": "QstLayout", "action": "Clear", "value": 2641, "comment": "Spawns Fabio, Gerd and Gurdolin in Breya Coast"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkDel", "Param1": 12, "comment": "Fabio"}
                     ],
                     "npc_id": "Gurdolin3",
                     "message_id": 14960
                 },
                 {
                     "type": "PartyGather",
-                    "announce_type": "Update",
                     "checkpoint": true,
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16226, "comment": "Gurdolin"}
+                    ],
                     "stage_id": {
                         "id": 335
                     },
@@ -210,6 +238,9 @@
                 {
                     "type": "KillGroup",
                     "announce_type": "Update",
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 3123, "comment": "Instance barriers"}
+                    ],
                     "groups": [0]
                 },
                 {
@@ -221,7 +252,10 @@
                     "event_id": 15,
                     "jump_stage_id": {
                         "id": 3
-                    }
+                    },
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 3123, "comment": "Instance barriers"}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
@@ -244,7 +278,90 @@
                     "npc_id": "Joseph",
                     "message_id": 15007,
                     "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 2640, "comment": "Elliot and Lise"},
                         {"type": "WorldManageLayout", "action": "Set", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"}
+                    ],
+                    "result_commands": [
+                        {"type": "TutorialDialog", "Param1": 266, "comment": "About Infected: Small Enemies"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16298, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16299, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16300, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 1, "Param2": 16301, "comment": "White Dragon"}
+                    ]
+                }
+            ]
+        },
+        {
+            "comment": "Process 1",
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "StageNoWithoutMarker", "Param1": 100},
+                        {"type": "IsMyquestLayoutFlagOn", "Param1": 2641}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 2762, "comment": "Gurdolin - Audience Chamber"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16180, "comment": "Gurdolin"}
+                    ]
+                }
+            ]
+        },
+        {
+            "comment": "Process 2",
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "StageNoWithoutMarker", "Param1": 100},
+                        {"type": "IsMyquestLayoutFlagOn", "Param1": 2641}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 12, "Param2": 14945, "comment": "Fabio"}
+                    ],
+                    "check_commands": [
+                        {"type": "TalkNpcWithoutMarker", "Param1": 100, "Param2": 12, "comment": "Fabio"}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 12, "Param2": 16178, "comment": "Fabio"}
+                    ]
+                }
+            ]
+        },
+        {
+            "comment": "Process 3",
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "StageNoWithoutMarker", "Param1": 100},
+                        {"type": "IsMyquestLayoutFlagOn", "Param1": 2641}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 14946, "comment": "Gerd"}
+                    ],
+                    "check_commands": [
+                        {"type": "TalkNpcWithoutMarker", "Param1": 100, "Param2": 7, "comment": "Gerd"}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16179, "comment": "Gerd"}
                     ]
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020020.json
@@ -42,13 +42,15 @@
                 "id": 1,
                 "group_id": 83
             },
+            "starting_index": 12,
             "enemies": [
                 {
                     "comment": "Zuhl",
                     "enemy_id": "0x020402",
-                    "level": 53,
-                    "exp": 62540,
-                    "is_boss": true
+                    "level": 55,
+                    "exp": 6880,
+                    "is_boss": true,
+                    "named_enemy_params_id": 921
                 }
             ]
         }
@@ -66,7 +68,7 @@
                     },
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
-                        {"type": "QstLayout", "action": "Set", "value": 2692, "comment": "Spawns Gurdolin, Lise and Elliot"}
+                        {"type": "QstLayout", "action": "Set", "value": 2692, "comment": "Spawns Gurdolin and Lise"}
                     ],
                     "npc_id": "Lise0",
                     "message_id": 15008
@@ -76,6 +78,16 @@
                     "announce_type": "Accept",
                     "flags": [
                         {"type": "QstLayout", "action": "Set", "value": 3026, "comment": "Elliot and Cecily"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16302, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16303, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16304, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16552, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 14, "Param2": 16305, "comment": "Mayleaf"},
+                        {"type": "QstTalkChg", "Param1": 1003, "Param2": 16306, "comment": "Pamela"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16307, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16308, "comment": "Elliot"}
                     ],
                     "stage_id": {
                         "id": 350
@@ -93,15 +105,35 @@
                     },
                     "flags": [
                         {"type": "QstLayout", "action": "Clear", "value": 3026, "comment": "Elliot and Cecily"},
-                        {"type": "QstLayout", "action": "Set", "value": 3440, "comment": "Elliot and Cecily (in the house)"},
-                        {"type": "QstLayout", "action": "Set", "value": 2764, "comment": "Elliot and Cecily (in breya coast)"}
+                        {"type": "QstLayout", "action": "Set", "value": 3440, "comment": "Elliot and Cecily (in the house)"}
                     ],
                     "event_id": 0
                 },
                 {
-                    "type": "NewTalkToNpc",
+                    "type": "Raw",
                     "announce_type": "Update",
                     "checkpoint": true,
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 2764, "comment": "Elliot and Cecily (in breya coast)"}
+                    ],
+                    "check_commands": [
+                        [{"type": "StageNoWithoutMarker", "Param1": 100}],
+                        [{"type": "NewTalkNpc", "Param1": 100, "Param2": 1, "Param3": 2, "Param4": 20020}, {"type": "DummyNotProgress"}]
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16314, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16315, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 14, "Param2": 16316, "comment": "Mayleaf"}
+                    ]
+                },
+                {
+                    "type": "NewTalkToNpc",
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 3440, "comment": "Elliot and Cecily (in the house)"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 15023, "comment": "Cecily"}
+                    ],
                     "stage_id": {
                         "id": 1,
                         "group_id": 1,
@@ -114,8 +146,9 @@
                     "type": "PartyGather",
                     "announce_type": "Update",
                     "checkpoint": true,
-                    "flags": [
-                        {"type": "QstLayout", "action": "Clear", "value": 3440, "comment": "Elliot and Cecily (in the house)"}
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16317, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16318, "comment": "Cecily"}
                     ],
                     "stage_id": {
                         "id": 1
@@ -136,14 +169,31 @@
                 {
                     "type": "KillGroup",
                     "announce_type": "Update",
-                    "groups": [0]
+                    "groups": [0],
+                    "result_commands": [
+                        {"type": "PlayMessage", "Param1": 15030, "Param2": 10, "comment": "Zuhl: It's you! I can't stand you!"},
+                        {"type": "PlayMessage", "Param1": 15031, "Param2": 10, "comment": "Zuhl: Move aside! You're a nuisance!"},
+                        {"type": "PlayMessage", "Param1": 15032, "Param2": 12, "comment": "Zuhl: I sense that woman nearby! Where is she?"},
+                        {"type": "PlayMessage", "Param1": 15033, "Param2": 13, "comment": "Zuhl: You lot, it's no use resisting!"},
+                        {"type": "PlayMessage", "Param1": 15034, "Param2": 15, "comment": "Zuhl: Whoa whoa whoa!"},
+                        {"type": "PlayMessage", "Param1": 15035, "Param2": 15, "comment": "Zuhl: Did you forget how terrifying I am?"},
+                        {"type": "PlayMessage", "Param1": 15036, "Param2": 15, "comment": "Zuhl: I will show no mercy, you know that, right?"},
+                        {"type": "PlayMessage", "Param1": 15037, "Param2": 15, "comment": "Zuhl: You are still weak, aren't you?"},
+                        {"type": "PlayMessage", "Param1": 15038, "Param2": 15, "comment": "Zuhl: I am the calamity... I'm not so easily erased."},
+                        {"type": "PlayMessage", "Param1": 15039, "Param2": 15, "comment": "Zuhl: You... you're hiding a woman, aren't you?"},
+                        {"type": "PlayMessage", "Param1": 15040, "Param2": 15, "comment": "Zuhl: The girl... where is she?"},
+                        {"type": "PlayMessage", "Param1": 15041, "Param2": 15, "comment": "Zuhl: Black Knight... grant me your power, come to me..."}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
                     "stage_id": {
                         "id": 1
                     },
-                    "event_id": 115
+                    "event_id": 115,
+                    "result_commands": [
+                        {"type": "StopMessage"}
+                    ]
                 },
                 {
                     "type": "PartyGather",
@@ -156,7 +206,11 @@
                         "x": -204091,
                         "y": 3345,
                         "z": -74870
-                    }
+                    },
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16321, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16322, "comment": "Cecily"}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
@@ -178,7 +232,11 @@
                         "z": -29
                     },
                     "flags": [
-                        {"type": "QstLayout", "action": "Clear", "value": 2692, "comment": "Spawns Gurdolin, Lise and Elliot"}
+                        {"type": "QstLayout", "action": "Clear", "value": 2692, "comment": "Spawns Gurdolin and Lise"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16323, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16324, "comment": "Cecily"}
                     ]
                 },
                 {
@@ -199,13 +257,19 @@
                         "id": 3
                     },
                     "flags": [
-                        {"type": "QstLayout", "action": "Set", "value": 3027, "comment": "Spawns Cici, Gurdolin, Lise and Elliot"}
+                        {"type": "QstLayout", "action": "Clear", "value": 2764, "comment": "Elliot and Cecily (in breya coast)"},
+                        {"type": "QstLayout", "action": "Set", "value": 3027, "comment": "Spawns Cici, Gurdolin, Lise and Elliot"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16326, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16327, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16553, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16554, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16328, "comment": "Klaus"}
                     ],
                     "npc_id": "Joseph",
-                    "message_id": 15078,
-                    "flags": [
-                        {"type": "WorldManageLayout", "action": "Set", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"}
-                    ]
+                    "message_id": 15078
                 },
                 {
                     "type": "TalkToNpc",
@@ -215,7 +279,10 @@
                         "id": 3
                     },
                     "npc_id": "Klaus0",
-                    "message_id": 15079
+                    "message_id": 15079,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16329, "comment": "Joseph"}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020030.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020030.json
@@ -46,36 +46,43 @@
                 "id": 1,
                 "group_id": 48
             },
+            "starting_index": 14,
             "enemies": [
                 {
                     "comment": "Infected Direwolf",
                     "enemy_id": "0x010209",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 320,
+                    "named_enemy_params_id": 922
                 },
                 {
                     "comment": "Infected Direwolf",
                     "enemy_id": "0x010209",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 320,
+                    "named_enemy_params_id": 922
                 },
                 {
                     "comment": "Infected Direwolf",
                     "enemy_id": "0x010209",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 320,
+                    "named_enemy_params_id": 922
                 },
                 {
                     "comment": "Infected Direwolf",
                     "enemy_id": "0x010209",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 320,
+                    "named_enemy_params_id": 922
                 },
                 {
-                    "comment": "Infected Direwolf",
+                    "comment": "Infected Direwolf (Severe)",
                     "enemy_id": "0x010209",
+                    "infection_type": 2,
                     "level": 55,
-                    "exp": 6476
+                    "exp": 320,
+                    "named_enemy_params_id": 922
                 }
             ]
         },
@@ -84,67 +91,61 @@
                 "id": 1,
                 "group_id": 58
             },
-            "starting_index": 1,
+            "starting_index": 8,
             "enemies": [
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 384,
+                    "named_enemy_params_id": 923
                 },
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 384,
+                    "named_enemy_params_id": 923
                 },
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 384,
+                    "named_enemy_params_id": 923
                 },
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 55,
-                    "exp": 6476
+                    "exp": 384,
+                    "named_enemy_params_id": 923
                 },
                 {
-                    "comment": "Infected Snow Harpy",
+                    "comment": "Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
+                    "infection_type": 2,
                     "level": 55,
-                    "exp": 6476
+                    "exp": 384,
+                    "named_enemy_params_id": 923
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 1,
-                "group_id": 56
+                "group_id": 57
             },
+            "starting_index": 2,
             "enemies": [
                 {
-                    "comment": "Infected Gorecyclops",
+                    "comment": "Infected Gorecyclops (Slight)",
                     "enemy_id": "0x015012",
                     "infection_type": 1,
                     "level": 55,
-                    "exp": 64760,
-                    "is_boss": true
-                },
-                {
-                    "comment": "Infected Hobgoblin",
-                    "enemy_id": "0x010160",
-                    "start_think_tbl_no": 1,
-                    "level": 55,
-                    "exp": 6476
-                },
-                {
-                    "comment": "Infected Hobgoblin Fighter",
-                    "enemy_id": "0x010161",
-                    "start_think_tbl_no": 1,
-                    "level": 55,
-                    "exp": 6476
+                    "exp": 6400,
+                    "is_boss": true,
+                    "named_enemy_params_id": 924
                 }
             ]
         }
@@ -162,7 +163,7 @@
                     },
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
-                        {"type": "QstLayout", "action": "Set", "value": 2738, "comment": "Spawns Gurdolin, Lise and Elliot"}
+                        {"type": "QstLayout", "action": "Set", "value": 2738, "comment": "Spawns Elliot"}
                     ],
                     "npc_id": "Elliot0",
                     "message_id": 15080
@@ -174,7 +175,19 @@
                         "id": 2
                     },
                     "npc_id": "Heinz2",
-                    "message_id": 15081
+                    "message_id": 15081,
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 3847, "comment": "Spawns Cecily and Lise"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16330, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16331, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16332, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16555, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16556, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 1016, "Param2": 16334, "comment": "Duke"},
+                        {"type": "QstTalkChg", "Param1": 1017, "Param2": 16335, "comment": "Logan"}
+                    ]
                 },
                 {
                     "type": "NewTalkToNpc",
@@ -188,6 +201,9 @@
                     "flags": [
                         {"type": "QstLayout", "action": "Set", "value": 2739, "comment": "Spawns Gerd"}
                     ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 8, "Param2": 16333, "comment": "Heinz"}
+                    ],
                     "npc_id": "Gerd1",
                     "message_id": 15082
                 },
@@ -195,7 +211,10 @@
                     "type": "DiscoverEnemy",
                     "checkpoint": true,
                     "announce_type": "Update",
-                    "groups": [ 0 ]
+                    "groups": [ 0 ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16336, "comment": "Gerd"}
+                    ]
                 },
                 {
                     "type": "KillGroup",
@@ -246,14 +265,37 @@
                         {"type": "QstLayout", "action": "Set", "value": 3051, "comment": "Spawns Gerd"},
                         {"type": "MyQst", "action": "Set", "value": 1339, "comment": "Starts NPC Battle State Machine"}
                     ],
-                    "groups": [ 2 ]
+                    "groups": [ 2 ],
+                    "result_commands": [
+                        {"type": "PlayMessage", "Param1": 15089, "Param2": 5, "comment": "Gerd: You monsters, be still!"},
+                        {"type": "PlayMessage", "Param1": 15090, "Param2": 15, "comment": "Gerd: Knights! Follow me!"},
+                        {"type": "PlayMessage", "Param1": 15098, "Param2": 15, "comment": "Travers: The Knights of the White Dragon stand at the ready!"},
+                        {"type": "PlayMessage", "Param1": 15101, "Param2": 15, "comment": "White Knight 1: Hey there!"},
+                        {"type": "PlayMessage", "Param1": 15104, "Param2": 15, "comment": "White Knight 2: Fighting alongside the leader's right hand is an incredible honor!"},
+                        {"type": "PlayMessage", "Param1": 15091, "Param2": 15, "comment": "Gerd: Arisen! Battle with all your might!"},
+                        {"type": "PlayMessage", "Param1": 15092, "Param2": 15, "comment": "Gerd: Good, good!"},
+                        {"type": "PlayMessage", "Param1": 15093, "Param2": 15, "comment": "Gerd: Onwards!"},
+                        {"type": "PlayMessage", "Param1": 15099, "Param2": 15, "comment": "Travers: Don't be scared!"},
+                        {"type": "PlayMessage", "Param1": 15103, "Param2": 15, "comment": "White Knight 1: Don't underestimate the knights!"},
+                        {"type": "PlayMessage", "Param1": 15106, "Param2": 15, "comment": "White Knight 2: I discovered my life's calling on the field of battle!"},
+                        {"type": "PlayMessage", "Param1": 15094, "Param2": 15, "comment": "Gerd: Attack with your heart!"},
+                        {"type": "PlayMessage", "Param1": 15095, "Param2": 15, "comment": "Gerd: Don't falter!"},
+                        {"type": "PlayMessage", "Param1": 15102, "Param2": 15, "comment": "White Knight 1: Look this way, over here!"},
+                        {"type": "PlayMessage", "Param1": 15096, "Param2": 15, "comment": "Gerd: Forward! Onwards!"},
+                        {"type": "PlayMessage", "Param1": 15097, "Param2": 15, "comment": "Gerd: Finish them off and earn your renown!"},
+                        {"type": "PlayMessage", "Param1": 15100, "Param2": 15, "comment": "Travers: Commander! Are you watching me?"},
+                        {"type": "PlayMessage", "Param1": 15105, "Param2": 15, "comment": "White Knight 2: This fight is one I will never forget for all my days."}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
                     "stage_id": {
                         "id": 1
                     },
-                    "event_id": 130
+                    "event_id": 130,
+                    "result_commands": [
+                        {"type": "StopMessage"}
+                    ]
                 },
                 {
                     "type": "NewTalkToNpc",
@@ -265,25 +307,46 @@
                         "layer_no": 1
                     },
                     "flags": [
-                        {"type": "MyQst", "action": "Clear", "value": 1199, "comment": "Starts NPC Battle State Machine"},
+                        {"type": "MyQst", "action": "Set", "value": 1199, "comment": "Ends NPC Battle State Machine"},
                         {"type": "QstLayout", "action": "Clear", "value": 3050, "comment": "Spawns Travers and WhiteKnights"},
                         {"type": "QstLayout", "action": "Clear", "value": 3051, "comment": "Spawns Gerd"},
                         {"type": "QstLayout", "action": "Set", "value": 3124, "comment": "Spawns Gerd after battle"}
+                    ],
+                    "result_commands": [
+                        {"type": "TutorialDialog", "Param1": 275, "comment": "About Infected: Large Enemies"}
                     ],
                     "npc_id": "Gerd1",
                     "message_id": 15126
                 },
                 {
-                    "type": "NewTalkToNpc",
+                    "type": "IsStageNo",
                     "checkpoint": true,
                     "announce_type": "Update",
+                    "stage_id": {
+                        "id": 3
+                    },
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 8, "Param2": 16337, "comment": "Heinz"},
+                        {"type": "QstTalkChg", "Param1": 1016, "Param2": 16338, "comment": "Duke"},
+                        {"type": "QstTalkChg", "Param1": 1017, "Param2": 16339, "comment": "Logan"}
+                    ]
+                },
+                {
+                    "type": "NewTalkToNpc",
                     "stage_id": {
                         "id": 3,
                         "group_id": 2,
                         "layer_no": 1
                     },
                     "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 3847, "comment": "Spawns Cecily and Lise"},
+                        {"type": "QstLayout", "action": "Clear", "value": 3124, "comment": "Spawns Gerd after battle"},
                         {"type": "QstLayout", "action": "Set", "value": 2769, "comment": "Spawns Gerd in Audience Chamber"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 15128, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16340, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16341, "comment": "Klaus"}
                     ],
                     "npc_id": "Gerd1",
                     "message_id": 15127
@@ -296,7 +359,10 @@
                         "id": 3
                     },
                     "npc_id": "Joseph",
-                    "message_id": 15129
+                    "message_id": 15129,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16342, "comment": "Gerd"}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020040.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020040.json
@@ -118,6 +118,14 @@
                             "comment": "The White Dragon (Full)"
                         }
                     ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 1, "Param2": 16343, "comment": "White Dragon"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16344, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16345, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16346, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16557, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16558, "comment": "Lise"}
+                    ],
                     "npc_id": "Klaus0",
                     "message_id": 15148
                 },
@@ -127,6 +135,13 @@
                     "stage_id": {
                         "id": 5
                     },
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16347, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16348, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16349, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16559, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16560, "comment": "Lise"}
+                    ],
                     "npc_id": "Zerkin",
                     "message_id": 15149
                 },
@@ -135,6 +150,16 @@
                     "announce_type": "Update",
                     "stage_id": {
                         "id": 335
+                    }
+                },
+                {
+                    "type": "NewTalkToNpc",
+                    "checkpoint": true,
+                    "announce_type": "Update",
+                    "stage_id": {
+                        "id": 335,
+                        "group_id": 1,
+                        "layer_no": 1
                     },
                     "flags": [
                         {
@@ -149,17 +174,12 @@
                             "value": 2476,
                             "comment": "Spawns Cecily, Gurdolin, Lise and Elliot"
                         }
-                    ]
-                },
-                {
-                    "type": "NewTalkToNpc",
-                    "checkpoint": true,
-                    "announce_type": "Update",
-                    "stage_id": {
-                        "id": 335,
-                        "group_id": 1,
-                        "layer_no": 1
-                    },
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 15151, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 15152, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 15153, "comment": "Cecily"}
+                    ],
                     "npc_id": "Gurdolin3",
                     "message_id": 15150
                 },
@@ -172,6 +192,10 @@
                             "type": "IsReleaseWarpPointAnyone",
                             "Param1": 16
                         }
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16350, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 549, "Param2": 16893, "comment": "Bertrand"}
                     ]
                 },
                 {
@@ -196,6 +220,16 @@
                             "value": 2855,
                             "comment": "Spawns Cecily, Gurdolin, Lise and Elliot"
                         }
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2400, "Param2": 16894, "comment": "Clarissa"},
+                        {"type": "QstTalkChg", "Param1": 2401, "Param2": 16895, "comment": "Gunther"},
+                        {"type": "QstTalkChg", "Param1": 2402, "Param2": 16896, "comment": "Rolf"},
+                        {"type": "QstTalkChg", "Param1": 2403, "Param2": 16897, "comment": "Sven"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16898, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16899, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16900, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16901, "comment": "Elliot"}
                     ]
                 },
                 {
@@ -248,7 +282,7 @@
                             "type": "QstLayout",
                             "action": "Set",
                             "value": 3441,
-                            "comment": "Spawns Cecily, Gurdolin, Lise and Elliot"
+                            "comment": "Spawns Gurdolin"
                         }
                     ]
                 },
@@ -260,7 +294,22 @@
                         "id": 3
                     },
                     "npc_id": "Joseph",
-                    "message_id": 15175
+                    "message_id": 15175,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16351, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 1, "Param2": 16352, "comment": "White Dragon"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16353, "comment": "Klaus"}
+                    ]
+                },
+                {
+                    "type": "IsStageNo",
+                    "stage_id": {
+                        "id": 3
+                    },
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 1, "Param2": 696, "comment": "Area Master for Bloodbane Isle has been unlocked."},
+                        {"type": "PlayMessage", "Param1": 18174, "Param2": 0, "comment": "Area Master for Bloodbane Isle has been unlocked. Talk to Bertrand at the Expedition Garrison."}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020050.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020050.json
@@ -48,79 +48,86 @@
             },
             "enemies": [
                 {
-                    "comment": "Hobgoblin Leader",
-                    "enemy_id": "0x010113",
+                    "comment": "Infected Hobgoblin",
+                    "enemy_id": "0x010160",
                     "level": 57,
-                    "exp": 6706,
-                    "infection_type": 1,
-                    "named_enemy_params_id": 1480
+                    "exp": 328,
+                    "named_enemy_params_id": 926
                 },
                 {
                     "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Infected Hobgoblin FIgter",
-                    "enemy_id": "0x010161",
-                    "level": 57,
-                    "exp": 6706
+                    "exp": 328,
+                    "named_enemy_params_id": 926
                 },
                 {
                     "comment": "Infected Hobgoblin",
                     "enemy_id": "0x010160",
                     "level": 57,
-                    "exp": 6706
+                    "exp": 328,
+                    "named_enemy_params_id": 926
                 },
                 {
-                    "comment": "Infected Sling Hobgoblin",
-                    "enemy_id": "0x010162",
+                    "comment": "Infected Hobgoblin",
+                    "enemy_id": "0x010160",
                     "level": 57,
-                    "exp": 6706
+                    "exp": 328,
+                    "named_enemy_params_id": 926
+                },
+                {
+                    "comment": "Infected Hobgoblin (Severe)",
+                    "enemy_id": "0x010160",
+                    "infection_type": 2,
+                    "scale": 120,
+                    "level": 57,
+                    "exp": 328,
+                    "named_enemy_params_id": 926
                 }
             ]
         },
         {
             "stage_id": {
                 "id": 69,
-                "group_id": 5
+                "group_id": 27
             },
             "enemies": [
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 57,
-                    "exp": 6706,
-                    "named_enemy_params_id": 1480
+                    "exp": 393,
+                    "named_enemy_params_id": 927
                 },
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 57,
-                    "exp": 6706,
-                    "named_enemy_params_id": 1480
+                    "exp": 393,
+                    "named_enemy_params_id": 927
                 },
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 57,
-                    "exp": 6706,
-                    "named_enemy_params_id": 1480
+                    "exp": 393,
+                    "named_enemy_params_id": 927
                 },
                 {
                     "comment": "Infected Snow Harpy",
                     "enemy_id": "0x010612",
                     "level": 57,
-                    "exp": 6706,
-                    "named_enemy_params_id": 1480
+                    "exp": 393,
+                    "named_enemy_params_id": 927
                 },
                 {
-                    "comment": "Infected Snow Harpy",
+                    "comment": "Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
+                    "infection_type": 2,
+                    "scale": 120,
                     "level": 57,
-                    "exp": 6706,
-                    "named_enemy_params_id": 1480
+                    "exp": 393,
+                    "named_enemy_params_id": 927
                 }
             ]
         },
@@ -129,14 +136,16 @@
                 "id": 69,
                 "group_id": 2
             },
+            "starting_index": 7,
             "enemies": [
                 {
-                    "comment": "Infected Behemoth",
+                    "comment": "Infected Behemoth (Slight)",
                     "enemy_id": "0x015712",
                     "level": 57,
-                    "exp": 67060,
-                    "infection_type": 2,
-                    "is_boss": true
+                    "exp": 9840,
+                    "infection_type": 1,
+                    "is_boss": true,
+                    "named_enemy_params_id": 928
                 }
             ]
         }
@@ -166,7 +175,12 @@
                         "id": 2
                     },
                     "npc_id": "Heinz2",
-                    "message_id": 15177
+                    "message_id": 15177,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16354, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16355, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16356, "comment": "Klaus"}
+                    ]
                 },
                 {
                     "type": "NewTalkToNpc",
@@ -178,7 +192,15 @@
                         "layer_no": 1
                     },
                     "flags": [
-                        {"type": "QstLayout", "action": "Set", "value": 2741, "comment": "Spawns Gurdolin"}
+                        {"type": "QstLayout", "action": "Set", "value": 2741, "comment": "Spawns Dreed Castle NPCs"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 8, "Param2": 16357, "comment": "Heinz"},
+                        {"type": "QstTalkChg", "Param1": 1016, "Param2": 16358, "comment": "Duke"},
+                        {"type": "QstTalkChg", "Param1": 1017, "Param2": 16359, "comment": "Logan"},
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 15179, "comment": "Gerd"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 15180, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16561, "comment": "Lise"}
                     ],
                     "npc_id": "Gurdolin3",
                     "message_id": 15178
@@ -230,14 +252,20 @@
                 {
                     "type": "KillGroup",
                     "announce_type": "Update",
-                    "groups": [ 2 ]
+                    "groups": [ 2 ],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 3655, "comment": "Instance barriers"}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
                     "stage_id": {
                         "id": 69
                     },
-                    "event_id": 25
+                    "event_id": 25,
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 3655, "comment": "Instance barriers"}
+                    ]
                 },
                 {
                     "type": "TalkToNpc",
@@ -247,7 +275,16 @@
                         "id": 3
                     },
                     "flags": [
-                        {"type": "QstLayout", "action": "Clear", "value": 2741, "comment": "Spawns Gurdolin"}
+                        {"type": "QstLayout", "action": "Clear", "value": 2741, "comment": "Spawns Dreed Castle NPCs"},
+                        {"type": "QstLayout", "action": "Set", "value": 3097, "comment": "Gerd"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16360, "comment": "Gerd"},
+                        {"type": "QstTalkChg", "Param1": 8, "Param2": 16361, "comment": "Heinz"},
+                        {"type": "QstTalkChg", "Param1": 1016, "Param2": 16362, "comment": "Duke"},
+                        {"type": "QstTalkChg", "Param1": 1017, "Param2": 16363, "comment": "Logan"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16562, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16364, "comment": "Klaus"}
                     ],
                     "bgm_stop": true,
                     "npc_id": "Joseph",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020060.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020060.json
@@ -43,13 +43,15 @@
                 "id": 1,
                 "group_id": 313
             },
+            "starting_index": 5,
             "enemies": [
                 {
                     "comment": "Zuhl",
                     "enemy_id": "0x020402",
                     "level": 57,
-                    "exp": 67060,
-                    "is_boss": true
+                    "exp": 7072,
+                    "is_boss": true,
+                    "named_enemy_params_id": 929
                 }
             ]
         }
@@ -80,9 +82,13 @@
                         "id": 3
                     },
                     "npc_id": "Joseph",
-                    "message_id": 15210
+                    "message_id": 15210,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16365, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16563, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16366, "comment": "Klaus"}
+                    ]
                 },
-
                 {
                     "type": "PartyGather",
                     "announce_type": "Update",
@@ -94,7 +100,10 @@
                         "x": -146041,
                         "y": 13242,
                         "z": -302402
-                    }
+                    },
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16367, "comment": "Joseph"}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
@@ -106,14 +115,37 @@
                 {
                     "type": "KillGroup",
                     "announce_type": "Update",
-                    "groups": [ 0 ]
+                    "groups": [ 0 ],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 3656, "comment": "Instance barriers"}
+                    ],
+                    "result_commands": [
+                        {"type": "PlayMessage", "Param1": 15237, "Param2": 10, "comment": "Zuhl: I have no use for you!"},
+                        {"type": "PlayMessage", "Param1": 15238, "Param2": 10, "comment": "Zuhl: These annoying pests!"},
+                        {"type": "PlayMessage", "Param1": 15239, "Param2": 15, "comment": "Zuhl: Arisen of that stricken dragon, get twisted!"},
+                        {"type": "PlayMessage", "Param1": 15240, "Param2": 15, "comment": "Zuhl: Bring out the woman! I'll say it over and over!"},
+                        {"type": "PlayMessage", "Param1": 15241, "Param2": 15, "comment": "Zuhl: I'm being lenient, but you'd better listen!"},
+                        {"type": "PlayMessage", "Param1": 15242, "Param2": 15, "comment": "Zuhl: Oh, things are starting to get exciting!"},
+                        {"type": "PlayMessage", "Param1": 15243, "Param2": 15, "comment": "Zuhl: O Lady! Come here!"},
+                        {"type": "PlayMessage", "Param1": 15244, "Param2": 15, "comment": "Zuhl: Ah... This is getting tedious."},
+                        {"type": "PlayMessage", "Param1": 15245, "Param2": 15, "comment": "Zuhl: I'm about to get serious, you bastards!"},
+                        {"type": "PlayMessage", "Param1": 15246, "Param2": 15, "comment": "Zuhl: Why do you need her so bad?"},
+                        {"type": "PlayMessage", "Param1": 15247, "Param2": 15, "comment": "Zuhl: You lot just don't get it..."},
+                        {"type": "PlayMessage", "Param1": 15248, "Param2": 15, "comment": "Zuhl: Tremble... Flee before me... Do not take me lightly!"}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
                     "stage_id": {
                         "id": 1
                     },
-                    "event_id": 140
+                    "event_id": 140,
+                    "result_commands": [
+                        {"type": "StopMessage"}
+                    ],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 3656, "comment": "Instance barriers"}
+                    ]
                 },
                 {
                     "type": "TalkToNpc",
@@ -122,8 +154,18 @@
                     "stage_id": {
                         "id": 3
                     },
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 3098, "comment": "Lise and Cecily"}
+                    ],
                     "npc_id": "Joseph",
-                    "message_id": 15254
+                    "message_id": 15254,
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16368, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16369, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16370, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16564, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16371, "comment": "Klaus"}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020070.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020070.json
@@ -42,48 +42,55 @@
                 "id": 1,
                 "group_id": 296
             },
+            "starting_index": 15,
             "enemies": [
                 {
-                    "comment": "Infected Snow Harpy",
+                    "comment": "Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 384,
+                    "named_enemy_params_id": 930
                 },
                 {
-                    "comment": "Infected Snow Harpy",
-                    "enemy_id": "0x010612",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Infected Snow Harpy",
-                    "enemy_id": "0x010612",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Infected Snow Harpy",
-                    "enemy_id": "0x010612",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Infected Direwolf",
+                    "comment": "Infected Direwolf (Severe)",
                     "enemy_id": "0x010209",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 930
                 },
                 {
-                    "comment": "Infected Direwolf",
+                    "comment": "Infected Direwolf (Severe)",
                     "enemy_id": "0x010209",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 930
+                },
+                {
+                    "comment": "Infected Direwolf (Severe)",
+                    "enemy_id": "0x010209",
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 930
+                },
+                {
+                    "comment": "Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 384,
+                    "named_enemy_params_id": 930
+                },
+                {
+                    "comment": "Infected Direwolf (Severe)",
+                    "enemy_id": "0x010209",
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 930
                 }
             ]
         },
@@ -92,41 +99,53 @@
                 "id": 1,
                 "group_id": 422
             },
+            "starting_index": 14,
             "enemies": [
                 {
-                    "comment": "Bolt Grimward",
-                    "enemy_id": "0x010211",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Bolt Grimward",
-                    "enemy_id": "0x010211",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Infected Hobgoblin",
+                    "comment": "Infected Hobgoblin (Severe)",
                     "enemy_id": "0x010160",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 931
                 },
                 {
-                    "comment": "Infected Hobgoblin Fighter",
-                    "enemy_id": "0x010161",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
-                },
-                {
-                    "comment": "Infected Hobgoblin",
+                    "comment": "Infected Hobgoblin (Severe)",
                     "enemy_id": "0x010160",
-                    "infection_type": 1,
-                    "level": 57,
-                    "exp": 6706
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 931
+                },
+                {
+                    "comment": "Infected Hobgoblin (Severe)",
+                    "enemy_id": "0x010160",
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 931
+                },
+                {
+                    "comment": "Infected Hobgoblin (Severe)",
+                    "enemy_id": "0x010160",
+                    "infection_type": 2,
+                    "level": 55,
+                    "exp": 320,
+                    "named_enemy_params_id": 931
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 55,
+                    "exp": 432,
+                    "named_enemy_params_id": 931
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 55,
+                    "exp": 432,
+                    "named_enemy_params_id": 931
                 }
             ]
         },
@@ -135,44 +154,59 @@
                 "id": 76,
                 "group_id": 10
             },
+            "starting_index": 5,
             "enemies": [
                 {
-                    "comment": "Infected Snow Harpy",
-                    "enemy_id": "0x010612",
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
                     "start_think_tbl_no": 1,
-                    "infection_type": 1,
                     "level": 60,
-                    "exp": 15254
+                    "exp": 510,
+                    "named_enemy_params_id": 932
                 },
                 {
-                    "comment": "Infected Snow Harpy",
+                    "comment": "Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
                     "start_think_tbl_no": 1,
-                    "infection_type": 1,
+                    "infection_type": 2,
                     "level": 60,
-                    "exp": 15254
+                    "exp": 408,
+                    "named_enemy_params_id": 932
                 },
                 {
-                    "comment": "Infected Snow Harpy",
+                    "comment": "Infected Snow Harpy (Severe)",
                     "enemy_id": "0x010612",
                     "start_think_tbl_no": 1,
-                    "infection_type": 1,
+                    "infection_type": 2,
                     "level": 60,
-                    "exp": 15254
+                    "exp": 408,
+                    "named_enemy_params_id": 932
+                },
+                {
+                    "comment": "Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "infection_type": 2,
+                    "level": 60,
+                    "exp": 408,
+                    "named_enemy_params_id": 932
+                },
+                {
+                    "comment": "Infected Snow Harpy (Severe)",
+                    "enemy_id": "0x010612",
+                    "start_think_tbl_no": 1,
+                    "infection_type": 2,
+                    "level": 60,
+                    "exp": 408,
+                    "named_enemy_params_id": 932
                 },
                 {
                     "comment": "Frost Skeleton Brute",
                     "enemy_id": "0x010321",
                     "start_think_tbl_no": 1,
                     "level": 60,
-                    "exp": 15254
-                },
-                {
-                    "comment": "Frost Skeleton Brute",
-                    "enemy_id": "0x010321",
-                    "start_think_tbl_no": 1,
-                    "level": 60,
-                    "exp": 15254
+                    "exp": 510,
+                    "named_enemy_params_id": 932
                 }
             ]
         },
@@ -181,14 +215,16 @@
                 "id": 76,
                 "group_id": 4
             },
+            "starting_index": 28,
             "enemies": [
                 {
-                    "comment": "Infected Griffin",
+                    "comment": "Infected Griffin (Slight)",
                     "enemy_id": "0x015306",
-                    "infection_type": 2,
-                    "level": 60,
-                    "exp": 152540,
-                    "is_boss": true
+                    "infection_type": 1,
+                    "level": 57,
+                    "exp": 8200,
+                    "is_boss": true,
+                    "named_enemy_params_id": 933
                 }
             ]
         }
@@ -204,10 +240,10 @@
                     },
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Clear", "value": 8630, "quest_id": 70034001, "comment": "Spawns Gurdolin, Lise and Elliot"},
-                        {"type": "QstLayout", "action": "Set", "value": 2758, "comment": "Spawns Gurdolin"}
+                        {"type": "QstLayout", "action": "Set", "value": 2758, "comment": "Spawns Audience Chamber NPCs"}
                     ],
                     "npc_id": "Joseph",
-                    "message_id": 15210
+                    "message_id": 0
                 },
                 {
                     "type": "PlayEvent",
@@ -225,6 +261,20 @@
                     "groups": [ 0 ],
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Set", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16372, "comment": "Gerd"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16373, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16374, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 20, "Param2": 16565, "comment": "Cecily"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16566, "comment": "Elliot"},
+                        {"type": "QstTalkChg", "Param1": 13, "Param2": 16567, "comment": "Lise"},
+                        {"type": "QstTalkChg", "Param1": 501, "Param2": 16568, "comment": "Gurdolin"},
+                        {"type": "QstTalkChg", "Param1": 8, "Param2": 16375, "comment": "Heinz"},
+                        {"type": "QstTalkChg", "Param1": 1016, "Param2": 16376, "comment": "Duke"},
+                        {"type": "QstTalkChg", "Param1": 1017, "Param2": 16376, "comment": "Logan"},
+                        {"type": "QstTalkChg", "Param1": 12, "Param2": 16378, "comment": "Fabio"},
+                        {"type": "QstTalkChg", "Param1": 11, "Param2": 16379, "comment": "Vanessa"}
                     ]
                 },
                 {
@@ -258,8 +308,13 @@
                         "z": -369
                     },
                     "flags": [
-                        {"type": "QstLayout", "action": "Clear", "value": 2758, "comment": "Spawns Gurdolin"},
+                        {"type": "QstLayout", "action": "Clear", "value": 2758, "comment": "Spawns Audience Chamber NPCs"},
                         {"type": "QstLayout", "action": "Set", "value": 3101, "comment": "Spawns Elliot and Gerd"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16380, "comment": "Gerd"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16381, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16382, "comment": "Elliot"}
                     ]
                 },
                 {
@@ -283,13 +338,22 @@
                     "message_id": 15272,
                     "flags": [
                         {"type": "WorldManageLayout", "action": "Set", "value": 7390, "quest_id": 70032001, "comment": "The White Dragon (Full)"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 7, "Param2": 16383, "comment": "Gerd"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16384, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16385, "comment": "Klaus"},
+                        {"type": "QstTalkChg", "Param1": 21, "Param2": 16386, "comment": "Elliot"}
                     ]
                 },
                 {
                     "type": "DiscoverEnemy",
                     "checkpoint": true,
                     "announce_type": "Update",
-                    "groups": [ 2 ]
+                    "groups": [ 2 ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 10, "Param2": 16387, "comment": "Theodor"}
+                    ]
                 },
                 {
                     "type": "KillGroup",
@@ -320,7 +384,10 @@
                 {
                     "type": "KillGroup",
                     "announce_type": "Update",
-                    "groups": [ 3 ]
+                    "groups": [ 3 ],
+                    "flags": [
+                        {"type": "QstLayout", "action": "Set", "value": 3122, "comment": "Instance barriers"}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
@@ -343,7 +410,16 @@
                         "z": 0
                     },
                     "flags": [
+                        {"type": "QstLayout", "action": "Clear", "value": 3122, "comment": "Instance barriers"},
                         {"type": "QstLayout", "action": "Clear", "value": 3101, "comment": "Spawns Elliot and Gerd"}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 10, "Param2": 16394, "comment": "Theodor"},
+                        {"type": "QstTalkChg", "Param1": 8, "Param2": 16395, "comment": "Heinz"},
+                        {"type": "QstTalkChg", "Param1": 1016, "Param2": 16396, "comment": "Duke"},
+                        {"type": "QstTalkChg", "Param1": 1017, "Param2": 16397, "comment": "Logan"},
+                        {"type": "QstTalkChg", "Param1": 4, "Param2": 16398, "comment": "Joseph"},
+                        {"type": "QstTalkChg", "Param1": 3, "Param2": 16399, "comment": "Klaus"}
                     ]
                 },
                 {

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014005.json
@@ -67,7 +67,7 @@
                     "type": "Raw",
                     "announce_type": "CheckpointAndUpdate",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 910, "Param2": 2600},
+                        {"type": "TalkNpc", "Param1": 910, "Param2": 4509},
                         {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 22}
                     ],
                     "result_commands": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014006.json
@@ -68,7 +68,7 @@
                     "type": "Raw",
                     "announce_type": "CheckpointAndUpdate",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 910, "Param2": 2600},
+                        {"type": "TalkNpc", "Param1": 910, "Param2": 4509},
                         {"type": "WeatherEq", "Param1": 3}
                     ],
                     "result_commands": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014023.json
@@ -68,7 +68,7 @@
                     "type": "Raw",
                     "announce_type": "CheckpointAndUpdate",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 910, "Param2": 2600},
+                        {"type": "TalkNpc", "Param1": 910, "Param2": 4509},
                         {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 7}
                     ],
                     "result_commands": [
@@ -84,7 +84,7 @@
                     ],
                     "check_commands": [
                         {"type": "HaveItemAllBag", "Param1": 16002, "Param2": 5}
-                    ]
+                    ]	
                 },
                 {
                     "type": "DeliverItems",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015005.json
@@ -67,7 +67,7 @@
                     "type": "Raw",
                     "announce_type": "CheckpointAndUpdate",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 930, "Param2": 2600},
+                        {"type": "TalkNpc", "Param1": 930, "Param2": 2501},
                         {"type": "IngameTimeRangeEq", "Param1": 11, "Param2": 15}
                     ],
                     "result_commands": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015006.json
@@ -68,7 +68,7 @@
                     "type": "Raw",
                     "announce_type": "CheckpointAndUpdate",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 930, "Param2": 2600},
+                        {"type": "TalkNpc", "Param1": 930, "Param2": 2501},
                         {"type": "WeatherEq", "Param1": 2}
                     ],
                     "result_commands": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015023.json
@@ -68,7 +68,7 @@
                     "type": "Raw",
                     "announce_type": "CheckpointAndUpdate",
                     "check_commands": [
-                        {"type": "TalkNpc", "Param1": 930, "Param2": 2600},
+                        {"type": "TalkNpc", "Param1": 930, "Param2": 2501},
                         {"type": "IngameTimeRangeNotEq", "Param1": 2, "Param2": 23}
                     ],
                     "result_commands": [

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016022.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21016022.json
@@ -136,7 +136,7 @@
         },
         {
           "comment": "Infected Snow Harpy (Severe)",
-          "enemy_id": "0x011067",
+          "enemy_id": "0x010612",
           "infection_type": 2,
           "level": 80,
           "exp": 4035,
@@ -144,7 +144,7 @@
         },
         {
           "comment": "Infected Snow Harpy (Severe)",
-          "enemy_id": "0x011067",
+          "enemy_id": "0x010612",
           "infection_type": 2,
           "level": 80,
           "exp": 4035,
@@ -152,7 +152,7 @@
         },
         {
           "comment": "Infected Snow Harpy (Severe)",
-          "enemy_id": "0x011067",
+          "enemy_id": "0x010612",
           "infection_type": 2,
           "level": 80,
           "exp": 4035,
@@ -160,7 +160,7 @@
         },
         {
           "comment": "Infected Snow Harpy (Severe)",
-          "enemy_id": "0x011067",
+          "enemy_id": "0x010612",
           "infection_type": 2,
           "level": 80,
           "exp": 4035,
@@ -223,7 +223,7 @@
           "index": 2
         },
         {
-          "comment": "Severely Infected Pixie Stymphalides (Severe)",
+          "comment": "Severely Infected Stymphalides (Severe)",
           "enemy_id": "0x010614",
           "infection_type": 2,
           "level": 80,
@@ -231,7 +231,7 @@
           "index": 6
         },
         {
-          "comment": "Severely Infected Pixie Stymphalides (Severe)",
+          "comment": "Severely Infected Stymphalides (Severe)",
           "enemy_id": "0x010614",
           "infection_type": 2,
           "level": 80,
@@ -239,7 +239,7 @@
           "index": 7
         },
         {
-          "comment": "Severely Infected Pixie Stymphalides (Severe)",
+          "comment": "Severely Infected Stymphalides (Severe)",
           "enemy_id": "0x010614",
           "infection_type": 2,
           "level": 80,
@@ -247,7 +247,7 @@
           "index": 8
         },
         {
-          "comment": "Severely Infected Pixie Stymphalides (Severe)",
+          "comment": "Severely Infected Stymphalides (Severe)",
           "enemy_id": "0x010614",
           "infection_type": 2,
           "level": 80,


### PR DESCRIPTION
Restores several instances of missing extra dialogue, voiced combat lines and absent NPCs across S2.0 main story quests, whilst also updating enemy groups with more accurate enemy composition, positioning, and adding missing named titles.

Also fixes several gathering WQs being unable to progress properly and one WQ having the wrong enemy.