### PR TITLE
More S2 world quests

### DIFF
--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000063.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000063.json
@@ -1,0 +1,437 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Hard] Save the Island",
+  "quest_id": 21000063,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BloodbaneIsle",
+  "news_image": 900,
+  "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 14}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 16020
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": "CrestOfHerculeanPowerShock0",
+          "num": 1
+        },
+        {
+          "item_id": "CrestOfSuperiorMagickShock0",
+          "num": 1
+        },
+        {
+          "item_id": "Panacea",
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 337,
+        "group_id": 2
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Ogre",
+          "enemy_id": "0x015500",
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 4
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535,
+          "index": 9
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535,
+          "index": 10
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 408,
+        "group_id": 3
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Flame Corpse Punisher",
+          "enemy_id": "0x010513",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Flame Corpse Punisher",
+          "enemy_id": "0x010513",
+          "level": 70,
+          "exp": 1535
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 408,
+        "group_id": 13
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops - Severe",
+          "enemy_id": "0x015012",
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 9
+        },
+        {
+          "comment": "Infected Sling Hobgoblin - Severe",
+          "enemy_id": "0x010162",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 10
+        },
+        {
+          "comment": "Infected Sling Hobgoblin - Severe",
+          "enemy_id": "0x010162",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 11
+        },
+        {
+          "comment": "Infected Sling Hobgoblin - Severe",
+          "enemy_id": "0x010162",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 12
+        },
+        {
+          "comment": "Infected Sling Hobgoblin - Severe",
+          "enemy_id": "0x010162",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 13
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 408,
+        "group_id": 14
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Griffin - Severe",
+          "enemy_id": "0x015306",
+          "set_type": 3,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 38375,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 70,
+          "exp": 1535,
+          "index": 9
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 70,
+          "exp": 1535,
+          "index": 10
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 70,
+          "exp": 1535,
+          "index": 11
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 70,
+          "exp": 1535,
+          "index": 12
+        },
+        {
+          "comment": "Infected Direwolf",
+          "enemy_id": "0x010209",
+          "level": 70,
+          "exp": 1535,
+          "index": 13
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 317
+          },
+          "npc_id": "Bertrand",
+          "message_id": 17458
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 549,
+              "Param2": 17459
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 317
+          },
+          "npc_id": "Bertrand",
+          "message_id": 17460
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000074.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000074.json
@@ -1,0 +1,465 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Hard] For Youthful Strength",
+  "quest_id": 21000074,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BloodbaneIsle",
+  "news_image": 900,
+  "order_conditions": [{"type": "AreaRank", "Param1": 13, "Param2": 14}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 18420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": "CrestOfHerculeanPowerBlinding0",
+          "num": 1
+        },
+        {
+          "item_id": "CrestOfSuperiorMagickBlinding0",
+          "num": 1
+        },
+        {
+          "item_id": "Panacea",
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 335,
+        "group_id": 8
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 5
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 12
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 13
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 14
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 15
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 16
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 17
+        },
+        {
+          "comment": "Infected Direwolf - Slight",
+          "enemy_id": "0x010209",
+          "infection_type": 1,
+          "level": 70,
+          "exp": 1535,
+          "index": 18
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 319,
+        "group_id": 2
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Chimera",
+          "enemy_id": "0x015200",
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Electric Slime",
+          "enemy_id": "0x010907",
+          "level": 70,
+          "exp": 1535,
+          "index": 5
+        },
+        {
+          "comment": "Electric Slime",
+          "enemy_id": "0x010907",
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Electric Slime",
+          "enemy_id": "0x010907",
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Electric Slime",
+          "enemy_id": "0x010907",
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Electric Slime",
+          "enemy_id": "0x010907",
+          "level": 70,
+          "exp": 1535,
+          "index": 9
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 319,
+        "group_id": 5
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops - Severe",
+          "enemy_id": "0x015012",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "set_type": 3,
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 2
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "set_type": 3,
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 3
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "set_type": 3,
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 4
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 2,
+          "set_type": 3,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 5
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "set_type": 3,
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 319,
+        "group_id": 6
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Frost Machina",
+          "enemy_id": "0x015851",
+          "level": 70,
+          "exp": 38375,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 2
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 3
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 4
+        },
+        {
+          "comment": "Infected Hobgoblin Fighter - Severe",
+          "enemy_id": "0x010161",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 5
+        },
+        {
+          "comment": "Infected Hobgoblin - Severe",
+          "enemy_id": "0x010160",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Hobgoblin - Severe",
+          "enemy_id": "0x010160",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Hobgoblin - Severe",
+          "enemy_id": "0x010160",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Infected Hobgoblin - Severe",
+          "enemy_id": "0x010160",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 9
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 317
+          },
+          "npc_id": "Bertrand",
+          "message_id": 17465
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 549,
+              "Param2": 17466
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 317
+          },
+          "npc_id": "Bertrand",
+          "message_id": 17467
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000086.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21000086.json
@@ -1,0 +1,409 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Hard] Don't Let Your Guard Down",
+  "quest_id": 21000086,
+  "base_level": 70,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "BloodbaneIsle",
+  "news_image": 900,
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 20140}, {"type": "AreaRank", "Param1": 13, "Param2": 14}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 18420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 2309
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": "CrestOfGreaterProtection1",
+          "num": 1
+        },
+        {
+          "item_id": "CrestOfGreaterIntelligence1",
+          "num": 1
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 336,
+        "group_id": 2
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Black Griffin",
+          "enemy_id": "0x015303",
+          "level": 70,
+          "exp": 7675,
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 5
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "start_think_tbl_no": 2,
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 322,
+        "group_id": 3
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Hobgoblin Fighter",
+          "enemy_id": "0x010161",
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Hobgoblin Slinger",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Infected Hobgoblin Slinger",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 12
+        },
+        {
+          "comment": "Infected Hobgoblin Slinger",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 13
+        },
+        {
+          "comment": "Infected Hobgoblin Slinger",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 14
+        },
+        {
+          "comment": "Infected Hobgoblin Slinger",
+          "enemy_id": "0x010162",
+          "level": 70,
+          "exp": 1535,
+          "index": 15
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 16
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 17
+        },
+        {
+          "comment": "Infected Snow Harpy - Severe",
+          "enemy_id": "0x010612",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 18
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 322,
+        "group_id": 4
+      },
+      "starting_index": 2,
+      "enemies": [
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Bolt Grimwarg",
+          "enemy_id": "0x010211",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1535
+        },
+        {
+          "comment": "Gargoyle",
+          "enemy_id": "0x010603",
+          "level": 70,
+          "exp": 1535
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 322,
+        "group_id": 6
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Infected Behemoth - Severe",
+          "enemy_id": "0x015712",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 38375,
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Infected Direwolf - Severe",
+          "enemy_id": "0x010209",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 6
+        },
+        {
+          "comment": "Infected Direwolf - Severe",
+          "enemy_id": "0x010209",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 7
+        },
+        {
+          "comment": "Infected Direwolf - Severe",
+          "enemy_id": "0x010209",
+          "infection_type": 2,
+          "level": 70,
+          "exp": 1535,
+          "index": 8
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535,
+          "index": 10
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535,
+          "index": 11
+        },
+        {
+          "comment": "Infected Hobgoblin",
+          "enemy_id": "0x010160",
+          "level": 70,
+          "exp": 1535,
+          "index": 12
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 317
+          },
+          "npc_id": "Bertrand",
+          "message_id": 17474
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 549,
+              "Param2": 17475
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 317
+          },
+          "npc_id": "Bertrand",
+          "message_id": 17476
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016.json
@@ -1,0 +1,359 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Simian Relatives",
+    "quest_id": 21014016,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 282,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 32820
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4494
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "ThickShell",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 42
+            },
+            "enemies": [
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 42
+            },
+            "enemies": [
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 451,
+                "group_id": 6
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Dread Ape",
+                    "enemy_id": "0x015502",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Spineback",
+                    "enemy_id": "0x015506",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 451,
+                "group_id": 6
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Silver Roar",
+                    "enemy_id": "0x015505",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Spineback",
+                    "enemy_id": "0x015506",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 11},
+                        {"type": "StageNo", "Param1": 121}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 6, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 42, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4570}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 121, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4570},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 819, "Param2": 6, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 819, "Param2": 6, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016_1.json
@@ -1,0 +1,360 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Simian Relatives",
+    "quest_id": 21014016,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 282,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 11}],
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 32820
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4494
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "ThickShell",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 49
+            },
+            "enemies": [
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Brute Ape",
+                    "enemy_id": "0x015504",
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 49
+            },
+            "enemies": [
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x015507",
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 451,
+                "group_id": 6
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Dread Ape",
+                    "enemy_id": "0x015502",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Spineback",
+                    "enemy_id": "0x015506",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Brute Ape",
+                    "enemy_id": "0x015504",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 451,
+                "group_id": 6
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Silver Roar",
+                    "enemy_id": "0x015505",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Spineback",
+                    "enemy_id": "0x015506",
+                    "level": 75,
+                    "exp": 11875,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                },
+                {
+                    "comment": "Wounded Little Spine",
+                    "enemy_id": "0x015507",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 2375
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 11},
+                        {"type": "StageNo", "Param1": 121}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 26, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 49, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4571}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 121, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4571},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 819, "Param2": 6, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 819, "Param2": 6, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018.json
@@ -1,0 +1,307 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Elanic Contrast",
+    "quest_id": 21014018,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 282,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 14}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 48420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5106
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "SanctoSap",
+                    "num": 1
+                },
+                {
+                    "item_id": "ThousandYearMoss",
+                    "num": 1
+                },
+                {
+                    "item_id": "TransparentCoarseSand",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 44
+            },
+            "enemies": [
+                {
+                    "comment": "White Griffin",
+                    "enemy_id": "0x015320",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 44
+            },
+            "enemies": [
+                {
+                    "comment": "Black Griffin",
+                    "enemy_id": "0x015303",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 1
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Phindymian Ent",
+                    "enemy_id": "0x015032",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Wounded White Griffin",
+                    "enemy_id": "0x015320",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 10500,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 1
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Phindymian Ent",
+                    "enemy_id": "0x015032",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Wounded Black Griffin",
+                    "enemy_id": "0x015303",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 10500,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 14},
+                        {"type": "StageNo", "Param1": 121}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 20, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 44, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4594}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 121, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4594},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 818, "Param2": 1, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 818, "Param2": 1, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018_1.json
@@ -1,0 +1,308 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Elanic Contrast",
+    "quest_id": 21014018,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 282,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 14}],
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 48420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5106
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "SanctoSap",
+                    "num": 1
+                },
+                {
+                    "item_id": "ThousandYearMoss",
+                    "num": 1
+                },
+                {
+                    "item_id": "TransparentCoarseSand",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 48
+            },
+            "enemies": [
+                {
+                    "comment": "White Griffin",
+                    "enemy_id": "0x015320",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 48
+            },
+            "enemies": [
+                {
+                    "comment": "Black Griffin",
+                    "enemy_id": "0x015303",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 1
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Phindymian Ent",
+                    "enemy_id": "0x015032",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Wounded White Griffin",
+                    "enemy_id": "0x015320",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 10500,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 1
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Phindymian Ent",
+                    "enemy_id": "0x015032",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Little Spine",
+                    "enemy_id": "0x010324",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Wounded Black Griffin",
+                    "enemy_id": "0x015303",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 10500,
+                    "is_boss": true
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 14},
+                        {"type": "StageNo", "Param1": 121}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 19, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 48, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4595}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 121, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4595},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 818, "Param2": 1, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 818, "Param2": 1, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019.json
@@ -1,0 +1,307 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Brethren Hiding Poison",
+    "quest_id": 21014019,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 615,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 44220
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "TransparentCoarseSand",
+                    "num": 3
+                },
+                {
+                    "item_id": "ProtectedBeastsGreenFur",
+                    "num": 1
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 43
+            },
+            "enemies": [
+                {
+                    "comment": "Troll",
+                    "enemy_id": "0x015040",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 43
+            },
+            "enemies": [
+                {
+                    "comment": "Mole Troll",
+                    "enemy_id": "0x015041",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 5
+            },
+            "starting_index": 9,
+            "enemies": [
+                {
+                    "comment": "Mole Troll",
+                    "enemy_id": "0x015041",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Troll",
+                    "enemy_id": "0x015040",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 6180,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 5
+            },
+            "starting_index": 9,
+            "enemies": [
+                {
+                    "comment": "Troll",
+                    "enemy_id": "0x015040",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Mole Troll",
+                    "enemy_id": "0x015041",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 6180,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 13},
+                        {"type": "StageNo", "Param1": 121}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 17, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 43, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4582}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 121, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4582},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 818, "Param2": 5, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 818, "Param2": 5, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019_1.json
@@ -1,0 +1,308 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Brethren Hiding Poison",
+    "quest_id": 21014019,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "ElanWaterGrove",
+    "news_image": 615,
+    "order_conditions": [{"type": "AreaRank", "Param1": 14, "Param2": 13}],
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 44220
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "TransparentCoarseSand",
+                    "num": 3
+                },
+                {
+                    "item_id": "ProtectedBeastsGreenFur",
+                    "num": 1
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 47
+            },
+            "enemies": [
+                {
+                    "comment": "Troll",
+                    "enemy_id": "0x015040",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 372,
+                "group_id": 47
+            },
+            "enemies": [
+                {
+                    "comment": "Mole Troll",
+                    "enemy_id": "0x015041",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 5
+            },
+            "starting_index": 9,
+            "enemies": [
+                {
+                    "comment": "Mole Troll",
+                    "enemy_id": "0x015041",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Troll",
+                    "enemy_id": "0x015040",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 6180,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 439,
+                "group_id": 5
+            },
+            "starting_index": 9,
+            "enemies": [
+                {
+                    "comment": "Troll",
+                    "enemy_id": "0x015040",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Mole Troll",
+                    "enemy_id": "0x015041",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 6180,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Green Guardian",
+                    "enemy_id": "0x010210",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 13},
+                        {"type": "StageNo", "Param1": 121}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 25, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 121, "Param2": 47, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4583}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 121, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4583},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 818, "Param2": 5, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 818, "Param2": 5, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016.json
@@ -1,0 +1,336 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Lightning Scorching the Waterway",
+    "quest_id": 21015016,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 526,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 11}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 32830
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4494
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "UnappraisedWindTrinketSoldier",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 73
+            },
+            "enemies": [
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2735
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 73
+            },
+            "starting_index": 2,
+            "enemies": [
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 440,
+                "group_id": 1
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Lindwurm",
+                    "enemy_id": "0x015303",
+                    "level": 75,
+                    "exp": 68375,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Bolt Corpse Torturer",
+                    "enemy_id": "0x010518",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Corpse Torturer",
+                    "enemy_id": "0x010518",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Corpse Torturer",
+                    "enemy_id": "0x010518",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Wounded Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 540
+                },
+                {
+                    "comment": "Wounded Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 540
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 440,
+                "group_id": 1
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Lindwurm",
+                    "enemy_id": "0x015303",
+                    "level": 75,
+                    "exp": 68375,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Bolt Skeleton Brute",
+                    "enemy_id": "0x010322",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Skeleton Brute",
+                    "enemy_id": "0x010322",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Skeleton Brute",
+                    "enemy_id": "0x010322",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Wounded Blue Newt",
+                    "enemy_id": "0x010460",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 308
+                },
+                {
+                    "comment": "Wounded Blue Newt",
+                    "enemy_id": "0x010460",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 308
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 11},
+                        {"type": "StageNo", "Param1": 120}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 33, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 73, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4606}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 120, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4606},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 831, "Param2": 1, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 831, "Param2": 1, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016_1.json
@@ -1,0 +1,336 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Lightning Scorching the Waterway",
+    "quest_id": 21015016,
+    "base_level": 75,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 526,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 11}],
+	"variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 32830
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 4494
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 300
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "UnappraisedWindTrinketSoldier",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 76
+            },
+            "enemies": [
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "level": 75,
+                    "exp": 2735
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 76
+            },
+            "enemies": [
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Blue Newt",
+                    "enemy_id": "0x010460",
+                    "level": 75,
+                    "exp": 2735
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 440,
+                "group_id": 1
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Lindwurm",
+                    "enemy_id": "0x015303",
+                    "level": 75,
+                    "exp": 68375,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Bolt Corpse Torturer",
+                    "enemy_id": "0x010518",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Corpse Torturer",
+                    "enemy_id": "0x010518",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Corpse Torturer",
+                    "enemy_id": "0x010518",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Wounded Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 540
+                },
+                {
+                    "comment": "Wounded Bolt Grimwarg",
+                    "enemy_id": "0x010211",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 540
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 440,
+                "group_id": 1
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Lindwurm",
+                    "enemy_id": "0x015303",
+                    "level": 75,
+                    "exp": 68375,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Bolt Skeleton Brute",
+                    "enemy_id": "0x010322",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Skeleton Brute",
+                    "enemy_id": "0x010322",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Bolt Skeleton Brute",
+                    "enemy_id": "0x010322",
+                    "level": 75,
+                    "exp": 2735
+                },
+                {
+                    "comment": "Wounded Blue Newt",
+                    "enemy_id": "0x010460",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 308
+                },
+                {
+                    "comment": "Wounded Blue Newt",
+                    "enemy_id": "0x010460",
+                    "named_enemy_params_id": 1480,
+                    "level": 75,
+                    "exp": 308
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 11},
+                        {"type": "StageNo", "Param1": 120}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 32, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 76, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4607}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 120, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4607},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 831, "Param2": 1, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 831, "Param2": 1, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018.json
@@ -1,0 +1,443 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Cruel Winged Shadow",
+    "quest_id": 21015018,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 262,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 48420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5106
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "UnappraisedWindTrinketGeneral",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 74
+            },
+            "enemies": [
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 74
+            },
+            "enemies": [
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 397,
+                "group_id": 1
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Wyrm",
+                    "enemy_id": "0x015701",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 397,
+                "group_id": 1
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Drake",
+                    "enemy_id": "0x015700",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 630
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 13},
+                        {"type": "StageNo", "Param1": 120}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 20, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 74, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4618}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 120, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4618},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 901, "Param2": 1, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 901, "Param2": 1, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018_1.json
@@ -1,0 +1,444 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Cruel Winged Shadow",
+    "quest_id": 21015018,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 262,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 13}],
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 48420
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5106
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "UnappraisedWindTrinketGeneral",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 77
+            },
+            "enemies": [
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 77
+            },
+            "enemies": [
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Pixie Jabber",
+                    "enemy_id": "0x010155",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 397,
+                "group_id": 1
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Wyrm",
+                    "enemy_id": "0x015701",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Siren",
+                    "enemy_id": "0x010605",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Siren",
+                    "enemy_id": "0x010605",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 397,
+                "group_id": 1
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Drake",
+                    "enemy_id": "0x015700",
+                    "level": 80,
+                    "exp": 20175,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Wounded Strix",
+                    "enemy_id": "0x010610",
+                    "named_enemy_params_id": 1480,
+                    "level": 80,
+                    "exp": 2100
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                },
+                {
+                    "comment": "Strix",
+                    "enemy_id": "0x010610",
+                    "level": 80,
+                    "exp": 4035
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 13},
+                        {"type": "StageNo", "Param1": 120}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 18, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 77, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4619}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 120, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4619},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 901, "Param2": 1, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 901, "Param2": 1, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019.json
@@ -1,0 +1,297 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Fierce Tail and Splendid Wings",
+    "quest_id": 21015019,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 623,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 12}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 44220
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "AncientSagoPalm",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 75
+            },
+            "enemies": [
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 75
+            },
+            "enemies": [
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 5
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Black Griffin",
+                    "enemy_id": "0x015303",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Ghost Mail",
+                    "enemy_id": "0x010311",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Wounded Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 3910
+                },
+                {
+                    "comment": "Wounded Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 3910
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 5
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Nightmare",
+                    "enemy_id": "0x015305",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Wounded Witch",
+                    "enemy_id": "0x015604",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 4326
+                },
+                {
+                    "comment": "Wounded Witch",
+                    "enemy_id": "0x015604",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 4326
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 12},
+                        {"type": "StageNo", "Param1": 120}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 17, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 75, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4630}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 120, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4630},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 861, "Param2": 5, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 861, "Param2": 5, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019_1.json
@@ -1,0 +1,298 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Fierce Tail and Splendid Wings",
+    "quest_id": 21015019,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FaranaPlains",
+    "news_image": 623,
+    "order_conditions": [{"type": "AreaRank", "Param1": 15, "Param2": 12}],
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 44220
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "AncientSagoPalm",
+                    "num": 3
+                },
+                {
+                    "item_id": "Panacea",
+                    "num": 3
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 78
+            },
+            "enemies": [
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wight",
+                    "enemy_id": "0x015600",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 371,
+                "group_id": 78
+            },
+            "enemies": [
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Witch",
+                    "enemy_id": "0x015604",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 5
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Black Griffin",
+                    "enemy_id": "0x015303",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Ghost Mail",
+                    "enemy_id": "0x010311",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Wounded Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 3910
+                },
+                {
+                    "comment": "Wounded Wight",
+                    "enemy_id": "0x015600",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 3910
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 367,
+                "group_id": 5
+            },
+            "starting_index": 7,
+            "enemies": [
+                {
+                    "comment": "Nightmare",
+                    "enemy_id": "0x015305",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Ghost",
+                    "enemy_id": "0x015620",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Wounded Witch",
+                    "enemy_id": "0x015604",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 4326
+                },
+                {
+                    "comment": "Wounded Witch",
+                    "enemy_id": "0x015604",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 4326
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 12},
+                        {"type": "StageNo", "Param1": 120}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 16, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 120, "Param2": 78, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4631}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 120, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4631},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 861, "Param2": 5, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 861, "Param2": 5, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017002.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017002.json
@@ -1,0 +1,384 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Hard] The Mayhem Abyss",
+  "quest_id": 21017002,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "KingalCanyon",
+  "news_image": 900,
+  "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 10}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 48420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5138
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 940
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": "UnappraisedWindTrinketKing",
+          "num": 2
+        },
+        {
+          "item_id": "SuperiorStrongGalaExtract",
+          "num": 3
+        },
+        {
+          "item_id": "Panacea",
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 373,
+        "group_id": 22
+      },
+      "starting_index": 3,
+      "enemies": [
+        {
+          "comment": "Geo Golem",
+          "enemy_id": "0x015104",
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true
+        },
+        {
+          "comment": "Shadow Goblin Leader",
+          "enemy_id": "0x011160",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Shadow Wolf",
+          "enemy_id": "0x010206",
+          "level": 80,
+          "exp": 4035
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 455,
+        "group_id": 6
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Infected Gorecyclops - Slight",
+          "enemy_id": "0x015012",
+          "infection_type": 1,
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010112",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010112",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010112",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Infected Sling Hobgoblin",
+          "enemy_id": "0x010112",
+          "level": 80,
+          "exp": 4035
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 455,
+        "group_id": 3
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Witch",
+          "enemy_id": "0x015604",
+          "start_think_tbl_no": 1,
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true,
+          "index": 4
+        },
+        {
+          "comment": "Gorechimera",
+          "enemy_id": "0x015201",
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true,
+          "index": 5
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 2,
+          "level": 80,
+          "exp": 4035,
+          "index": 7
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 2,
+          "level": 80,
+          "exp": 4035,
+          "index": 8
+        },
+        {
+          "comment": "Sludgeman",
+          "enemy_id": "0x010510",
+          "start_think_tbl_no": 2,
+          "level": 80,
+          "exp": 4035,
+          "index": 9
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 455,
+        "group_id": 7
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Drake",
+          "enemy_id": "0x015700",
+          "level": 80,
+          "exp": 100875,
+          "is_boss": true,
+          "index": 1
+        },
+        {
+          "comment": "Gigant Machina",
+          "enemy_id": "0x015850",
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true,
+          "index": 6
+        },
+        {
+          "comment": "Grigori",
+          "enemy_id": "0x015900",
+          "level": 80,
+          "exp": 4035,
+          "index": 7
+        },
+        {
+          "comment": "Grigori",
+          "enemy_id": "0x015900",
+          "level": 80,
+          "exp": 4035,
+          "index": 8
+        },
+        {
+          "comment": "Grigori",
+          "enemy_id": "0x015900",
+          "level": 80,
+          "exp": 4035,
+          "index": 9
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 377
+          },
+          "npc_id": "Ciaran",
+          "message_id": 19456
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 2700,
+              "Param2": 19457
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 377
+          },
+          "npc_id": "Ciaran",
+          "message_id": 19458
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019.json
@@ -1,0 +1,317 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Frozen Blaze",
+    "quest_id": 21017019,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "KingalCanyon",
+    "news_image": 615,
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 13}],
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 44220
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "FrostMetal",
+                    "num": 1
+                },
+                {
+                    "item_id": "DarkMetal",
+                    "num": 1
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 373,
+                "group_id": 48
+            },
+            "enemies": [
+                {
+                    "comment": "Living Armor",
+                    "enemy_id": "0x010306",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Living Armor",
+                    "enemy_id": "0x010306",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 373,
+                "group_id": 48
+            },
+            "enemies": [
+                {
+                    "comment": "Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 422,
+                "group_id": 9
+            },
+            "starting_index": 5,
+            "enemies": [
+                {
+                    "comment": "Frost Machina",
+                    "enemy_id": "0x015851",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Wounded Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 422,
+                "group_id": 9
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Gigant Machina",
+                    "enemy_id": "0x015850",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Skull Lord",
+                    "enemy_id": "0x010313",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Wounded Skull Lord",
+                    "enemy_id": "0x010313",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Flame Skeleton Brute",
+                    "enemy_id": "0x010320",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Flame Skeleton Brute",
+                    "enemy_id": "0x010320",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Flame Skeleton Brute",
+                    "enemy_id": "0x010320",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 17, "Param1": 13},
+                        {"type": "StageNo", "Param1": 122}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 122, "Param2": 28, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 122, "Param2": 48, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4678}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 122, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4678},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 829, "Param2": 9, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 829, "Param2": 9, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019_1.json
@@ -1,0 +1,318 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Frozen Blaze",
+    "quest_id": 21017019,
+    "base_level": 78,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "KingalCanyon",
+    "news_image": 615,
+    "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 13}],
+    "variant_index": 1,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 44220
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5073
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "FrostMetal",
+                    "num": 1
+                },
+                {
+                    "item_id": "DarkMetal",
+                    "num": 1
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 373,
+                "group_id": 54
+            },
+            "enemies": [
+                {
+                    "comment": "Living Armor",
+                    "enemy_id": "0x010306",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Living Armor",
+                    "enemy_id": "0x010306",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 373,
+                "group_id": 54
+            },
+            "enemies": [
+                {
+                    "comment": "Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Skull Lord",
+                    "enemy_id": "0x010313",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 422,
+                "group_id": 9
+            },
+            "starting_index": 5,
+            "enemies": [
+                {
+                    "comment": "Frost Machina",
+                    "enemy_id": "0x015851",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Wounded Living Armor",
+                    "enemy_id": "0x010306",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Frost Skeleton Brute",
+                    "enemy_id": "0x010321",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 422,
+                "group_id": 9
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Gigant Machina",
+                    "enemy_id": "0x015850",
+                    "level": 78,
+                    "exp": 18425,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Wounded Skull Lord",
+                    "enemy_id": "0x010313",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Wounded Skull Lord",
+                    "enemy_id": "0x010313",
+                    "named_enemy_params_id": 1480,
+                    "level": 78,
+                    "exp": 1900
+                },
+                {
+                    "comment": "Flame Skeleton Brute",
+                    "enemy_id": "0x010320",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Flame Skeleton Brute",
+                    "enemy_id": "0x010320",
+                    "level": 78,
+                    "exp": 3685
+                },
+                {
+                    "comment": "Flame Skeleton Brute",
+                    "enemy_id": "0x010320",
+                    "level": 78,
+                    "exp": 3685
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 17, "Param1": 13},
+                        {"type": "StageNo", "Param1": 122}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 122, "Param2": 34, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035},
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 122, "Param2": 54, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 4679}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 122, "Param2": 1, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 4679},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ],
+                    "check_commands": [
+                        {"type": "IsEnemyFoundForOrder", "Param1": 829, "Param2": 9, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 829, "Param2": 9, "Param3": -1}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 2}
+                    ]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [0]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [1]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 1},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [2]
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "RandomEq", "Param1": 1, "Param2": 2},
+                        {"type": "MyQstFlagOn", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "SpawnGroup",
+                    "groups": [3]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017022.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017022.json
@@ -1,0 +1,346 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "[Hard] A Disastrous Encounter",
+  "quest_id": 21017022,
+  "base_level": 80,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "KingalCanyon",
+  "news_image": 900,
+  "order_conditions": [{"type": "AreaRank", "Param1": 17, "Param2": 15}, {"type": "MainQuestCompleted", "Param1": 20250}],
+  "rewards": [
+    {
+      "type": "exp",
+      "amount": 48420
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5138
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 940
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "item_id": "UnappraisedMoonTrinketKing",
+          "num": 2
+        },
+        {
+          "item_id": "SuperiorStrongGalaExtract",
+          "num": 3
+        },
+        {
+          "item_id": "Panacea",
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 373,
+        "group_id": 27
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Grigori",
+          "enemy_id": "0x015900",
+          "level": 80,
+          "exp": 4035,
+          "index": 4
+        },
+        {
+          "comment": "Grigori",
+          "enemy_id": "0x015900",
+          "level": 80,
+          "exp": 4035,
+          "index": 5
+        },
+        {
+          "comment": "Grigori",
+          "enemy_id": "0x015900",
+          "level": 80,
+          "exp": 4035,
+          "index": 6
+        },
+        {
+          "comment": "Bearded Grigori",
+          "enemy_id": "0x015920",
+          "level": 80,
+          "exp": 4035,
+          "index": 7
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 80,
+          "exp": 4035,
+          "index": 9
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 80,
+          "exp": 4035,
+          "index": 10
+        },
+        {
+          "comment": "Grimwarg",
+          "enemy_id": "0x010205",
+          "level": 80,
+          "exp": 4035,
+          "index": 11
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 385,
+        "group_id": 20
+      },
+      "enemies": [
+        {
+          "comment": "Scourge - Severe",
+          "enemy_id": "0x020601",
+          "infection_type": 2,
+          "level": 80,
+          "exp": 100875,
+          "is_boss": true
+        },
+        {
+          "comment": "Bearded Grigori",
+          "enemy_id": "0x015920",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Bearded Grigori",
+          "enemy_id": "0x015920",
+          "level": 80,
+          "exp": 4035
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 385,
+        "group_id": 15
+      },
+      "placement_type": "manual",
+      "enemies": [
+        {
+          "comment": "Manticore",
+          "enemy_id": "0x015210",
+          "level": 80,
+          "exp": 20175,
+          "is_boss": true,
+          "index": 0
+        },
+        {
+          "comment": "Severely Infected Demon",
+          "enemy_id": "0x015910",
+          "level": 80,
+          "exp": 4035,
+          "index": 2
+        },
+        {
+          "comment": "Severely Infected Demon",
+          "enemy_id": "0x015910",
+          "level": 80,
+          "exp": 4035,
+          "index": 3
+        },
+        {
+          "comment": "Severely Infected Demon",
+          "enemy_id": "0x015910",
+          "level": 80,
+          "exp": 4035,
+          "index": 4
+        }
+      ]
+    },
+    {
+      "stage_id": {
+        "id": 385,
+        "group_id": 23
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Eliminator Slay",
+          "enemy_id": "0x010530",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Eliminator Slay",
+          "enemy_id": "0x010530",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
+          "exp": 4035
+        },
+        {
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
+          "exp": 4035
+        }
+      ]
+    }
+  ],
+  "processes": [
+    {
+      "blocks": [
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 377
+          },
+          "npc_id": "Ciaran",
+          "message_id": 19993
+        },
+        {
+          "type": "SeekOutEnemiesAtMarkedLocation",
+          "announce_type": "Accept",
+          "result_commands": [
+            {
+              "comment": "Idle dialogue",
+              "type": "QstTalkChg",
+              "Param1": 2700,
+              "Param2": 19994
+            }
+          ],
+          "groups": [0]
+        },
+        {
+          "type": "KillGroup",
+          "announce_type": "Update",
+          "reset_group": false,
+          "groups": [ 0 ]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [1],
+          "check_flags": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "check_flags": [3, 4, 5]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 377
+          },
+          "npc_id": "Ciaran",
+          "message_id": 19995
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [1]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [1]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [3]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [2]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [2]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [4]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "MyQstFlags",
+          "check_flags": [1]
+        },
+        {
+          "type": "DiscoverEnemy",
+          "groups": [3]
+        },
+        {
+          "type": "KillGroup",
+          "reset_group": false,
+          "result_commands": [
+            {
+              "type": "MyQstFlagOn",
+              "Param1": 2
+            }
+          ],
+          "groups": [3]
+        },
+        {
+          "type": "MyQstFlags",
+          "announce_type": "Update",
+          "set_flags": [5]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the following world quests:

- q21000063: [Hard] Save the Island
- q21000074: [Hard] For Youthful Strength
- q21000086: [Hard] Don't Let Your Guard Down
- q21014016: Simian Relatives
- q21014018: Elanic Contrast
- q21014019: Brethren Hiding Poison
- q21015016: Lightning Scorching the Waterway
- q21015018: Cruel Winged Shadow
- q21015019: Fierce Tail and Splendid Wings
- q21017002: [Hard] The Mayhem Abyss
- q21017019: Frozen Blaze
- q21017022: [Hard] A Disastrous Encounter

Note: I went with a more accurate implementation for Chance Encounters which requires killing regular map enemies, but we're yet unable to mark non-quest enemies so the quests may feel "bugged". They work, and just require the player to kill the enemy group near the quest marker.