### PR TITLE
Season 3.2 Quests

### DIFF
--- a/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
+++ b/Arrowgene.Ddon.Database/DdonDatabaseBuilder.cs
@@ -13,7 +13,7 @@ public static class DdonDatabaseBuilder
 {
     private const string DefaultSchemaFile = "Script/schema_sqlite.sql";
 
-    public const uint Version = 65;
+    public const uint Version = 66;
     private static readonly ILogger Logger = LogProvider.Logger<Logger>(typeof(DdonDatabaseBuilder));
 
     public static IDatabase Build(DatabaseSetting settings)

--- a/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_3.2.sql
+++ b/Arrowgene.Ddon.Database/Files/Database/Script/migration_msq_3.2.sql
@@ -1,0 +1,4 @@
+INSERT INTO ddon_quest_progress(character_common_id, quest_type, quest_schedule_id, step)
+SELECT ddon_completed_quests.character_common_id, 3, 6312960, 0
+FROM ddon_completed_quests
+WHERE ddon_completed_quests.quest_id = 00030130;

--- a/Arrowgene.Ddon.Database/Sql/Core/Migration/00000066_Msq32Migration.cs
+++ b/Arrowgene.Ddon.Database/Sql/Core/Migration/00000066_Msq32Migration.cs
@@ -1,0 +1,17 @@
+using System.Data.Common;
+
+namespace Arrowgene.Ddon.Database.Sql.Core.Migration
+{
+    public class Msq32Migration(DatabaseSetting databaseSetting) : IMigrationStrategy
+    {
+        public uint From => 65;
+        public uint To => 66;
+
+        public bool Migrate(IDatabase db, DbConnection conn)
+        {
+            string adaptedSchema = DdonDatabaseBuilder.GetAdaptedSchema(databaseSetting, "Script/migration_msq_3.2.sql");
+            db.Execute(conn, adaptedSchema, true);
+            return true;
+        }
+    }
+}

--- a/Arrowgene.Ddon.GameServer/Characters/AreaRankManager.cs
+++ b/Arrowgene.Ddon.GameServer/Characters/AreaRankManager.cs
@@ -294,7 +294,7 @@ namespace Arrowgene.Ddon.GameServer.Characters
             }
 
             // Until S3.
-            if (spot.AreaId >= QuestAreaId.MegadosysPlateau)
+            if (spot.AreaId >= QuestAreaId.UrtecaMountains)
             {
                 return true;
             }

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar01_abhorrent_territory.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar01_abhorrent_territory.csx
@@ -12,76 +12,44 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 0),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 1),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 3),
-            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 4),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrigin, 90, 21000, 5)
-                .SetIsBoss(true),
-            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 6),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 7),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableAncestorOrc = LibDdon.Enemy.GetDropsTable(EnemyId.AncestorOrc, 90).Clone()
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
+        var dropsTableCaptainAncestorOrc = LibDdon.Enemy.GetDropsTable(EnemyId.CaptainAncestorOrc, 90).Clone()
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
+        var dropsTableProgenitor = LibDdon.Enemy.GetDropsTable(EnemyId.AncestorOrigin, 90).Clone()
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.UNCOMMON);
-        enemies[5].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[7].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 0)
+                .SetDropsTable(dropsTableCaptainAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 1)
+                .SetDropsTable(dropsTableAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 2)
+                .SetDropsTable(dropsTableAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 3)
+                .SetDropsTable(dropsTableAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 4)
+                .SetDropsTable(dropsTableCaptainAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrigin, 90, 105000, 5)
+                .SetDropsTable(dropsTableProgenitor)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 6)
+                .SetDropsTable(dropsTableCaptainAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 7)
+                .SetDropsTable(dropsTableAncestorOrc),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar01_firefall_mountain_eroded_rock.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar01_firefall_mountain_eroded_rock.csx
@@ -12,52 +12,38 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 0),
-            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 1),
-            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 3),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrigin, 90, 21000, 4)
-                .SetIsBoss(true),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableGrimwarg = LibDdon.Enemy.GetDropsTable(EnemyId.Grimwarg, 90).Clone()
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
+        var dropsTableCaptainAncestorOrc = LibDdon.Enemy.GetDropsTable(EnemyId.CaptainAncestorOrc, 90).Clone()
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
+        var dropsTableProgenitor = LibDdon.Enemy.GetDropsTable(EnemyId.AncestorOrigin, 90).Clone()
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.UNCOMMON);
-        enemies[4].SetDropsTable(dropsTable);
 
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 0)
+                .SetDropsTable(dropsTableCaptainAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 1)
+                .SetDropsTable(dropsTableGrimwarg),
+            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 2)
+                .SetDropsTable(dropsTableCaptainAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 3)
+                .SetDropsTable(dropsTableGrimwarg),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrigin, 90, 21000, 4)
+                .SetDropsTable(dropsTableProgenitor)
+                .SetIsBoss(true),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar01_firefall_mountain_eroded_rock_1.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar01_firefall_mountain_eroded_rock_1.csx
@@ -13,43 +13,29 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
+        var dropsTableAncestorOrc = LibDdon.Enemy.GetDropsTable(EnemyId.AncestorOrc, 90).Clone()
+            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
+
+        var dropsTableGrimwarg = LibDdon.Enemy.GetDropsTable(EnemyId.Grimwarg, 90).Clone()
+            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
+
+        AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 0),
-            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 1),
-            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 3),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Phlogopite, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.BlazingOre, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.RedGarnet, 1, 1, DropRate.RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 0)
+                .SetDropsTable(dropsTableAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 1)
+                .SetDropsTable(dropsTableAncestorOrc),
+            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 2)
+                .SetDropsTable(dropsTableGrimwarg),
+            LibDdon.Enemy.Create(EnemyId.Grimwarg, 90, 4200, 3)
+                .SetDropsTable(dropsTableGrimwarg),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar02_isolated_beach.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar02_isolated_beach.csx
@@ -13,57 +13,34 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 0),
-            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 1),
-            LibDdon.Enemy.Create(EnemyId.Witch, 92, 21000, 2)
-                .SetIsBoss(true),
-            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 3),
-            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 4),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableGiantGeoSaurian = LibDdon.Enemy.GetDropsTable(EnemyId.GiantGeoSaurian, 92).Clone()
             .AddDrop(ItemId.SpiritPurifierStone, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.SpiritPurifierStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.Waterweed, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.HighlandAkadama, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.SpiritPurifierStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.SpiritPurifierStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Waterweed, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.HighlandAkadama, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
+        var dropsTableWitch = LibDdon.Enemy.GetDropsTable(EnemyId.Grimwarg, 92).Clone()
             .AddDrop(ItemId.SpiritPurifierStone, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.SpiritPurifierStoneShard, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.Waterweed, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.HighlandAkadama, 1, 1, DropRate.UNCOMMON);
-        enemies[2].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.SpiritPurifierStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.SpiritPurifierStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Waterweed, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.HighlandAkadama, 1, 1, DropRate.RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.SpiritPurifierStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.SpiritPurifierStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.Waterweed, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.HighlandAkadama, 1, 1, DropRate.RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 0)
+                .SetDropsTable(dropsTableGiantGeoSaurian),
+            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 1)
+                .SetDropsTable(dropsTableGiantGeoSaurian),
+            LibDdon.Enemy.Create(EnemyId.Witch, 92, 21000, 2)
+                .SetDropsTable(dropsTableWitch)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 3)
+                .SetDropsTable(dropsTableGiantGeoSaurian),
+            LibDdon.Enemy.Create(EnemyId.GiantGeoSaurian, 92, 4200, 4)
+                .SetDropsTable(dropsTableGiantGeoSaurian),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar02_merciful_funeral_hall.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar02_merciful_funeral_hall.csx
@@ -13,48 +13,32 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 0),
-            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 1),
-            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.DeathKnight, 92, 21000, 0)
-                .SetIsBoss(true),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableGrudgeGhost = LibDdon.Enemy.GetDropsTable(EnemyId.GrudgeGhost, 92).Clone()
             .AddDrop(ItemId.CursedExorciserStone, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.CursedExorciserStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.GiantCaterpillar, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.CursedExorciserStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.CursedExorciserStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.GiantCaterpillar, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.CursedExorciserStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.CursedExorciserStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.GiantCaterpillar, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.RARE);
-        enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
+        var dropsTableDeathKnight = LibDdon.Enemy.GetDropsTable(EnemyId.DeathKnight, 92).Clone()
             .AddDrop(ItemId.CursedExorciserStone, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.CursedExorciserStoneShard, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantCaterpillar, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.UNCOMMON);
-        enemies[3].SetDropsTable(dropsTable);
 
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 0)
+                .SetDropsTable(dropsTableGrudgeGhost),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 1)
+                .SetDropsTable(dropsTableGrudgeGhost),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 2)
+                .SetDropsTable(dropsTableGrudgeGhost),
+            LibDdon.Enemy.Create(EnemyId.DeathKnight, 92, 21000, 0)
+                .SetDropsTable(dropsTableDeathKnight)
+                .SetIsBoss(true),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar03_nilviris_bridge_checkpoint.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar03_nilviris_bridge_checkpoint.csx
@@ -12,61 +12,34 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.WarReadyNightmareLightArmor, 93, 21000, 9)
-                .SetIsBoss(true),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 10),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 11),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 12),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 13),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 14),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 15),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableWarReadyNightmare = LibDdon.Enemy.GetDropsTable(EnemyId.WarReadyNightmareLightArmor, 93).Clone()
             .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
+        var dropsTableRangedSoldierDwarfOrc = LibDdon.Enemy.GetDropsTable(EnemyId.RangedSoldierDwarfOrc, 93).Clone()
             .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[1].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyNightmareLightArmor, 93, 21000, 9)
+                .SetDropsTable(dropsTableWarReadyNightmare)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 10)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 11)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 12)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 13)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 14)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 15)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar03_nilviris_bridge_checkpoint_1.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar03_nilviris_bridge_checkpoint_1.csx
@@ -13,25 +13,18 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
+        var dropsTableHeavySoldier = LibDdon.Enemy.GetDropsTable(EnemyId.HeavySoldierDwarfOrc, 93).Clone()
+            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
+
+        AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 3),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[0].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 2)
+                .SetDropsTable(dropsTableHeavySoldier),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 3)
+                .SetDropsTable(dropsTableHeavySoldier),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar03_nilviris_bridge_checkpoint_2.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar03_nilviris_bridge_checkpoint_2.csx
@@ -13,25 +13,18 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
+        var dropsTableHeavySoldier = LibDdon.Enemy.GetDropsTable(EnemyId.HeavySoldierDwarfOrc, 93).Clone()
+            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
+
+        AddEnemies(new List<InstancedEnemy>()
         {
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 3),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[0].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 2)
+                .SetDropsTable(dropsTableHeavySoldier),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 3)
+                .SetDropsTable(dropsTableHeavySoldier),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar05_demon_army_standby_spot.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar05_demon_army_standby_spot.csx
@@ -13,83 +13,45 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 93, 4200, 0),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 1),
-            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 2),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 3),
-            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 4),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 5),
-            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 6),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 7),
-            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 8),
-        };
+        var dropsTableBluntSoldier = LibDdon.Enemy.GetDropsTable(EnemyId.BluntSoldierDwarfOrc, 93).Clone()
+            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
 
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableRangedSoldier = LibDdon.Enemy.GetDropsTable(EnemyId.RangedSoldierDwarfOrc, 93).Clone()
+            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
+            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
+            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
+
+        var dropsTableSquadLeader = LibDdon.Enemy.GetDropsTable(EnemyId.SquadLeaderDwarfOrc, 93).Clone()
             .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.UNCOMMON);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[2].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[7].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[8]).Clone()
-            .AddDrop(ItemId.AlchemySealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.AlchemySealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.RoseMegadosys, 1, 1, DropRate.RARE);
-        enemies[8].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 93, 4200, 0)
+                .SetDropsTable(dropsTableSquadLeader),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 1)
+                .SetDropsTable(dropsTableRangedSoldier),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 2)
+                .SetDropsTable(dropsTableBluntSoldier),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 3)
+                .SetDropsTable(dropsTableRangedSoldier),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 4)
+                .SetDropsTable(dropsTableBluntSoldier),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 5)
+                .SetDropsTable(dropsTableRangedSoldier),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 6)
+                .SetDropsTable(dropsTableBluntSoldier),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 7)
+                .SetDropsTable(dropsTableRangedSoldier),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 93, 4200, 8)
+                .SetDropsTable(dropsTableBluntSoldier),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar05_prisoner_interrogation_gaol.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar05_prisoner_interrogation_gaol.csx
@@ -13,36 +13,28 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 3),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 4),
-            LibDdon.Enemy.Create(EnemyId.WarReadyOgreLightArmor, 93, 105000, 5)
-                .SetIsBoss(true),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableRangedSoldier = LibDdon.Enemy.GetDropsTable(EnemyId.RangedSoldierDwarfOrc, 93).Clone()
             .AddDrop(ItemId.CorruptedSealerStone, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.CorruptedSealerStoneShard, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
-            .AddDrop(ItemId.CorruptedSealerStone, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.CorruptedSealerStoneShard, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.RARE);
-        enemies[1].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
+        var dropsTableWarReadyOgre = LibDdon.Enemy.GetDropsTable(EnemyId.RangedSoldierDwarfOrc, 93).Clone()
             .AddDrop(ItemId.CorruptedSealerStone, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.CorruptedSealerStoneShard, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.FlameMushroom, 1, 1, DropRate.UNCOMMON);
-        enemies[2].SetDropsTable(dropsTable);
 
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 3)
+                .SetDropsTable(dropsTableRangedSoldier),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 4)
+                .SetDropsTable(dropsTableRangedSoldier),
+            LibDdon.Enemy.Create(EnemyId.WarReadyOgreLightArmor, 93, 105000, 5)
+                .SetDropsTable(dropsTableWarReadyOgre)
+                .SetIsBoss(true),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar06_bridge_training_ground.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/area_rank/monster_caution_spots/20_megadosys_plateau/ar06_bridge_training_ground.csx
@@ -12,75 +12,43 @@ public class MonsterSpotInfo : IMonsterSpotInfo
 
     public override void Initialize()
     {
-        var enemies = new List<InstancedEnemy>()
-        {
-            LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 93, 21000, 14)
-                .SetIsBoss(true),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 15),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 16),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 17),
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 18),
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 19),
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 20),
-            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 21),
-            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 22),
-        };
-
-        var dropsTable = LibDdon.Enemy.GetDropsTable(enemies[0]).Clone()
+        var dropsTableWarReadyGorecyclopsLightArmor0 = LibDdon.Enemy.GetDropsTable(EnemyId.WarReadyGorecyclopsLightArmor0, 93).Clone()
             .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.UNCOMMON)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.RARE);
-        enemies[0].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[1]).Clone()
+        var dropsTableRangedSoldierDwarfOrc = LibDdon.Enemy.GetDropsTable(EnemyId.RangedSoldierDwarfOrc, 93).Clone()
             .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[1].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[2]).Clone()
+        var dropsTableHeavySoldierDwarfOrc = LibDdon.Enemy.GetDropsTable(EnemyId.HeavySoldierDwarfOrc, 93).Clone()
             .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
             .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
             .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[2].SetDropsTable(dropsTable);
 
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[3]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[3].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[4]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[4].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[5]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[5].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[6]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[6].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[7]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[7].SetDropsTable(dropsTable);
-
-        dropsTable = LibDdon.Enemy.GetDropsTable(enemies[8]).Clone()
-            .AddDrop(ItemId.LowGradeReinforcedArmor, 1, 1, DropRate.VERY_RARE)
-            .AddDrop(ItemId.BattleArmorFragment, 1, 1, DropRate.RARE)
-            .AddDrop(ItemId.GiantAnimalSkull, 1, 1, DropRate.VERY_RARE);
-        enemies[8].SetDropsTable(dropsTable);
-
-        AddEnemies(enemies);
+        AddEnemies(new List<InstancedEnemy>()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 93, 21000, 14)
+                .SetDropsTable(dropsTableWarReadyGorecyclopsLightArmor0)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 15)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 16)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 17)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 18)
+                .SetDropsTable(dropsTableHeavySoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 19)
+                .SetDropsTable(dropsTableHeavySoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 20)
+                .SetDropsTable(dropsTableHeavySoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 93, 4200, 21)
+                .SetDropsTable(dropsTableHeavySoldierDwarfOrc),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 93, 4200, 22)
+                .SetDropsTable(dropsTableRangedSoldierDwarfOrc),
+        });
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300022.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300022.csx
@@ -35,7 +35,7 @@ public class ScriptedQuest : IQuest
         var process0 = AddNewProcess(0);
         process0.AddNpcTalkAndOrderBlock(Stage.FortressCityMegadoResidentialLevel1, NpcId.Toyugaru, 28160);
         process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.OldHeroicSpiritShrine)
-            .AddWorldManageUnlock(QuestFlags.FortressCityMegadoRoyalPalaceLevel.OldEpitaphRoadShrine)
+            .AddWorldManageUnlock(QuestFlags.FortressCityMegadoResidentialLevel.OldEpitaphRoadShrine)
             .AddResultCmdQstTalkChg(NpcId.Toyugaru, 28161);
         process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
             .AddResultCmdQstTalkChg(NpcId.Morgan, 28291)

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300200.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300200.csx
@@ -1,0 +1,109 @@
+/**
+ * @brief Crown and Scepter I
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.CrownAndScepterI;
+    public override ushort RecommendedLevel => 97;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => false;
+    public override bool? EnableCancel => true;
+    public override bool? OverrideEnemySpawn => true;
+    public override StageInfo StageInfo => Stage.FirefallMountainCampsite;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+    public override bool Enabled => false;
+
+    public override bool ShowInAdventureGuide(GameClient client)
+    {
+        return client.Character.HasQuestCompleted(QuestId.TheRelicsOfTheFirstKing) &&
+               client.Character.HasQuestCompleted(QuestId.TheHighSceptersHeir);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheRelicsOfTheFirstKing));
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.TheHighSceptersHeir));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.BloodOrb1000Bo, 5);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Set8260 = 8260;
+    }
+
+    private class NamedParamId
+    {
+        public const uint GuardianOfTheUnderworldSpring = 2659;
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Set8260, Stage.BeforetheSecretSpring, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Angules0, 97, 13629, 1)
+                .SetNamedEnemyParams(NamedParamId.GuardianOfTheUnderworldSpring)
+                .SetIsAreaBoss(true)
+                .SetIsBoss(true)
+                .SetEnemyTargetTypesId(TargetTypesId.AreaBoss),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.TheRelicsOfTheFirstKing);
+        process0.AddNewNpcTalkAndOrderBlock(Stage.FirefallMountainCampsite, 0, 0, NpcId.LiberationArmySoldier5, 30927)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8258);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.MegadosysPlateau, NpcId.Kirsty0, 30929)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier5, 30928);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.DarkPathtotheSecretSpring)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30930);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.DarkPathtotheSecretSpring, 0, 0, NpcId.Kirsty0, 30931)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8259);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Update, Stage.BeforetheSecretSpring)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5031);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.None, EnemyGroupId.Set8260)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8259)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8263);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8260, resetGroup: false)
+            .AddResultCmdPlayMessage(30935, 10)
+            .AddResultCmdPlayMessage(30936, 10)
+            .AddResultCmdPlayMessage(30937, 10)
+            .AddResultCmdPlayMessage(30938, 10)
+            .AddResultCmdPlayMessage(30939, 10);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.BeforetheSecretSpring, 0, 0, NpcId.Kirsty0, 30932)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8263)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8261)
+            .AddResultCmdPlayCameraEvent(Stage.BeforetheSecretSpring, 90)
+            .AddResultCmdStopMessage();
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, NpcId.Kirsty0, 30933)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5034);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(5034)
+            .AddCheckCmdStageNoNotEq(Stage.BeforetheSecretSpring);
+        process1.AddProcessEndBlock(false)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8261)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30934);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300201.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300201.csx
@@ -1,0 +1,99 @@
+/**
+ * @brief Crown and Scepter II
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.CrownAndScepterII;
+    public override ushort RecommendedLevel => 97;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => false;
+    public override bool? EnableCancel => true;
+    public override bool? OverrideEnemySpawn => true;
+    public override StageInfo StageInfo => Stage.MegadosysPlateau;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+    public override bool Enabled => false;
+
+    public override bool ShowInAdventureGuide(GameClient client)
+    {
+        return client.Character.HasQuestCompleted(QuestId.CrownAndScepterI);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.CrownAndScepterI));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.BloodOrb1000Bo, 5);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Set8265 = 8265;
+    }
+
+    private class NamedParamId
+    {
+        public const uint TheReincarnatedWarlordsPet = 2660;
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Set8265, Stage.TheRoyalFamilyMausoleum, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BlazeChimera, 97, 16738, 4)
+                .SetNamedEnemyParams(NamedParamId.TheReincarnatedWarlordsPet)
+                .SetIsBoss(true),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear(QuestId.CrownAndScepterI);
+        process0.AddNpcTalkAndOrderBlock(Stage.MegadosysPlateau, NpcId.Kirsty0, 30946);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.TheRoyalFamilyMausoleum)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30947);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.TheRoyalFamilyMausoleum, 0, 0, NpcId.Kirsty0, 30948)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8264);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8265)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5037);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8265, resetGroup: false)
+            .AddResultCmdPlayMessage(30952, 10)
+            .AddResultCmdPlayMessage(30953, 10)
+            .AddResultCmdPlayMessage(30954, 10)
+            .AddResultCmdPlayMessage(30955, 10)
+            .AddResultCmdPlayMessage(30956, 10);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.TheRoyalFamilyMausoleum, 1, 0, NpcId.Kirsty0, 30949)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8264)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8267)
+            .AddResultCmdPlayCameraEvent(Stage.TheRoyalFamilyMausoleum, 90)
+            .AddResultCmdStopMessage();
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, NpcId.Kirsty0, 30950)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5040);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(5040)
+            .AddCheckCmdStageNoNotEq(Stage.BeforetheSecretSpring);
+        process1.AddProcessEndBlock(false)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8267)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30951);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300202.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300202.csx
@@ -1,0 +1,103 @@
+/**
+ * @brief Crown and Scepter III
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.CrownAndScepterIII;
+    public override ushort RecommendedLevel => 97;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => false;
+    public override bool? EnableCancel => true;
+    public override bool? OverrideEnemySpawn => true;
+    public override StageInfo StageInfo => Stage.MegadosysPlateau;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+    public override bool Enabled => false;
+
+    public override bool ShowInAdventureGuide(GameClient client)
+    {
+        return client.Character.HasQuestCompleted(QuestId.CrownAndScepterII);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.CrownAndScepterI));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.BloodOrb1000Bo, 5);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Set8269 = 8269;
+    }
+
+    private class NamedParamId
+    {
+        public const uint AncientUnderworldGateGuardian = 2661;
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Set8269, Stage.RoyalFamilysSecretPath, 5, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.DeathKnight, 97, 2391, 1)
+                .SetNamedEnemyParams(NamedParamId.AncientUnderworldGateGuardian),
+            LibDdon.Enemy.Create(EnemyId.Medusa, 97, 7173, 2)
+                .SetNamedEnemyParams(NamedParamId.AncientUnderworldGateGuardian)
+                .SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.DeathKnight, 97, 2391, 6)
+                .SetNamedEnemyParams(NamedParamId.AncientUnderworldGateGuardian),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear(QuestId.CrownAndScepterII);
+        process0.AddNpcTalkAndOrderBlock(Stage.MegadosysPlateau, NpcId.Kirsty0, 30957);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.RoyalFamilysSecretPath)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30958);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.RoyalFamilysSecretPath, 0, 0, NpcId.Kirsty0, 30959)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8268);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8269)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5043);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8269, resetGroup: false)
+            .AddResultCmdPlayMessage(30963, 10)
+            .AddResultCmdPlayMessage(30964, 10)
+            .AddResultCmdPlayMessage(30965, 10)
+            .AddResultCmdPlayMessage(30966, 10)
+            .AddResultCmdPlayMessage(30967, 10);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.RoyalFamilysSecretPath, 1, 0, NpcId.Kirsty0, 30960)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8268)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8271)
+            .AddResultCmdPlayCameraEvent(Stage.RoyalFamilysSecretPath, 90)
+            .AddResultCmdStopMessage();
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, NpcId.Kirsty0, 30961)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5046);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(5046)
+            .AddCheckCmdStageNoNotEq(Stage.RoyalFamilysSecretPath);
+        process1.AddProcessEndBlock(false)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8271)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30962);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300203.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/disabled/q60300203.csx
@@ -1,0 +1,120 @@
+/**
+ * @brief Crown and Scepter IV
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.CrownAndScepterIV;
+    public override ushort RecommendedLevel => 97;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => false;
+    public override bool? EnableCancel => true;
+    public override bool? OverrideEnemySpawn => true;
+    public override StageInfo StageInfo => Stage.MegadosysPlateau;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+    public override bool Enabled => false;
+
+    public override bool ShowInAdventureGuide(GameClient client)
+    {
+        return client.Character.HasQuestCompleted(QuestId.CrownAndScepterIII);
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.PersonalQuestCleared(QuestId.CrownAndScepterIII));
+        AddQuestOrderCondition(QuestOrderCondition.SoloWithPawns());
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+
+        AddFixedItemReward(ItemId.RingOfTheFirstKing, 1);
+        AddFixedItemReward(ItemId.BloodOrb1000Bo, 5);
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Set8273 = 8273;
+        public const uint Set8274 = 8274;
+    }
+
+    private class NamedParamId
+    {
+        public const uint AncientUnderworldSpirit = 2662;
+        public const uint GuardianOfTheRing = 2679;
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Set8273, Stage.CrumblingEntrancePath, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SkeletonLordAbyss, 97, 16738, 1)
+                .SetNamedEnemyParams(NamedParamId.AncientUnderworldSpirit),
+            LibDdon.Enemy.Create(EnemyId.SkeletonLordAbyss, 97, 16738, 2)
+                .SetNamedEnemyParams(NamedParamId.AncientUnderworldSpirit),
+        });
+
+        AddEnemies(EnemyGroupId.Set8274, Stage.CrumblingEntrancePath, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.EvilEye0, 97, 23912, 0)
+                .SetNamedEnemyParams(NamedParamId.GuardianOfTheRing)
+                .SetIsBoss(true),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsTutorialQuestClear(QuestId.CrownAndScepterIII);
+        process0.AddNpcTalkAndOrderBlock(Stage.MegadosysPlateau, NpcId.Kirsty0, 30968);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.CrumblingEntrancePath)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30969);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.CrumblingEntrancePath, 0, 0, NpcId.Kirsty0, 30970)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8272);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5049)
+            .AddCheckCmdSceHitIn(Stage.CrumblingEntrancePath, 0);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.CrumblingEntrancePath, 2, 0, NpcId.Kirsty0, 31031)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8272)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8313)
+            .AddResultCmdPlayCameraEvent(Stage.CrumblingEntrancePath, 90);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8273)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5051)
+            .AddResultCmdPlayMessage(30974, 10)
+            .AddResultCmdPlayMessage(30975, 10)
+            .AddResultCmdPlayMessage(30976, 10)
+            .AddResultCmdPlayMessage(30977, 10)
+            .AddResultCmdPlayMessage(30978, 10);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set8274)
+			.AddResultCommands([
+				QuestManager.ResultCommand.CallMessage(4513, 31032)
+			]);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.CrumblingEntrancePath, 1, 0, NpcId.Kirsty0, 30971)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8313)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 8275)
+            .AddResultCmdStopMessage();
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, NpcId.Kirsty0, 30972)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 5052)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30950);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdMyQstFlagOn(5052)
+            .AddCheckCmdStageNoNotEq(Stage.CrumblingEntrancePath);
+        process1.AddProcessEndBlock(false)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 8275)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 30973);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.1/q00030130.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.1/q00030130.csx
@@ -14,7 +14,7 @@ public class ScriptedQuest : IQuest
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => true;
     public override StageInfo StageInfo => Stage.AudienceChamber;
-    public override QuestId NextQuestId => QuestId.None;
+    public override QuestId NextQuestId => QuestId.TheRoadToTheRoyalCapital;
 
     private class EnemyGroupId
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030140.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030140.csx
@@ -1,0 +1,177 @@
+/**
+ * @brief The Road to the Royal Capital
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.TheRoadToTheRoyalCapital;
+    public override ushort RecommendedLevel => 89;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.RallyTheTroops;
+
+    private class GeneralAnnouncement
+    {
+        public const int AreaMasterUnlocked = 100576;
+    }
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint TowerOccupying = 2302;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(89));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheBattleOfLookoutCastle));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.MegadosysPlateau, 22, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 89, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 89, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 89, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 89, 4200, 7)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 89, 4200, 8)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 89, 4200, 9)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.MegadosysPlateau, 22, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 89, 4200, 10)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 89, 4200, 11)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 89, 4200, 12)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 89, 4200, 13)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 89, 4200, 14)
+                .SetNamedEnemyParams(NamedParamId.TowerOccupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.MegadosysPlateau, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            /* prevent enemies from spawning */
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTouchAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 0)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.AudienceChamber, 205, 6);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.LookoutCastle1, 0, 1, NpcId.Meirova0, 21893)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7002)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7655)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 23964)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 23965)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 23966)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 23967);
+        process0.AddSceHitInBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LookoutCastle1, 1)
+            .AddWorldManageUnlock(QuestFlags.LookoutCastle.HarborDoor)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 23968)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 23969)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 23970);
+        process0.AddPartyGatherBlock(QuestAnnounceType.None, Stage.LookoutCastle1, -9081, -84, -8873)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.LookoutCastle.MegadosysPlateauWarp)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7214)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 23971)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 23972)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 23973)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 23974)
+            .AddResultCmdQstTalkChg(NpcId.Lotta, 27240);
+        process0.AddEventExecContBlock(QuestAnnounceType.None, Stage.LookoutCastle1, 0);
+        process0.AddEventAfterJumpBlock(QuestAnnounceType.None, Stage.MegadosysPlateau, 0, 13);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 0, 0, NpcId.Gillian0, 21912)
+            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.FieldAreaMarkers1)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.LookoutCastle.MegadosysPlateauWarp)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.EliGuardTowerWellOpen)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.EliGuardTowerWellClosed) // Part of the default world state
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7214)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7215)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 23975)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 23976)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 23977);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 23978)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 23979)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 23980)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 23981);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0, resetGroup: false);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 1, 0, NpcId.Gillian0, 21913)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7244)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7215)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 23982)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 23983);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddCheckCmdIsReleaseWarpPointAnyone(82);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 1, 0, NpcId.Gillian0, 21914)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 23984)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 23985);
+        process0.AddPartyGatherBlock(QuestAnnounceType.Update, Stage.MegadosysPlateau, 77652, 21505, -253208);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.MegadosysPlateau, 5, 12);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 2, 0, NpcId.Nedo0, 21932)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7243)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7244)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 23986)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 23987)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 23988)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 23989)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 23990)
+            .AddResultCmdQstTalkChg(NpcId.Yuri, 27242)
+            .AddResultCmdQstTalkChg(NpcId.Ross, 27243);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.EliGuardTower, NpcId.Doris, 27244)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.EliGuardTower.Doris)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.EliGuardTowerWellClosed)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.EliGuardTowerWellOpen)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 23991)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 23992);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.AudienceChamber, NpcId.TheWhiteDragon, 21933)
+            .AddResultCmdGeneralAnnounce(QuestGeneralAnnounceType.CommonMsg, GeneralAnnouncement.AreaMasterUnlocked)
+            .AddWorldManageUnlock(QuestFlags.NpcFunctions.MegadosysPlateauAreaInfo)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 23993)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 23994)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 23995)
+            .AddResultCmdQstTalkChg(NpcId.Doris, 27245)
+            .AddResultCmdQstTalkChg(NpcId.Lucas, 27246)
+            .AddResultCmdQstTalkChg(NpcId.Umit, 27247);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.MegadosysPlateauWorldQuests);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030150.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030150.csx
@@ -1,0 +1,174 @@
+/**
+ * @brief Rally the Troops
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.RallyTheTroops;
+    public override ushort RecommendedLevel => 90;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.AttackOnTheRoyalCapital;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint Pursuit2303 = 2303;
+        public const uint Pursuit2304 = 2304;
+        public const uint Pursuit2305 = 2305;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(90));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.TheRoadToTheRoyalCapital));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.MegadosysPlateau, 23, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2303),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2303),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 7)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2303),
+            LibDdon.Enemy.Create(EnemyId.AncestorOrc, 90, 4200, 8)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2303),
+            LibDdon.Enemy.Create(EnemyId.CaptainAncestorOrc, 90, 4200, 9)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2303),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.MegadosysPlateau, 40, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.GhostMail, 90, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2304),
+            LibDdon.Enemy.Create(EnemyId.DarkCorpseTorturer, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2304),
+            LibDdon.Enemy.Create(EnemyId.GhostMail, 90, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2304),
+            LibDdon.Enemy.Create(EnemyId.DarkCorpseTorturer, 90, 4200, 7)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2304),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.MegadosysPlateau, 51, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2305),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2305),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2305),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 90, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2305),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 90, 4200, 7)
+                .SetNamedEnemyParams(NamedParamId.Pursuit2305),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 21934)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34);
+        process0.AddPartyGatherBlock(QuestAnnounceType.Accept, Stage.LookoutCastle1, 22, 18280, -14478)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7245)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7257)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25314)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25315)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25316)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25317)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25318)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25319)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25320)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25321)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25322);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.LookoutCastle1, 5, 25);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LookoutCastle1, 1, 0, NpcId.Gillian0, 21947)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25323)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25324)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25325)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25326)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25327)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25328);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 6, 0, NpcId.Yuri, 28162)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7468)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25329);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.CheckpointAndUpdate, EnemyGroupId.Encounter + 0)
+            .AddResultCmdQstTalkChg(NpcId.Yuri, 28163)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7252)
+            .AddCheckCmdIsEnemyFoundForOrderRadius(Stage.MegadosysPlateau, 23, -1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 1, 0, NpcId.Kirsty0, 27252)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.MegadosysPlateau.Kirsty)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7247)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7252);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.CheckpointAndUpdate, EnemyGroupId.Encounter + 1)
+            .AddResultCmdQstTalkChg(NpcId.Eddys, 25336)
+            .AddResultCmdQstTalkChg(NpcId.Sago, 25337)
+            .AddResultCmdQstTalkChg(NpcId.Kirsty0, 27253)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7253)
+            .AddCheckCmdIsEnemyFoundForOrderRadius(Stage.MegadosysPlateau, 40, -1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 3, 0, NpcId.Percy, 25343)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7249)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7253);
+        process0.AddSpawnGroupBlock(QuestAnnounceType.CheckpointAndUpdate, EnemyGroupId.Encounter + 2)
+            .AddResultCmdQstTalkChg(NpcId.Percy, 27254)
+            .AddResultCmdQstTalkChg(NpcId.Barry, 25344)
+            .AddResultCmdQstTalkChg(NpcId.Ivey, 25335)
+            .AddResultCmdQstTalkChg(NpcId.Fred, 25338)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7254)
+            .AddCheckCmdIsEnemyFoundForOrderRadius(Stage.MegadosysPlateau, 51, -1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 5, 0, NpcId.Cyril, 25342)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7251)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7254)
+            .AddResultCmdQstTalkChg(NpcId.Karen, 25339)
+            .AddResultCmdQstTalkChg(NpcId.Linus, 25340)
+            .AddResultCmdQstTalkChg(NpcId.Toyugaru, 25341)
+            .AddResultCmdQstTalkChg(NpcId.Esen, 25345);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.EliGuardTower)
+            .AddResultCmdQstTalkChg(NpcId.Cyril, 27255);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.EliGuardTower, 0, 0, NpcId.Gillian0, 25348)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7256)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7251)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7257)
+            .AddResultCmdQstTalkChg(NpcId.Karen, 27248)
+            .AddResultCmdQstTalkChg(NpcId.Linus, 27249)
+            .AddResultCmdQstTalkChg(NpcId.Toyugaru, 27250)
+            .AddResultCmdQstTalkChg(NpcId.Esen, 27251);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LookoutCastle1, 0, 1, NpcId.Meirova0, 21948)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25346)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25347)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25349)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25350)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25351);
+        process0.AddProcessEndBlock(true)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.MegadosysPlateau.Kirsty);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030160.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030160.csx
@@ -1,0 +1,281 @@
+/**
+ * @brief Attack on the Royal Capital
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.AttackOnTheRoyalCapital;
+    public override ushort RecommendedLevel => 90;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.AnOmenOfDestruction;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint Occupying = 2306;
+        public const uint Obstructing = 2307;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(90));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.RallyTheTroops));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.FortressCityMegadoResidentialLevel0, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 90, 4200, 8)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 90, 4200, 9)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 90, 4200, 10)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 90, 4200, 11)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 90, 4200, 12)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.FortressCityMegadoResidentialLevel0, 2, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 90, 4200, 0)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 90, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 90, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 90, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.FortressCityMegadoResidentialLevel0, 50, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 7)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 3, Stage.FortressCityMegadoResidentialLevel0, 53, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 90, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 4, Stage.FortressCityMegadoResidentialLevel0, 55, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 6)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 90, 4200, 7)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 8)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 90, 4200, 9)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 5, Stage.FortressCityMegadoResidentialLevel0, 57, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 90, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Occupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 6, Stage.FortressCityMegadoResidentialLevel0, 3, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGoremanticoreLightArmor, 90, 21000, 0)
+                .SetIsBoss(true)
+                .SetNamedEnemyParams(NamedParamId.Obstructing),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 7, Stage.FortressCityMegadoResidentialLevel0, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 90, 4200, 8)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.Occupying)
+                .SetRepopConditions(50, 10),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 90, 4200, 9)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.Occupying)
+                .SetRepopConditions(50, 10),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 90, 4200, 10)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.Occupying)
+                .SetRepopConditions(50, 10),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 21950)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.MegadosysPlateau, 0, 5, NpcId.Meirova0, 21951)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7269)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7270)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25640)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25641)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25642)
+            .AddResultCmdQstTalkChg(NpcId.Yuri, 25643)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25644)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25645)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25646)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25647)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25648);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadosysPlateau, 0, 3, NpcId.Nedo0, 21952)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25649)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25650)
+            .AddResultCmdQstTalkChg(NpcId.Yuri, 25651)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25652)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25653)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25654)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25655);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.HiddenWaterwaytoMegado)
+            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.FieldAreaMarkers2)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7277)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25656)
+            .AddResultCmdQstTalkChg(NpcId.Sly, 25658);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.HiddenWaterwaytoMegado, 0, 0, NpcId.Bertha, 25657)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7746, QuestId.Q70032001) // Ladder to residental level 1
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7512, QuestId.Q70032001) // Part of the default world state: Invisible barrier
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7270)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7278)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7513)
+            .AddResultCmdQstTalkChg(NpcId.Cyril, 25659);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel0)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7514, QuestId.Q70032001); // Warp to residential level 0
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7480)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7278)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7513)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7269)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7439, QuestId.Q70032001) // Door to megadosys plateau
+            .AddCheckCmdMyQstFlagOn(0)
+            .AddCheckCmdMyQstFlagOn(1)
+            .AddCheckCmdMyQstFlagOn(2)
+            .AddCheckCmdMyQstFlagOn(3)
+            .AddCheckCmdMyQstFlagOn(4)
+            .AddCheckCmdMyQstFlagOn(5);
+        process0.AddPartyGatherBlock(QuestAnnounceType.Update, Stage.FortressCityMegadoResidentialLevel0, 15, 1400, -20387);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.FortressCityMegadoResidentialLevel0, 0, 11);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 6)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 16)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7480);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Update, Stage.HiddenWaterwaytoMegado)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 16);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Checkpoint, Stage.EliGuardTower);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.EliGuardTower, 0, 4, NpcId.Fabio0, 21971)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25666)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25667)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25668)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25669)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7016);
+        process0.AddPartyGatherBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, -11938, 11898, -13)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25670)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25671)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25672)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25673);
+        process0.AddEventAfterJumpBlock(QuestAnnounceType.None, Stage.AudienceChamber, 210, 6);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.AudienceChamber, NpcId.TheWhiteDragon, 21994)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7291)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheWhiteDragon7)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheWhiteDragon5)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25674)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25675)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25676)
+            .AddResultCmdQstTalkChg(NpcId.Fabio0, 25677)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25678)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25679);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7480);
+        process1.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 0);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdMyQstFlagOn(0);
+
+        var process2 = AddNewProcess(2);
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7480);
+        process2.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1);
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdMyQstFlagOn(1);
+
+        var process3 = AddNewProcess(3);
+        process3.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7480);
+        process3.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 2);
+        process3.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdMyQstFlagOn(2);
+
+        var process4 = AddNewProcess(4);
+        process4.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7480);
+        process4.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 3);
+        process4.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdMyQstFlagOn(3);
+
+        var process5 = AddNewProcess(5);
+        process5.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7480);
+        process5.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 4);
+        process5.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdMyQstFlagOn(4);
+
+        var process6 = AddNewProcess(6);
+        process6.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7480);
+        process6.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 5);
+        process6.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdMyQstFlagOn(5);
+
+        var process7 = AddNewProcess(7);
+        process7.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(16);
+        process7.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 7)
+            .AddCheckCmdIsMyquestLayoutFlagOff(16);
+        process7.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 7);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030170.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030170.csx
@@ -1,0 +1,180 @@
+/**
+ * @brief An Omen of Destruction
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.AnOmenOfDestruction;
+    public override ushort RecommendedLevel => 92;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.ABriefDragonForce;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint StagnationDisturbing1 = 2308;
+        public const uint ChaosofStagnation = 2309;
+        public const uint StagnationDisturbing2 = 2310;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(92));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.AttackOnTheRoyalCapital));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.TempleofPurification, 5, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.MiseryGhost, 92, 4200, 0)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing1),
+            LibDdon.Enemy.Create(EnemyId.MiseryGhost, 92, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing1),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.TempleofPurification, 13, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.MiseryGhost, 92, 4200, 0)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing1),
+            LibDdon.Enemy.Create(EnemyId.MiseryGhost, 92, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing1),
+            LibDdon.Enemy.Create(EnemyId.MiseryGhost, 92, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing1),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.TempleofPurification, 12, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 3, Stage.VortexofStagnation0, 2, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.CursedDragon, 92, 105000, 0)
+                .SetIsBoss(true)
+                .SetNamedEnemyParams(NamedParamId.ChaosofStagnation),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 4, Stage.VortexofStagnation0, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 2)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 3)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+            LibDdon.Enemy.Create(EnemyId.GrudgeGhost, 92, 4200, 4)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal)
+                .SetNamedEnemyParams(NamedParamId.StagnationDisturbing2),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTouchAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 0)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheWhiteDragon7)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheWhiteDragon5);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.AudienceChamber, 215, 6);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.Accept, Stage.AudienceChamber, NpcId.Joseph, 22014)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7018)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25753)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25754)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25755)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25756)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25757)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25758)
+            .AddResultCmdQstTalkChg(NpcId.Gerd1, 25759)
+            .AddResultCmdQstTalkChg(NpcId.Fabio0, 25760)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25761)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25762);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TempleofPurification);
+        process0.AddOmInteractEventBlock(QuestAnnounceType.Update, Stage.TempleofPurification, 0, 0, OmQuestType.MyQuest, OmInteractType.Release)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7019)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7018);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7019);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0, resetGroup: false);
+        process0.AddOmInteractEventBlock(QuestAnnounceType.Update, Stage.TempleofPurification, 2, 0, OmQuestType.MyQuest, OmInteractType.Release)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7024);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7024);
+        process0.AddOmInteractEventBlock(QuestAnnounceType.Update, Stage.TempleofPurification, 3, 0, OmQuestType.MyQuest, OmInteractType.Release)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7025);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7025);
+        process0.AddOmInteractEventBlock(QuestAnnounceType.Update, Stage.TempleofPurification, 4, 0, OmQuestType.MyQuest, OmInteractType.Release)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7293);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.VortexofStagnation0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7293)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7020);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 3)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7294);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 3, resetGroup: false);
+        process0.AddPartyGatherBlock(QuestAnnounceType.Update, Stage.VortexofStagnation0, 80, -302, -15020);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.VortexofStagnation0, 10, 2)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 13);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MayleafsBedroom)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7090)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25763);
+        process0.AddPartyGatherBlock(QuestAnnounceType.None, Stage.MayleafsBedroom, -2241, 18, 7)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25764)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25765)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25766)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25767)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7089)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7091)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7090);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.MayleafsBedroom, 25, 1);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.AudienceChamber, NpcId.Joseph, 22032)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25768)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25769)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25770)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25771)
+            .AddResultCmdQstTalkChg(NpcId.Gerd1, 25772)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25773)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7092)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7091);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(13);
+        process1.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 4)
+            .AddCheckCmdIsMyquestLayoutFlagOff(13);
+        process1.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 4);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030180.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030180.csx
@@ -1,0 +1,148 @@
+/**
+ * @brief A Brief Dragon Force
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.ABriefDragonForce;
+    public override ushort RecommendedLevel => 92;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.ThePlightOfLookoutCastle;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint Awoken = 2311;
+        public const uint OldSpiritDragonGuardBeast1 = 2312;
+        public const uint OldSpiritDragonGuardBeast2 = 2313;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(92));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.AnOmenOfDestruction));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.TarieSmallTower, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedPixie, 92, 4200, 0)
+                .SetNamedEnemyParams(NamedParamId.Awoken),
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedPixie, 92, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.Awoken),
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedPixie, 92, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.Awoken),
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedDemon, 92, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.OldSpiritDragonGuardBeast1),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.SageTowerRuins, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.LotusFin, 92, 105000, 0)
+                .SetIsBoss(true)
+                .SetNamedEnemyParams(NamedParamId.OldSpiritDragonGuardBeast2),
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedStymphalides, 92, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.Awoken),
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedStymphalides, 92, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.Awoken),
+            LibDdon.Enemy.Create(EnemyId.SeverelyInfectedStymphalides, 92, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Awoken),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 22073)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheWhiteDragon7)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheWhiteDragon5);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.HollowofBeginnings1, 0, 0, NpcId.Gearoid0, 22074)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25774)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25775)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25776)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25777)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25778)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25779)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25780)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7093)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7094)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.HollowOfBeginnings.SpiritDragon)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.HollowOfBeginnings.Mordred);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.SpiritArtsHut, NpcId.AdairDonnchadh0, 27265)
+            .AddResultCmdQstTalkChg(NpcId.Gearoid0, 25781)
+            .AddResultCmdQstTalkChg(NpcId.Mordred0, 27264);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TarieSmallTower)
+            .AddWorldManageUnlock(QuestFlags.FaranaPlains.TarieSmallTower)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7095)
+            .AddResultCmdQstTalkChg(NpcId.Blair, 27266);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0, resetGroup: false);
+        process0.AddOmInteractEventBlock(QuestAnnounceType.Update, Stage.FaranaPlains0, 1, 0, OmQuestType.MyQuest, OmInteractType.Release)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7099);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.HollowofBeginnings1, 0, 0, NpcId.Gearoid0, 22075)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7350)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7093)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7099)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25784)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25785)
+            .AddResultCmdQstTalkChg(NpcId.Blair, 27267)
+            .AddResultCmdQstTalkChg(NpcId.AdairDonnchadh0, 27268)
+            .AddResultCmdQstTalkChg(NpcId.Mordred0, 27270);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.ExpeditionGarrison, NpcId.Bertrand, 27271)
+            .AddResultCmdQstTalkChg(NpcId.Gearoid0, 27269);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.SageTowerRuins)
+            .AddWorldManageUnlock(QuestFlags.BloodbaneIsle.SageTowerRuins)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7096)
+            .AddResultCmdQstTalkChg(NpcId.ArisenCorpsRegimentalSoldier12, 27272);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1, resetGroup: false);
+        process0.AddOmInteractEventBlock(QuestAnnounceType.Update, Stage.BloodbaneIsle0, 1, 0, OmQuestType.MyQuest, OmInteractType.Release)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7100);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.HollowofBeginnings1, 0, 0, NpcId.Gearoid0, 25783)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7100)
+            .AddResultCmdQstTalkChg(NpcId.ArisenCorpsRegimentalSoldier12, 27273)
+            .AddResultCmdQstTalkChg(NpcId.Bertrand, 27274)
+            .AddResultCmdQstTalkChg(NpcId.Mordred0, 25782);
+        process0.AddPartyGatherBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.HollowofBeginnings1, 0, 1600, -22020)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 27275)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 27276);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.HollowofBeginnings1, 35, 7);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.HollowofBeginnings1, 0, 0, NpcId.Gearoid0, 22208)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7350)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7892)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25787)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25788)
+            .AddResultCmdQstTalkChg(NpcId.Mordred0, 25789);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.AudienceChamber, NpcId.Joseph, 22209)
+            .AddResultCmdQstTalkChg(NpcId.Gearoid0, 25786)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25790)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25791);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030190.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030190.csx
@@ -86,23 +86,23 @@ public class ScriptedQuest : IQuest
         {
             LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 0)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 1)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 2)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 92, 4200, 3)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 92, 4200, 4)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
         });
 
@@ -110,31 +110,31 @@ public class ScriptedQuest : IQuest
         {
             LibDdon.Enemy.Create(EnemyId.WarReadyOgreLightArmor, 92, 21000, 5)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 6)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 7)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 8)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 9)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 10)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 11)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
         });
 
@@ -142,23 +142,23 @@ public class ScriptedQuest : IQuest
         {
             LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 92, 4200, 12)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 13)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 14)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 15)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 16)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
         });
 
@@ -166,11 +166,11 @@ public class ScriptedQuest : IQuest
         {
             LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 92, 4200, 17)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
             LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 92, 4200, 20)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
         });
 
@@ -178,7 +178,7 @@ public class ScriptedQuest : IQuest
         {
             LibDdon.Enemy.Create(EnemyId.WarReadyNightmareLightArmor, 92, 21000, 0)
                 .SetIsManualSet(true)
-                .SetStartThinkTblNo(1)
+                .SetStartThinkTblNo(9)
                 .SetEnemyTargetTypesId(TargetTypesId.Normal),
         });
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030190.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030190.csx
@@ -1,0 +1,283 @@
+/**
+ * @brief The Plight of Lookout Castle
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.ThePlightOfLookoutCastle;
+    public override ushort RecommendedLevel => 92;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.TheFinalBattleOfTheRoyalCapital;
+
+    private class EnemyGroupId
+    {
+        public const uint Empty = 0;
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint Raid = 2314;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(92));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.ABriefDragonForce));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.LookoutCastle2, 3, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 92, 4200, 0)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.LookoutCastle2, 1, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 0)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 92, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.WarReadyGrimwargLightArmor, 92, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 92, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 92, 4200, 5)
+                .SetNamedEnemyParams(NamedParamId.Raid),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.LookoutCastle2, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarMaster0, 92, 105000, 0)
+                .SetIsBoss(true),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 10, Stage.LookoutCastle2, 10, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 0)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 1)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.HeavySoldierDwarfOrc, 92, 4200, 2)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 92, 4200, 3)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.RangedSoldierDwarfOrc, 92, 4200, 4)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 11, Stage.LookoutCastle2, 10, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyOgreLightArmor, 92, 21000, 5)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 6)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 7)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 8)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 9)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 10)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.WarReadySaurianLightArmor, 92, 4200, 11)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 12, Stage.LookoutCastle2, 10, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 92, 4200, 12)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 13)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 14)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 15)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 92, 4200, 16)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 13, Stage.LookoutCastle2, 10, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 92, 4200, 17)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 92, 4200, 20)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 14, Stage.LookoutCastle2, 11, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyNightmareLightArmor, 92, 21000, 0)
+                .SetIsManualSet(true)
+                .SetStartThinkTblNo(1)
+                .SetEnemyTargetTypesId(TargetTypesId.Normal),
+        });
+
+        AddEnemies(EnemyGroupId.Empty, Stage.MegadosysPlateau, 15, QuestEnemyPlacementType.Manual, new()
+        {
+
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 22210)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheWhiteDragon7)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheWhiteDragon5);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.MegadosysPlateau, 0, 0, NpcId.LiberationArmySoldier3, 27337)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7102)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7104)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25833)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25834)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25835)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25836)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25837)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25838)
+            .AddResultCmdQstTalkChg(NpcId.Sago, 28164)
+            .AddResultCmdQstTalkChg(NpcId.Fred, 28165);
+        process0.AddPartyGatherBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LookoutCastle1, 22, 18280, -14478)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7102)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7103)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier3, 27338)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25839)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25840)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25841)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25842)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25843)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25844)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25845);
+        process0.AddEventExecContBlock(QuestAnnounceType.None, Stage.LookoutCastle1, 10);
+        process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.LookoutCastle2, 13);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.LookoutCastle2, 0, 0, NpcId.Nedo0, 25866)
+            .AddResultCmdSetDiePlayerReturnPos(Stage.LookoutCastle2, 13, 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7103)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7105)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25863)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25864)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25865)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25867)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25868)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25869);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7945)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7106);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.LookoutCastle2, 1, 0, NpcId.Sara, 27340)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 4020)
+            .AddResultCmdQstTalkChg(NpcId.Adem, 27342)
+            .AddResultCmdQstTalkChg(NpcId.Dennis, 27343);
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 1, resetGroup: false);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.LookoutCastle2, 4, 0, NpcId.LiberationArmySoldier4, 27344)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier5, 27346)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier6, 27347)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7104)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7308);
+        process0.AddPartyGatherBlock(QuestAnnounceType.Update, Stage.LookoutCastle2, -10, 150, 8570)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier4, 27345);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.LookoutCastle2, 0, 3);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2)
+            .AddResultCmdResetDiePlayerReturnPos(Stage.Invalid, 0)
+            .AddResultCmdSetDiePlayerReturnPos(Stage.LookoutCastle2, 3, 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7109);
+        process0.AddEventExecContBlock(QuestAnnounceType.None, Stage.LookoutCastle2, 5)
+            .AddResultCmdBgmStop();
+        process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.LookoutCastle1, 0);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.LookoutCastle1, 1, 1, NpcId.Meirova0, 22239)
+            .AddResultCmdResetDiePlayerReturnPos(Stage.Invalid, 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7308)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7113)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25870)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25871)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25872)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25873)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25874)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25875);
+        process0.AddProcessEndBlock(true);
+
+        var process1 = AddNewProcess(1);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdEmHpLess(Stage.LookoutCastle2, 0, 0, 100);
+        process1.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 10)
+            .AddCheckCmdEmHpLess(Stage.LookoutCastle2, 0, 0, 75);
+        process1.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 11)
+            .AddCheckCmdEmHpLess(Stage.LookoutCastle2, 0, 0, 50);
+        process1.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 12)
+            .AddCheckCmdEmHpLess(Stage.LookoutCastle2, 0, 0, 25);
+        process1.AddSpawnGroupsBlock(QuestAnnounceType.None, [EnemyGroupId.Encounter + 13, EnemyGroupId.Encounter + 14]);
+        process1.AddProcessEndBlock(false);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030200.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/msq/season3.2/q00030200.csx
@@ -1,0 +1,255 @@
+/**
+ * @brief The Final Battle Of The Royal Capital
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    private static readonly ServerLogger Logger = LogProvider.Logger<ServerLogger>(typeof(ScriptedQuest));
+
+    public override QuestType QuestType => QuestType.Main;
+    public override QuestId QuestId => QuestId.TheFinalBattleOfTheRoyalCapital;
+    public override ushort RecommendedLevel => 94;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override StageInfo StageInfo => Stage.AudienceChamber;
+    public override QuestId NextQuestId => QuestId.None;
+
+    private class EnemyGroupId
+    {
+        public const uint Encounter = 10;
+    }
+
+    private class NamedParamId
+    {
+        public const uint Obstructing = 2316;
+        public const uint BlackWarriorsTamed = 2317;
+        public const uint CastleOccupying = 2318;
+        public const uint WhiteDragonBlackKnight = 2319;
+    }
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.MinimumLevel(94));
+        AddQuestOrderCondition(QuestOrderCondition.MainQuestCompleted(QuestId.ThePlightOfLookoutCastle));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 800000);
+        AddWalletReward(WalletType.Gold, 90000);
+        AddWalletReward(WalletType.RiftPoints, 9000);
+
+        AddFixedItemReward(ItemId.RoyalCrestMedalMegadosysDistrict, 5);
+        AddFixedItemReward(ItemId.UnappraisedWaterTrinketGeneral, 2);
+        AddFixedItemReward(ItemId.ApMegadosysPlateau, 500);
+    }
+
+    protected override void InitializeEnemyGroups()
+    {
+        AddEnemies(EnemyGroupId.Encounter + 0, Stage.MegadoCorridor0, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyOgreLightArmor, 94, 21000, 0)
+                .SetIsBoss(true)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 94, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 94, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+            LibDdon.Enemy.Create(EnemyId.BluntSoldierDwarfOrc, 94, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 1, Stage.MegadoCorridor0, 2, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 94, 21000, 0)
+                .SetIsBoss(true)
+                .SetInfectionType(3)
+                .SetNamedEnemyParams(NamedParamId.Obstructing),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 2, Stage.FortressCityMegadoRoyalPalaceLevel, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.Goremanticore, 94, 105000, 0)
+                .SetIsBoss(true)
+                .SetNamedEnemyParams(NamedParamId.BlackWarriorsTamed),
+            LibDdon.Enemy.Create(EnemyId.Grigori, 94, 4200, 1)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+            LibDdon.Enemy.Create(EnemyId.Grigori, 94, 4200, 2)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+            LibDdon.Enemy.Create(EnemyId.BeardedGrigori, 94, 4200, 3)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+            LibDdon.Enemy.Create(EnemyId.BeardedGrigori, 94, 4200, 4)
+                .SetNamedEnemyParams(NamedParamId.CastleOccupying),
+        });
+
+        AddEnemies(EnemyGroupId.Encounter + 3, Stage.BlackKingsRoom0, 0, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BlackKnightHolyIce0, 94, 105000, 0)
+                .SetIsBoss(true)
+                .SetNamedEnemyParams(NamedParamId.WhiteDragonBlackKnight),
+        });
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+        process0.AddNpcTalkAndOrderBlock(Stage.AudienceChamber, NpcId.Joseph, 22230)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheCrewEndSeason34)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheWhiteDragon7)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheWhiteDragon5);
+        process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.LookoutCastle1)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7114)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25897)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25898)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25899)
+            .AddResultCmdQstTalkChg(NpcId.Gerd1, 25900)
+            .AddResultCmdQstTalkChg(NpcId.Fabio0, 25901)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25902)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25903);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.None, Stage.LookoutCastle1, 0, 0, NpcId.Meirova0, 22231)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7115)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25905)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25906)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25907)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25908);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel0)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25904)
+            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.FieldAreaMarkers3)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7439, QuestId.Q70032001) // Door to megado city 0
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7440, QuestId.Q70032001); // Door to megado city 1
+        process0.AddPartyGatherBlock(QuestAnnounceType.None, Stage.FortressCityMegadoResidentialLevel0, 0, 2400, -25782)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7115)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7116)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25909)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25910)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier0, 25911)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier1, 25912)
+            .AddResultCmdQstTalkChg(NpcId.LiberationArmySoldier2, 25913);
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.FortressCityMegadoResidentialLevel0, 5, 12);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel0, 1, 0, NpcId.Gillian0, 22260)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7116)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7117)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25916)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25917)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25918)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25919);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.MegadoCorridor0)
+            .AddQuestFlag(QuestFlagType.WorldManageQuest, QuestFlagAction.Set, 4149, QuestId.Q70032001) // Opens gates
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25915);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7545, QuestId.Q70032001) // Door to megado city 1
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7544, QuestId.Q70032001) // Door to megado city 0
+            // Move these flags eventually to a world manage file as they're part of the default world state
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7549, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7551, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7553, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7555, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7557, QuestId.Q70032001)
+            .AddCheckCmdOmEndAnimation(Stage.MegadoCorridor0, 24, 0);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 0);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1);
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Update, Stage.MegadoCorridor0, 0, 0, NpcId.Meirova0, 25920)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7119);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoRoyalPalaceLevel)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7549, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7551, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7553, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7555, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7557, QuestId.Q70032001);
+        process0.AddPartyGatherBlock(QuestAnnounceType.None, Stage.FortressCityMegadoRoyalPalaceLevel, 28, 4400, -295)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7562, QuestId.Q70032001); // Door to inner palace
+        process0.AddPlayEventBlock(QuestAnnounceType.None, Stage.FortressCityMegadoRoyalPalaceLevel, 0, 5);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2)
+            .AddResultCmdSetDiePlayerReturnPos(Stage.FortressCityMegadoRoyalPalaceLevel, 5, 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7309)
+            .AddResultCmdPlayMessage(22275, 5)
+            .AddResultCmdPlayMessage(22281, 5)
+            .AddResultCmdPlayMessage(22287, 5)
+            .AddResultCmdPlayMessage(22293, 5)
+            .AddResultCmdPlayMessage(22299, 5)
+            .AddResultCmdPlayMessage(22276, 5)
+            .AddResultCmdPlayMessage(22282, 5)
+            .AddResultCmdPlayMessage(22301, 5)
+            .AddResultCmdPlayMessage(22288, 5)
+            .AddResultCmdPlayMessage(22295, 5)
+            .AddResultCmdPlayMessage(22277, 5)
+            .AddResultCmdPlayMessage(22283, 5)
+            .AddResultCmdPlayMessage(22296, 5)
+            .AddResultCmdPlayMessage(22290, 5)
+            .AddResultCmdPlayMessage(22302, 5)
+            .AddResultCmdPlayMessage(22279, 5)
+            .AddResultCmdPlayMessage(22289, 5)
+            .AddResultCmdPlayMessage(22286, 5)
+            .AddResultCmdPlayMessage(22300, 5)
+            .AddResultCmdPlayMessage(22294, 5)
+            .AddResultCmdPlayMessage(22278, 5)
+            .AddResultCmdPlayMessage(22284, 5)
+            .AddResultCmdPlayMessage(22291, 5)
+            .AddResultCmdPlayMessage(22303, 5)
+            .AddResultCmdPlayMessage(22298, 5)
+            .AddResultCmdPlayMessage(22280, 5)
+            .AddResultCmdPlayMessage(22285, 5)
+            .AddResultCmdPlayMessage(22292, 5)
+            .AddResultCmdPlayMessage(22297, 5)
+            .AddResultCmdPlayMessage(22304, 5)
+            .AddResultCmdPlayMessage(22289, 5);
+        process0.AddEventExecContBlock(QuestAnnounceType.None, Stage.FortressCityMegadoRoyalPalaceLevel, 5)
+            .AddResultCmdStopMessage();
+        process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.BlackKingsRoom0, 1);
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 3)
+            .AddResultCmdResetDiePlayerReturnPos(Stage.Invalid, 0)
+            .AddResultCmdSetDiePlayerReturnPos(Stage.BlackKingsRoom0, 1, 0)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, 7309)
+            .AddResultCmdPlayMessage(22332, 5)
+            .AddResultCmdPlayMessage(22333, 5)
+            .AddResultCmdPlayMessage(22334, 5)
+            .AddResultCmdPlayMessage(22335, 5)
+            .AddResultCmdPlayMessage(22336, 5)
+            .AddResultCmdPlayMessage(22337, 5)
+            .AddResultCmdPlayMessage(22338, 5)
+            .AddResultCmdPlayMessage(22339, 5)
+            .AddResultCmdPlayMessage(22340, 5)
+            .AddResultCmdPlayMessage(22341, 5)
+            .AddResultCmdPlayMessage(22342, 5)
+            .AddResultCmdPlayMessage(22343, 5)
+            .AddResultCmdPlayMessage(22344, 5);
+        process0.AddEventExecContBlock(QuestAnnounceType.None, Stage.BlackKingsRoom0, 0)
+            .AddResultCmdStopMessage();
+        process0.AddEventAfterJumpBlock(QuestAnnounceType.None, Stage.FortressCityMegadoRoyalPalaceLevel, 10, 6);
+        process0.AddIsStageNoBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.AudienceChamber)
+            .AddResultCmdResetDiePlayerReturnPos(Stage.Invalid, 0)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7562, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 7122)
+            .AddResultCmdQstTalkChg(NpcId.Meirova0, 25921)
+            .AddResultCmdQstTalkChg(NpcId.Bertha, 25922)
+            .AddResultCmdQstTalkChg(NpcId.Nedo0, 25923)
+            .AddResultCmdQstTalkChg(NpcId.Gillian0, 25924)
+            .AddResultCmdQstTalkChg(NpcId.Gurdolin3, 25925)
+            .AddResultCmdQstTalkChg(NpcId.Lise0, 25926)
+            .AddResultCmdQstTalkChg(NpcId.Elliot0, 25927);
+        process0.AddPartyGatherBlock(QuestAnnounceType.None, Stage.AudienceChamber, -222, 9164, -17)
+            .AddResultCmdQstTalkChg(NpcId.Pamela, 25928)
+            .AddResultCmdQstTalkChg(NpcId.Fabio0, 25929)
+            .AddResultCmdQstTalkChg(NpcId.Mayleaf0, 25930)
+            .AddResultCmdQstTalkChg(NpcId.Joseph, 25931)
+            .AddResultCmdQstTalkChg(NpcId.Klaus0, 25932)
+            .AddResultCmdQstTalkChg(NpcId.Gerd1, 25933)
+            .AddResultCmdQstTalkChg(NpcId.TheWhiteDragon, 25934);
+        process0.AddEventExecContBlock(QuestAnnounceType.None, Stage.AudienceChamber, 220);
+        process0.AddEventAfterJumpContinueBlock(QuestAnnounceType.None, Stage.LookoutCastle1, 17, 10);
+        process0.AddStageJumpBlock(QuestAnnounceType.None, Stage.AudienceChamber, 6);
+        process0.AddProcessEndBlock(true)
+            .AddWorldManageUnlock(QuestFlags.FortressCityMegadoResidentialLevel.MegadoCorridor)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.AudienceChamber.TheWhiteDragon5)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheWhiteDragon7)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.AudienceChamber.TheCrewEndSeason32)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7439, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Clear, 7544, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7440, QuestId.Q70032001)
+            .AddQuestFlag(QuestFlagType.WorldManageLayout, QuestFlagAction.Set, 7545, QuestId.Q70032001);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000014.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60000014.csx
@@ -57,7 +57,7 @@ public class ScriptedQuest : IQuest
             // TODO: Issac, Dooris, Endale and Nayajiku might be unlocked at different points
             //.AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.SenekaExm)
             //.AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.IsaacExm)
-            .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.DorisExm)
+            //.AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.DorisExm)
             .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.EndaleExm)
             .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.NayajikuExm);
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300107.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300107.csx
@@ -1,0 +1,49 @@
+/**
+ * @brief Adventure Spot Guide: Megadosys Plateau I
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.AdventureSpotGuideMegadosysPlateauI;
+    public override ushort RecommendedLevel => 90;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override bool? EnableCancel => true;
+    public override StageInfo StageInfo => Stage.EliGuardTower;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.MegadosysPlateau, 2));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+        AddFixedItemReward(ItemId.CaveShrimpEggs, 1);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.TheRoadToTheRoyalCapital);
+        process0.AddNpcTalkAndOrderBlock(Stage.EliGuardTower, NpcId.Lucas, 28037);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Lucas, 28038)
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsEnemyFound(1006, 10, -1, 1)
+            ]);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddCheckCmdSceHitIn(Stage.QuietConcealedCave, 0);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.EliGuardTower, NpcId.Lucas, 28039);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300108.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300108.csx
@@ -1,0 +1,49 @@
+/**
+ * @brief Adventure Spot Guide: Megadosys Plateau II
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.AdventureSpotGuideMegadosysPlateauII;
+    public override ushort RecommendedLevel => 92;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override bool? EnableCancel => true;
+    public override StageInfo StageInfo => Stage.EliGuardTower;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.MegadosysPlateau, 5));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+        AddFixedItemReward(ItemId.SimplePurificationCrystal, 1);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.TheRoadToTheRoyalCapital);
+        process0.AddNpcTalkAndOrderBlock(Stage.EliGuardTower, NpcId.Lucas, 28077);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddResultCmdQstTalkChg(NpcId.Lucas, 28078)
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsEnemyFound(1025, 10, 0, 1)
+            ]);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddCheckCmdSceHitIn(Stage.MegadoWaterSupplyNetwork, 0);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.EliGuardTower, NpcId.Lucas, 28079);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300109.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60300109.csx
@@ -1,0 +1,49 @@
+/**
+ * @brief Adventure Spot Guide: Megadosys Plateau III
+ */
+
+#load "libs.csx"
+
+public class ScriptedQuest : IQuest
+{
+    public override QuestType QuestType => QuestType.Tutorial;
+    public override QuestId QuestId => QuestId.AdventureSpotGuideMegadosysPlateauIII;
+    public override ushort RecommendedLevel => 95;
+    public override byte MinimumItemRank => 0;
+    public override bool IsDiscoverable => true;
+    public override bool? EnableCancel => true;
+    public override StageInfo StageInfo => Stage.FortressCityMegadoResidentialLevel1;
+    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
+
+    protected override void InitializeState()
+    {
+        AddQuestOrderCondition(QuestOrderCondition.HasAreaRank(QuestAreaId.MegadosysPlateau, 8));
+    }
+
+    protected override void InitializeRewards()
+    {
+        AddPointReward(PointType.ExperiencePoints, 105000);
+        AddWalletReward(WalletType.Gold, 11000);
+        AddWalletReward(WalletType.RiftPoints, 2000);
+        AddFixedItemReward(ItemId.RoyalFamilyChantsGrimoire, 1);
+    }
+
+    protected override void InitializeBlocks()
+    {
+        var process0 = AddNewProcess(0);
+		process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMainQuestClear(QuestId.TheFinalBattleOfTheRoyalCapital);
+        process0.AddNpcTalkAndOrderBlock(Stage.FortressCityMegadoResidentialLevel1, NpcId.Burj, 28081);
+        process0.AddRawBlock(QuestAnnounceType.Accept)
+			.AddResultCmdQstTalkChg(NpcId.Burj, 28082)
+			.AddCheckCommands([
+				QuestManager.CheckCommand.IsEnemyFound(463, 7, -1, 1)
+			]);
+        process0.AddRawBlock(QuestAnnounceType.Update)
+			.AddCheckCmdSceHitIn(Stage.MegadoCathedral, 0);
+        process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel1, NpcId.Burj, 28083);
+        process0.AddProcessEndBlock(true);
+    }
+}
+
+return new ScriptedQuest();

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320001.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320001.csx
@@ -13,7 +13,6 @@ public class ScriptedQuest : IQuest
     public override bool IsDiscoverable => false;
     public override StageInfo StageInfo => Stage.MegadosysPlateau;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
-    public override bool Enabled => false;
 
     private class EnemyGroupId
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320002.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320002.csx
@@ -13,7 +13,6 @@ public class ScriptedQuest : IQuest
     public override bool IsDiscoverable => false;
     public override StageInfo StageInfo => Stage.EliGuardTower;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
-    public override bool Enabled => false;
 
     private class EnemyGroupId
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320003.csx
@@ -13,7 +13,6 @@ public class ScriptedQuest : IQuest
     public override bool IsDiscoverable => false;
     public override StageInfo StageInfo => Stage.MegadosysPlateau;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
-    public override bool Enabled => false;
 
     private class EnemyGroupId
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320004.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/personal/q60320004.csx
@@ -13,7 +13,6 @@ public class ScriptedQuest : IQuest
     public override bool IsDiscoverable => false;
     public override StageInfo StageInfo => Stage.MegadosysPlateau;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
-    public override bool Enabled => false;
 
     private class EnemyGroupId
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/substory/carrie/q10300100.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/substory/carrie/q10300100.csx
@@ -12,7 +12,6 @@ public class ScriptedQuest : IQuest
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => true;
     public override StageInfo StageInfo => Stage.FortThinesGreatDiningHall;
-    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
 
     private class QstLayoutFlag
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/substory/carrie/q10300102.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/substory/carrie/q10300102.csx
@@ -12,7 +12,6 @@ public class ScriptedQuest : IQuest
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => true;
     public override StageInfo StageInfo => Stage.FortThinesGreatDiningHall;
-    public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.QuestUsefulForAdventure;
 
     private class QstLayoutFlag
     {

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/18_rathnite_foothills/q60318011.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/18_rathnite_foothills/q60318011.csx
@@ -16,9 +16,9 @@ public class ScriptedQuest : IQuest
 
     private class EnemyGroupId
     {
-		public const uint Empty1 = 0;
-		public const uint Empty2 = 1;
-		public const uint Empty3 = 2;
+        public const uint Empty1 = 0;
+        public const uint Empty2 = 1;
+        public const uint Empty3 = 2;
         public const uint Encounter1 = 10;
         public const uint Encounter2 = 11;
         public const uint Encounter3 = 12;
@@ -28,7 +28,7 @@ public class ScriptedQuest : IQuest
     private class NamedParamId
     {
         public const uint BaseDefense  = 1828;
-		public const uint DefenceOfficer = 1829;
+        public const uint DefenceOfficer = 1829;
         public const uint ArtilleryOfficer  = 1838;
     }
 
@@ -114,7 +114,7 @@ public class ScriptedQuest : IQuest
             LibDdon.Enemy.Create(EnemyId.SquadLeaderDwarfOrc, 83, 21000, 0)
                 .SetNamedEnemyParams(NamedParamId.DefenceOfficer),
             LibDdon.Enemy.Create(EnemyId.WarReadyGorecyclopsLightArmor0, 83, 105000, 2)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
         });
 
         // Catoblepas
@@ -135,7 +135,7 @@ public class ScriptedQuest : IQuest
             LibDdon.Enemy.Create(EnemyId.SwordSoldierDwarfOrc, 85, 4200, 8)
                 .SetNamedEnemyParams(NamedParamId.BaseDefense),
             LibDdon.Enemy.Create(EnemyId.Catoblepas, 83, 84563, 9)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
         });
     }
 
@@ -152,42 +152,42 @@ public class ScriptedQuest : IQuest
             .AddResultCmdQstTalkChg(NpcId.Endale, 23898);
 
         // 2. Ask Ozgur about the strength of the Liberation Army
-		process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
+        process0.AddRawBlock(QuestAnnounceType.CheckpointAndUpdate)
             .AddResultCmdQstTalkChg(NpcId.Ozgur, 23900)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.MyQstFlagOn(1)
-			])
-			.AddCheckCommands([
-				QuestManager.CheckCommand.MyQstFlagOn(2)
-			])
-			.AddCheckCommands([
-				QuestManager.CheckCommand.TalkNpc(631, NpcId.Ozgur),
-				QuestManager.CheckCommand.DummyNotProgress()
-			]);
+            .AddCheckCommands([
+                QuestManager.CheckCommand.MyQstFlagOn(1)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.MyQstFlagOn(2)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.TalkNpc(631, NpcId.Ozgur),
+                QuestManager.CheckCommand.DummyNotProgress()
+            ]);
 
         // 3. Head into enemy territory and strike with a surprise attack
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter1)
             .AddResultCmdQstTalkChg(NpcId.Ozgur, 25529)
-            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.AlliedAlways)
-            .AddQuestFlag(QuestFlagType.WorldManageQuest, QuestFlagAction.Set, 3284, (QuestId)70030001);
+            .AddWorldManageUnlock(QuestFlags.RathniteFoothillsLakeside.DemonArmyWarMachineGate)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.AlliedAlways);
 
         // 4. Destroy enemy artillery
-		process0.AddRawBlock(QuestAnnounceType.Update)
+        process0.AddRawBlock(QuestAnnounceType.Update)
             .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3293)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.CannonOm1)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.CannonOm2)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.IsOmBrokenQuest(131, 1, 0)
-			])
-			.AddCheckCommands([
-				QuestManager.CheckCommand.IsOmBrokenQuest(131, 2, 0)
-			]);
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsOmBrokenQuest(131, 1, 0)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.IsOmBrokenQuest(131, 2, 0)
+            ]);
 
         // 5. Defeat the leader of the reinforcements
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter2)
             .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, 3294);
-		process0.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCmdDieEnemy(Stage.RathniteFoothillsLakeside0, 50, 1);
+        process0.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdDieEnemy(Stage.RathniteFoothillsLakeside0, 50, 1);
 
         // 6. Head to the enemy's main stronghold deeper in
         process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter3)
@@ -211,65 +211,61 @@ public class ScriptedQuest : IQuest
             .AddResultCmdMyQstFlagOn(3);
         process0.AddProcessEndBlock(true);
 
-		// Branch 1 - Meirova
+        // Branch 1 - Meirova
         var process1 = AddNewProcess(1);
-		process1.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCmdTalkNpcChoice(Stage.RothgillTravelersInn, NpcId.Ozgur, 0);
-		process1.AddRawBlock(QuestAnnounceType.None)
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdTalkNpcChoice(Stage.RothgillTravelersInn, NpcId.Ozgur, 0);
+        process1.AddRawBlock(QuestAnnounceType.None)
             .AddResultCmdMyQstFlagOn(1)
             .AddCheckCmdMyQstFlagOn(3293);
-		process1.AddRawBlock(QuestAnnounceType.None)
+        process1.AddRawBlock(QuestAnnounceType.None)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 5638)
-			.AddResultCmdPlayMessage(25530,31)
+            .AddResultCmdPlayMessage(25530, 0)
             .AddCheckCmdMyQstFlagOn(3294);
-		process1.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25534,31)
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25534,0 )
             .AddCheckCmdMyQstFlagOn(3295);
-		process1.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25536,31)
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25536, 0)
             .AddCheckCmdMyQstFlagOn(3297);
-		process1.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25538,31)
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25538, 0)
             .AddCheckCmdMyQstFlagOn(3);
-		process1.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25540,31)
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25540, 0)
             .AddResultCmdQstTalkChg(NpcId.Meirova0, 25545);
 
-		// Branch 2 - Lise
+        // Branch 2 - Lise
         var process2 = AddNewProcess(2);
-		process2.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCmdTalkNpcChoice(Stage.RothgillTravelersInn, NpcId.Ozgur, 1);
-		process2.AddRawBlock(QuestAnnounceType.None)
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdTalkNpcChoice(Stage.RothgillTravelersInn, NpcId.Ozgur, 1);
+        process2.AddRawBlock(QuestAnnounceType.None)
             .AddResultCmdMyQstFlagOn(2)
             .AddCheckCmdMyQstFlagOn(3293);
-		process2.AddRawBlock(QuestAnnounceType.None)
+        process2.AddRawBlock(QuestAnnounceType.None)
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, 6339)
-			.AddResultCmdPlayMessage(25531,13)
+            .AddResultCmdPlayMessage(25531, 0)
             .AddCheckCmdMyQstFlagOn(3294);
-		process2.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25535,13)
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25535, 0)
             .AddCheckCmdMyQstFlagOn(3295);
-		process2.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25537,13)
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25537, 0)
             .AddCheckCmdMyQstFlagOn(3297);
-		process2.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25539,13)
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25539, 0)
             .AddCheckCmdMyQstFlagOn(3);
-		process2.AddRawBlock(QuestAnnounceType.None)
-			.AddResultCmdPlayMessage(25541,13)
+        process2.AddRawBlock(QuestAnnounceType.None)
+            .AddResultCmdPlayMessage(25541, 0)
             .AddResultCmdQstTalkChg(NpcId.Lise0, 25546);
 
-		// Send empty groups
-		var process3 = AddNewProcess(3);
-		process3.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.MyQstFlagOn(1),
-				QuestManager.CheckCommand.StageNo(131)
-			])
-			.AddCheckCommands([
-				QuestManager.CheckCommand.MyQstFlagOn(2),
-				QuestManager.CheckCommand.StageNo(131)
-			]);
+        // Send empty groups
+        var process3 = AddNewProcess(3);
+        process3.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCommands([
+                QuestManager.CheckCommand.WorldManageQuestFlagOn(3284, 70030001),
+                QuestManager.CheckCommand.StageNo(131)
+            ]);
         process3.AddSpawnGroupsBlock(QuestAnnounceType.None, [EnemyGroupId.Empty1, EnemyGroupId.Empty2, EnemyGroupId.Empty3]);
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319011.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/19_feryana_wilderness/q60319011.csx
@@ -236,8 +236,8 @@ public class ScriptedQuest : IQuest
             .AddCheckCmdIsTutorialQuestClear((QuestId)60319010);
         process0.AddNpcTalkAndOrderBlock(Stage.LookoutCastle1, NpcId.Nayajiku, 23902);
         process0.AddRawBlock(QuestAnnounceType.Accept)
+            .AddWorldManageUnlock(QuestFlags.FeryanaWilderness.OldTekiaGrotto)
 			.AddResultCommands([
-				QuestManager.ResultCommand.WorldManageQuestFlagOn(3286, 70031001),
 				QuestManager.ResultCommand.QstTalkChg(NpcId.Nayajiku, 23903)
 			])
 			.AddCheckCommands([
@@ -297,73 +297,75 @@ public class ScriptedQuest : IQuest
         var process1 = AddNewProcess(1);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddCheckCommands([
-				QuestManager.CheckCommand.MyQstFlagOn(3372)
+				QuestManager.CheckCommand.MyQstFlagOn(3372),
+				QuestManager.CheckCommand.MyQstFlagOff(3377)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25738, 595)
+				QuestManager.ResultCommand.PlayMessage(25738, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.IsEnemyFoundWithoutMarker(1063, 3, -1)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25739, 595)
+				QuestManager.ResultCommand.PlayMessage(25739, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.IsEnemyFoundWithoutMarker(1063, 4, -1)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25744, 595)
+				QuestManager.ResultCommand.PlayMessage(25744, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.SceHitInWithoutMarker(1063, 0)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25740, 595)
+				QuestManager.ResultCommand.PlayMessage(25740, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.MyQstFlagOn(3374)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25741, 595)
+				QuestManager.ResultCommand.PlayMessage(25741, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.MyQstFlagOn(3375)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25914, 595)
+				QuestManager.ResultCommand.PlayMessage(25914, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.IsEnemyFoundWithoutMarker(1063, 9, 0)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25742, 595)
+				QuestManager.ResultCommand.PlayMessage(25742, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.MyQstFlagOn(3376)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25743, 595)
+				QuestManager.ResultCommand.PlayMessage(25743, 0)
 			])
 			.AddCheckCommands([
 				QuestManager.CheckCommand.MyQstFlagOn(3377)
 			]);
         process1.AddRawBlock(QuestAnnounceType.None)
 			.AddResultCommands([
-				QuestManager.ResultCommand.PlayMessage(25736, 595)
+				QuestManager.ResultCommand.PlayMessage(25736, 0)
 			]);
 
         var process2 = AddNewProcess(2);
 		process2.AddRawBlock(QuestAnnounceType.None)
 			.AddCheckCommands([
-				QuestManager.CheckCommand.StageNo(1063)
+				QuestManager.CheckCommand.StageNo(1063),
+				QuestManager.CheckCommand.MyQstFlagOff(3377)
 			]);
         process2.AddSpawnGroupsBlock(QuestAnnounceType.None, [EnemyGroupId.Group2, EnemyGroupId.Group3, EnemyGroupId.Group4, EnemyGroupId.Group5])
 			.AddCheckCommands([

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320000.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320000.csx
@@ -13,7 +13,6 @@ public class ScriptedQuest : IQuest
     public override bool IsDiscoverable => false;
     public override StageInfo StageInfo => Stage.EliGuardTower;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.AreaTrialOrMission;
-    public override bool Enabled => false;
 
     protected override void InitializeState()
     {
@@ -103,7 +102,7 @@ public class ScriptedQuest : IQuest
             .AddResultCmdQstLayoutFlagOff(7491)
             .AddResultCmdQstLayoutFlagOff(7492);
         process0.AddSpawnGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter)
-            .AddResultCmdWorldManageLayoutFlagOn(7946, QuestId.Q70032001)
+            .AddResultCmdWorldManageLayoutFlagOn(7946, QuestId.Q70032001) // Player cannons
             .AddResultCmdQstLayoutFlagOff(7486)
             .AddResultCmdQstLayoutFlagOn(7495)
             .AddCheckCommands([

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320010.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320010.csx
@@ -14,7 +14,6 @@ public class ScriptedQuest : IQuest
     public override bool? EnableCancel => true;
     public override StageInfo StageInfo => Stage.FortressCityMegadoResidentialLevel1;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.AreaTrialOrMission;
-    public override bool Enabled => false;
 
     protected override void InitializeState()
     {
@@ -131,7 +130,7 @@ public class ScriptedQuest : IQuest
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel1, NpcId.Doris, 28279);
         process0.AddProcessEndBlock(true)
             .AddResultCmdAchievementBanner(6, 9)
-            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.Q70032001Unk1); // Figure out what this does later
+            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.FlamesOfDarkness);
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320011.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/trials/20_megadosys_plateau/q60320011.csx
@@ -13,7 +13,6 @@ public class ScriptedQuest : IQuest
     public override bool IsDiscoverable => false;
     public override StageInfo StageInfo => Stage.FortressCityMegadoResidentialLevel1;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.AreaTrialOrMission;
-    public override bool Enabled => false;
 
     protected override void InitializeState()
     {
@@ -39,13 +38,13 @@ public class ScriptedQuest : IQuest
             .AddCheckCmdIsTutorialQuestClear(QuestId.MegadosysPlateauTrialShadowOfHeresy);
         process0.AddNpcTalkAndOrderBlock(Stage.FortressCityMegadoResidentialLevel1, NpcId.Doris, 28298);
         process0.AddIsStageNoBlock(QuestAnnounceType.Accept, Stage.TheKingsRoomofConcealment0)
-            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.TheKingsHiddenChamberGates)
+            .AddWorldManageUnlock(QuestFlags.MegadosysPlateau.TheKingsHiddenChamber)
             .AddResultCmdQstTalkChg(NpcId.Doris, 28299);
         process0.AddRawBlock(QuestAnnounceType.Update)
             .AddCheckCmdEmDieForRandomDungeon(Stage.TheKingsRoomofConcealment0, EnemyId.Ifrit2ndForm, 1);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.FortressCityMegadoResidentialLevel1, NpcId.Doris, 28300);
         process0.AddProcessEndBlock(true)
-            .AddResultCmdAchievementBanner(6, 9); // This should show the achievement name, but how?
+            .AddResultCmdReleaseAnnounce(ContentsRelease.ExtremeMissions, flagInfo: QuestFlags.NpcFunctions.DorisExm);
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/vocation/11_high_scepter/q60300400.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/vocation/11_high_scepter/q60300400.csx
@@ -13,6 +13,7 @@ public class ScriptedQuest : IQuest
     public override ushort RecommendedLevel => 1;
     public override byte MinimumItemRank => 0;
     public override bool IsDiscoverable => true;
+    public override bool? EnableCancel => true;
     public override StageInfo StageInfo => Stage.TheWhiteDragonTemple0;
     public override QuestAdventureGuideCategory? AdventureGuideCategory => QuestAdventureGuideCategory.VocationQuest;
 
@@ -24,7 +25,8 @@ public class ScriptedQuest : IQuest
 
     private class EnemyGroupId
     {
-        public const uint Encounter = 10;
+        public const uint Set7418 = 7418;
+        public const uint Set7419 = 7419;
     }
 
     private class NamedParamId
@@ -37,7 +39,7 @@ public class ScriptedQuest : IQuest
     {
         // クエスト指定メッセージOM"
         // GroupNo=2, UnitNo=0
-        public const uint QuestSpecifiedMessageOM = 7417;
+        public const uint HighSceptersMark = 7417;
 
         // Wilson: GroupNo=0, UnitNo=0
         public const uint WilsonAndBarris = 7416;
@@ -46,11 +48,8 @@ public class ScriptedQuest : IQuest
     private class MyQstFlag
     {
         // NPC State Machine
-        public const uint BarrisFSM0 = 2011;
-        public const uint BarrisFSM1 = 4339;
-        public const uint BarrisFSM2 = 4349;
-
-        public const uint DespawnGroup0 = 1;
+        public const uint BarrisFSMStart = 4339;
+        public const uint BarrisFSMEnd = 4349;
     }
 
     public override bool AcceptRequirementsMet(GameClient client)
@@ -78,24 +77,23 @@ public class ScriptedQuest : IQuest
     protected override void InitializeEnemyGroups()
     {
         // 4 goblins
-        AddEnemies(EnemyGroupId.Encounter + 0, Stage.TrainingChapel, 0, QuestEnemyPlacementType.Manual, new()
+        AddEnemies(EnemyGroupId.Set7418, Stage.TrainingChapel, 0, QuestEnemyPlacementType.Manual, new()
         {
             LibDdon.Enemy.Create(EnemyId.GoblinFighter0, 1, 0, 0)
+                .SetRepopCount(50)
                 .SetNamedEnemyParams(NamedParamId.Training),
             LibDdon.Enemy.Create(EnemyId.GoblinFighter0, 1, 0, 1)
+                .SetRepopCount(50)
                 .SetNamedEnemyParams(NamedParamId.Training),
             LibDdon.Enemy.Create(EnemyId.GoblinFighter0, 1, 0, 2)
+                .SetRepopCount(50)
                 .SetNamedEnemyParams(NamedParamId.Training),
             LibDdon.Enemy.Create(EnemyId.GoblinFighter0, 1, 0, 3)
+                .SetRepopCount(50)
                 .SetNamedEnemyParams(NamedParamId.Training),
         });
 
-        AddEnemies(EnemyGroupId.Encounter + 1, Stage.TrainingChapel, 0, QuestEnemyPlacementType.Manual, new()
-        {
-            // Empty Group to despawn enemies
-        });
-
-        AddEnemies(EnemyGroupId.Encounter + 2, Stage.TrainingChapel, 1, QuestEnemyPlacementType.Manual, new()
+        AddEnemies(EnemyGroupId.Set7419, Stage.TrainingChapel, 1, QuestEnemyPlacementType.Manual, new()
         {
             LibDdon.Enemy.Create(EnemyId.Cyclops0, 3, 0, 0)
                 .SetIsBoss(true)
@@ -109,59 +107,72 @@ public class ScriptedQuest : IQuest
         process0.AddRawBlock(QuestAnnounceType.None)
             .AddCheckCmdPlJobEq(JobId.HighScepter);
         process0.AddNpcTalkAndOrderBlock(Stage.TheWhiteDragonTemple0, NpcId.Renton0, 28056);
-        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.TrainingChapel, 0, 0, NpcId.Wilson, 28058)
+        process0.AddNewTalkToNpcBlock(QuestAnnounceType.Accept, Stage.TrainingChapel, 0, 0, NpcId.Wilson, 28060)
+            .AddResultCmdQstTalkChg(NpcId.Renton0, 28057)
             .AddResultCmdResetTutorialFlag()
             .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.WilsonAndBarris);
-        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 0)
-            .AddResultCmdTutorialEnemyInvincibility(true)
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set7418)
+            .AddResultCmdPlayMessage(28089, 0)
+            .AddResultCmdQstTalkChg(NpcId.Wilson, 28058)
             .AddResultCmdTutorialDialog(TutorialId.AdvancedTacticsHighScepter)
-            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, MyQstFlag.BarrisFSM0)
-            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, MyQstFlag.BarrisFSM1);
-        // process0.AddNoProgressBlock();
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, MyQstFlag.BarrisFSMStart);
         process0.AddRawBlock(QuestAnnounceType.None)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(106); // Attack an enemy with Quadruple Slash
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28090, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(107); // Activate Will Marker
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28091, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(108); // Activate Ruin Shot
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28092, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(109); // Avoid an attack with Dodge Counter Slash
-        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2)
-            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, MyQstFlag.DespawnGroup0)
+        process0.AddDiscoverGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set7419)
+            .AddResultCmdPlayMessage(28244, 0)
+            .AddResultCmdTutorialEnemyInvincibility(true)
             .AddResultCmdTutorialDialog(TutorialId.FightingLargeEnemies)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(113); // Attack a marked foe with Magick Glyph to grow it
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28245, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(114); // Accumulate magick
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28093, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(110); // Move away from an enemy with Back Leap
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28094, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(111); // Attack an enemy with Ruin Blade
         process0.AddRawBlock(QuestAnnounceType.Update)
+            .AddResultCmdPlayMessage(28095, 0)
             .AddResultCmdResetTutorialFlag()
             .AddCheckCmdIsTutorialFlagOn(112); // Move toward an enemy with Return Shift
-        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Encounter + 2, false)
+        process0.AddDestroyGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set7419, false)
+            .AddResultCmdPlayMessage(28096, 0)
             .AddResultCmdTutorialEnemyInvincibility(false);
         process0.AddOmInteractEventBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TrainingChapel, 2, 0, OmQuestType.MyQuest, OmInteractType.Touch)
+            .AddResultCmdPlayMessage(28097, 0)
             .AddResultCmdTutorialDialog(TutorialId.TacticalRoleoftheHighScepter)
-            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.QuestSpecifiedMessageOM);
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Set, QstLayoutFlag.HighSceptersMark);
         process0.AddTalkToNpcBlock(QuestAnnounceType.CheckpointAndUpdate, Stage.TheWhiteDragonTemple0, NpcId.Renton0, 28062)
-            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, QstLayoutFlag.QuestSpecifiedMessageOM);
-        process0.AddIsStageNoBlock(QuestAnnounceType.None, Stage.TheWhiteDragonTemple0, false)
-            .AddResultCmdReleaseAnnounce(ContentsRelease.HighScepterWarSkillAugmentation, TutorialId.InheritanceSkillsOfBattleTechniques);
-        process0.AddProcessEndBlock(true);
+            .AddResultCmdQstTalkChg(NpcId.Wilson, 28061)
+            .AddResultCmdQstTalkChg(NpcId.Barris, 28088)
+            .AddQuestFlag(QuestFlagType.MyQst, QuestFlagAction.Set, MyQstFlag.BarrisFSMEnd)
+            .AddQuestFlag(QuestFlagType.QstLayout, QuestFlagAction.Clear, QstLayoutFlag.HighSceptersMark);
+        process0.AddProcessEndBlock(true)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.HighScepterWarSkillAugmentation)
+            .AddResultCmdReleaseAnnounce(ContentsRelease.WarSkillAugmentation, TutorialId.InheritanceSkillsOfBattleTechniques);
 
         var process1 = AddNewProcess(1);
-        process1.AddMyQstFlagsBlock(QuestAnnounceType.None)
-            .AddMyQstCheckFlag(MyQstFlag.DespawnGroup0);
-        process1.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Encounter + 1, true);
+        process1.AddRawBlock(QuestAnnounceType.None)
+            .AddCheckCmdIsMyquestLayoutFlagOn(7419);
+        process1.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Set7418);
         process1.AddProcessEndBlock(false);
     }
 }

--- a/Arrowgene.Ddon.Scripts/scripts/quests/world_manage/q79000003.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/world_manage/q79000003.csx
@@ -19,27 +19,16 @@ public class ScriptedQuest : IQuest
         process0.AddNoProgressBlock();
         process0.AddProcessEndBlock(false);
 
+		// Area Master Doris: Eli Guard Tower (until AR7)
         var process1 = AddNewProcess(1);
         process1.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.IsTutorialQuestClear(60318011)
-			]);
-        process1.AddRawBlock(QuestAnnounceType.None)
-            .AddQuestFlag(QuestFlagType.WorldManageQuest, QuestFlagAction.Set, 3284, (QuestId)70030001)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.DummyNotProgress()
-			]);
-
-        var process2 = AddNewProcess(2);
-        process2.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.IsTutorialQuestClear(60319011)
-			]);
-        process2.AddRawBlock(QuestAnnounceType.None)
-            .AddQuestFlag(QuestFlagType.WorldManageQuest, QuestFlagAction.Set, 3286, (QuestId)70031001)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.DummyNotProgress()
-			]);
+			.AddCheckCmdIsMainQuestClear(QuestId.TheRoadToTheRoyalCapital);
+		process1.AddRawBlock(QuestAnnounceType.None)
+            .AddQuestFlag(QuestFlagAction.Set, QuestFlags.EliGuardTower.Doris)
+			.AddCheckCmdCheckAreaRank(QuestAreaId.MegadosysPlateau, 7)
+			.AddCheckCmdStageNoNotEq(Stage.EliGuardTower); // Don't despawn her in front of the player
+        process1.AddProcessEndBlock(false)
+            .AddQuestFlag(QuestFlagAction.Clear, QuestFlags.EliGuardTower.Doris);
     }
 }
 

--- a/Arrowgene.Ddon.Scripts/scripts/quests/world_quests/megadosys_plateau/q22018050.csx
+++ b/Arrowgene.Ddon.Scripts/scripts/quests/world_quests/megadosys_plateau/q22018050.csx
@@ -23,6 +23,7 @@ public class ScriptedQuest : IQuest
     {
         public const uint Set7644 = 7644;
         public const uint Set7645 = 7645;
+        public const uint Boulders = 10;
     }
 
     protected override void InitializeRewards()
@@ -41,43 +42,49 @@ public class ScriptedQuest : IQuest
 
     protected override void InitializeEnemyGroups()
     {
+        var dropsTableCautionSpot = LibDdon.Enemy.GetDropsTable(EnemyId.Ifrit2ndForm, 95).Clone()
+            .AddDrop(ItemId.RingOfTheFlameDemon, 1, 1, DropRate.RARE);
+
         AddEnemies(EnemyGroupId.Set7644, Stage.TheKingsRoomofConcealment0, 2, QuestEnemyPlacementType.Manual, new()
         {
             LibDdon.Enemy.Create(EnemyId.Ifrit1stForm, 95, 0, 0)
-				.SetIsBoss(true),
+                .SetIsBoss(true),
         });
 
         AddEnemies(EnemyGroupId.Set7645, Stage.TheKingsRoomofConcealment0, 1, QuestEnemyPlacementType.Manual, new()
         {
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 1)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 2)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 3)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 4)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 5)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 6)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 7)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 8)
-				.SetRepopCount(50)
-				.SetIsRequired(false),
-            LibDdon.Enemy.Create(EnemyId.Ifrit2ndForm, 95, 21000, 9)
-				.SetStartThinkTblNo(1)
-				.SetIsBoss(true),
+            LibDdon.Enemy.Create(EnemyId.Ifrit2ndForm, 95, 105000, 9)
+                .SetDropsTable(dropsTableCautionSpot)
+                .SetStartThinkTblNo(1)
+                .SetIsBoss(true),
+        });
 
-			// Add caution spot drops to Ifrit later
+        AddEnemies(EnemyGroupId.Boulders, Stage.TheKingsRoomofConcealment0, 3, QuestEnemyPlacementType.Manual, new()
+        {
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 0)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 1)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 2)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 3)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 4)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 5)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 6)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
+            LibDdon.Enemy.Create(EnemyId.BlazingBoulder, 95, 0, 7)
+                .SetRepopCount(50)
+                .SetIsRequired(false),
         });
     }
 
@@ -85,30 +92,32 @@ public class ScriptedQuest : IQuest
     {
         var process0 = AddNewProcess(0);
         process0.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCommands([
-				QuestManager.CheckCommand.CheckAreaRank(20, 9),
-				QuestManager.CheckCommand.WorldManageQuestFlagOn(4580, 70032001),
-				QuestManager.CheckCommand.StageNo(133)
-			])
-			.AddCheckCommands([
-				QuestManager.CheckCommand.NewTalkNpc(133, 0, 0, 0)
-			]);
+            .AddCheckCommands([
+                QuestManager.CheckCommand.CheckAreaRank(20, 9),
+                QuestManager.CheckCommand.WorldManageQuestFlagOn(4580, 70032001),
+                QuestManager.CheckCommand.StageNo(133)
+            ])
+            .AddCheckCommands([
+                QuestManager.CheckCommand.NewTalkNpc(133, 0, 0, 0)
+            ]);
         process0.AddNewNpcTalkAndOrderBlock(Stage.MegadosysPlateau, 0, 0, NpcId.MegadoGuard0, 28774)
-			.AddResultCmdQstLayoutFlagOn(7651);
+            .AddResultCmdQstLayoutFlagOn(7651);
         process0.AddPartyGatherBlock(QuestAnnounceType.Accept, Stage.MegadosysPlateau, -8649, 22089, -314957)
-			.AddResultCmdQstTalkChg(NpcId.MegadoGuard0, 28775);
-		process0.AddEventAfterJumpBlock(QuestAnnounceType.None, Stage.TheKingsRoomofConcealment0, 5, 0);
+            .AddResultCmdQstTalkChg(NpcId.MegadoGuard0, 28775);
+        process0.AddEventAfterJumpBlock(QuestAnnounceType.None, Stage.TheKingsRoomofConcealment0, 5, 0);
         process0.AddSpawnGroupBlock(QuestAnnounceType.Update, EnemyGroupId.Set7644)
-			.AddCheckCmdIsLinkageEnemyFlag(Stage.TheKingsRoomofConcealment0, 2, 0, 2);
+            .AddCheckCmdIsLinkageEnemyFlag(Stage.TheKingsRoomofConcealment0, 2, 0, 2);
         process0.AddDestroyGroupBlock(QuestAnnounceType.None, EnemyGroupId.Set7645);
         process0.AddProcessEndBlock(true);
 
         var process1 = AddNewProcess(1);
         process1.AddRawBlock(QuestAnnounceType.None)
-			.AddCheckCmdIsLinkageEnemyFlag(Stage.TheKingsRoomofConcealment0, 1, 9, 4);
+            .AddCheckCmdIsLinkageEnemyFlag(Stage.TheKingsRoomofConcealment0, 2, 0, 1);
+        process1.AddSpawnGroupBlock(QuestAnnounceType.None, EnemyGroupId.Boulders)
+            .AddCheckCmdIsLinkageEnemyFlag(Stage.TheKingsRoomofConcealment0, 1, 9, 4);
         process1.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Set7644)
-			.AddCheckCmdDieEnemy(Stage.TheKingsRoomofConcealment0, 1, 9);
-        process1.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Set7645);
+            .AddCheckCmdDieEnemy(Stage.TheKingsRoomofConcealment0, 1, 9);
+        process1.AddRemoveGroupBlock(QuestAnnounceType.None, EnemyGroupId.Boulders);
     }
 }
 

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000020.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00000020.json
@@ -66,10 +66,9 @@
                 {
                     "comment" : "Iris",
                     "enemy_id": "0x011040",
-                    "level": 48,
-                    "exp": 57340,
                     "hm_present_no": 74,
-                    "is_boss": true,
+                    "level": 49,
+                    "exp": 0,
                     "index": 0
                 },
                 {
@@ -77,7 +76,8 @@
                     "enemy_id": "0x015103",
                     "named_enemy_params_id": 171,
                     "level": 48,
-                    "exp": 5734,
+                    "exp": 4554,
+                    "is_boss": true,
                     "index": 3
                 },
                 {
@@ -85,7 +85,8 @@
                     "enemy_id": "0x015103",
                     "named_enemy_params_id": 171,
                     "level": 48,
-                    "exp": 5734,
+                    "exp": 4554,
+                    "is_boss": true,
                     "index": 4
                 }
             ]
@@ -140,6 +141,16 @@
                     },
                     "npc_id": "Leo0",
                     "message_id": 8315,
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 1, "Param2": 466},
+                        {"type": "CallMessage", "Param1": 5, "Param2": 16184},
+						{"type": "QstTalkChg", "Param1": 4, "Param2": 8309, "comment": "Joseph"},
+						{"type": "QstTalkChg", "Param1": 3, "Param2": 8310, "comment": "Klaus"},
+						{"type": "QstTalkChg", "Param1": 7, "Param2": 8311, "comment": "Gerd"},
+						{"type": "QstTalkChg", "Param1": 14, "Param2": 8312, "comment": "Mayleaf"},
+						{"type": "QstTalkChg", "Param1": 1003, "Param2": 8313, "comment": "Pamela"},
+						{"type": "QstTalkChg", "Param1": 8, "Param2": 8314, "comment": "Heinz"}
+                    ],
                     "contents_release": [
                         {
                             "type": "None",
@@ -148,47 +159,29 @@
                     ]
                 },
                 {
-                    "type": "OmInteractEvent",
+                    "type": "Raw",
                     "checkpoint": true,
                     "announce_type": "Update",
                     "comment": "Interact with main door",
                     "flags": [
-                        {"type": "MyQst", "action": "Set", "value": 1, "comment": "Start Subprocess for marking door Main Door"},
                         {"type": "MyQst", "action": "Set", "value": 116, "comment": "Start Leo follow FSM"}
                     ],
-                    "quest_type": "WorldManageQuest",
-                    "quest_id": 70003001,
-                    "interact_type": "Release",
-                    "stage_id": {
-                        "id": 77,
-                        "group_id": 13,
-                        "layer_no": 1
-                    }
+                    "check_commands": [
+                        {"type": "QuestOmReleaseTouch", "Param1": 411, "Param2": 13, "Param3": 1, "Param4": 70003001}
+                    ]
                 },
                 {
-                    "type": "OmInteractEvent",
+                    "type": "Raw",
                     "checkpoint": true,
                     "announce_type": "Update",
                     "comment": "Interact with side door",
-                    "flags": [
-                        {"type": "MyQst", "action": "Set", "value": 2, "comment": "Signal to subprocess main door was touched"}
-                    ],
-                    "quest_type": "WorldManageQuest",
-                    "quest_id": 70003001,
-                    "interact_type": "Touch",
-                    "stage_id": {
-                        "id": 77,
-                        "group_id": 5,
-                        "layer_no": 2
-                    }
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 411, "Param2": 5, "Param3": 2, "Param4": 70003001}
+                    ]
                 },
                 {
                     "type": "CollectItem",
                     "checkpoint": true,
-                    "checkpoint_flags": [
-                        {"type": "MyQst", "action": "Clear", "value": 1, "comment": "Start Subprocess for marking Alchemy Door"},
-                        {"type": "MyQst", "action": "Clear", "value": 2, "comment": "Signal to subprocess main door was touched"}
-                    ],
                     "announce_type": "Update",
                     "comment": "Find key for side door",
                     "stage_id": {
@@ -196,13 +189,15 @@
                         "group_id": 3,
                         "layer_no": 1
                     },
+                    "result_commands": [
+                        {"type": "PlayMessage", "Param1": 8325, "Param2": 0}
+                    ],
                     "flags": [
-                        {"type": "MyQst", "action": "Set", "value": 3, "comment": "Signal to subprocess door was touched"},
                         {"type": "QstLayout", "action": "Set", "value": 906, "comment": "Spawns glitter in military facility"}
                     ]
                 },
                 {
-                    "type": "OmInteractEvent",
+                    "type": "Raw",
                     "checkpoint": true,
                     "announce_type": "Update",
                     "comment": "Open side door",
@@ -210,55 +205,36 @@
                         {"id": 1029, "amount": 1}
                     ],
                     "flags": [
-                        {"type": "MyQst", "action": "Set", "value": 4, "comment": "Signal to subprocess glitter was found"},
                         {"type": "QstLayout", "action": "Clear", "value": 906, "comment": "Spawns glitter for door"}
                     ],
-                    "quest_type": "WorldManageQuest",
-                    "quest_id": 70003001,
-                    "interact_type": "UsedKey",
-                    "stage_id": {
-                        "id": 77,
-                        "group_id": 5,
-                        "layer_no": 2
-                    }
+                    "check_commands": [
+                        {"type": "HasUsedKey", "Param1": 411, "Param2": 5, "Param3": 2, "Param4": 70003001}
+                    ]
                 },
                 {
-                    "type": "OmInteractEvent",
+                    "type": "Raw",
                     "checkpoint": true,
                     "consume_items": [
                         {"id": 1029, "amount": 1}
                     ],
-                    "checkpoint_flags": [
-                        {"type": "WorldManageLayout", "action": "Clear", "value": 1119, "quest_id": 70003001, "comment": "Alchemy Research Door Closed"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 1120, "quest_id": 70003001, "comment": "Alchemy Research Door Open"},
-                        {"type": "MyQst", "action": "Clear", "value": 4, "comment": "Signal to subprocess glitter was found"}
-                    ],
                     "announce_type": "Update",
                     "comment": "Pull Lever",
-                    "flags": [
-                        {"type": "MyQst", "action": "Set", "value": 5, "comment": "Signal to subprocess to mark lever"}
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0, "comment": "Handles alchemy door on stage exit"}
                     ],
-                    "quest_type": "WorldManageQuest",
-                    "quest_id": 70003001,
-                    "interact_type": "Release",
-                    "stage_id": {
-                        "id": 77,
-                        "group_id": 1,
-                        "layer_no": 1
-                    }
+                    "check_commands": [
+                        {"type": "QuestOmReleaseTouch", "Param1": 411, "Param2": 1, "Param3": 1, "Param4": 70003001}
+                    ]
                 },
                 {
                     "type": "PartyGather",
                     "announce_type": "Update",
                     "checkpoint": true,
                     "checkpoint_flags": [
-                        {"type": "MyQst", "action": "Clear", "value": 5, "comment": "Signal to subprocess lever was pulled"},
-                        {"type": "WorldManageLayout", "action": "Clear", "value": 1104, "quest_id": 70003001, "comment": "Large Front Door Closed"},
-                        {"type": "WorldManageLayout", "action": "Set", "value": 1105, "quest_id": 70003001, "comment": "Large Front Door Open"},
                         {"type": "WorldManageLayout", "action": "Clear", "value": 2458, "quest_id": 70003001, "comment": "Quest Specified Message"}
                     ],
                     "flags": [
-                        {"type": "MyQst", "action": "Set", "value": 6, "comment": "Signal to subprocess lever was pulled"}
+                        {"type": "MyQst", "action": "Set", "value": 1, "comment": "Handles large door on stage exit"}
                     ],
                     "stage_id": {
                         "id": 77
@@ -267,7 +243,10 @@
                         "x": -80,
                         "y": -271,
                         "z": 1642
-                    }
+                    },
+                    "result_commands": [
+                        {"type": "PlayCameraEvent", "Param1": 411, "Param2": 90}
+                    ]
                 },
                 {
                     "type": "PlayEvent",
@@ -300,6 +279,9 @@
                     },
                     "start_pos_no": 1,
                     "event_id": 5,
+                    "flags": [
+                        {"type": "MyQst", "action": "Set", "value": 799, "comment": "Ends Leo's FSM"}
+                    ],
                     "consume_items": [
                         {"id": 1051, "amount": 1}
                     ]
@@ -313,6 +295,14 @@
                         {"type": "QstLayout", "action": "Set", "value": 1024, "comment": "Spawns Iris"},
                         {"type": "QstLayout", "action": "Clear", "value": 1248, "comment": "Spawns Gerd"},
                         {"type": "QstLayout", "action": "Set", "value": 1249, "comment": "Spawns Gerd and Heinz in audience chamber"}
+                    ],
+                    "result_commands": [
+						{"type": "QstTalkChg", "Param1": 8, "Param2": 8340, "comment": "Heinz"},
+						{"type": "QstTalkChg", "Param1": 7, "Param2": 8341, "comment": "Gerd"},
+						{"type": "QstTalkChg", "Param1": 14, "Param2": 11703, "comment": "Mayleaf"},
+						{"type": "QstTalkChg", "Param1": 1003, "Param2": 11704, "comment": "Pamela"},
+						{"type": "QstTalkChg", "Param1": 3, "Param2": 8310, "comment": "Klaus"},
+						{"type": "QstTalkChg", "Param1": 4, "Param2": 16174, "comment": "Joseph"}
                     ],
                     "stage_id": {
                         "id": 3
@@ -333,71 +323,78 @@
             ]
         },
         {
-            "comment": "Process 1 (Marks Large Door)",
+            "comment": "Process 1 - Alchemy Research Door",
             "blocks": [
                 {
-                    "type": "MyQstFlags",
-                    "comment": "Wait for player to talk with Leo",
-                    "check_flags": [1]
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "StageNoNotEq", "Param1": 411}
+                    ]
                 },
                 {
                     "type": "Raw",
-                    "flags": [],
-                    "check_commands": [
-                        [
-                            {"type": "IsOpenDoorOmQuestSet", "Param1": 411, "Param2": 2, "Param3": 1, "Param4": 70003001}
-                        ],
-                        [
-                            {"type": "MyQstFlagOn", "Param1": 2}
-                        ]
-                    ],
-                    "result_commands": []
+                    "flags": [
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 1119, "quest_id": 70003001, "comment": "Alchemy Research Door Closed"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 1120, "quest_id": 70003001, "comment": "Alchemy Research Door Open"}
+                    ]
                 }
             ]
         },
         {
-            "comment": "Process 2 (Marks Small Door)",
+            "comment": "Process 2 - Large Door",
             "blocks": [
                 {
-                    "type": "MyQstFlags",
-                    "comment": "Wait for player to interact with the first door",
-                    "check_flags": [2]
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 1},
+                        {"type": "StageNoNotEq", "Param1": 411}
+                    ]
                 },
                 {
                     "type": "Raw",
-                    "flags": [],
-                    "check_commands": [
-                        [
-                            {"type": "IsOpenDoorOmQuestSet", "Param1": 411, "Param2": 5, "Param3": 2, "Param4": 70003001}
-                        ],
-                        [
-                            {"type": "MyQstFlagOn", "Param1": 3}
-                        ]
-                    ],
-                    "result_commands": []
+                    "flags": [
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 1104, "quest_id": 70003001, "comment": "Large Front Door Closed"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 1105, "quest_id": 70003001, "comment": "Large Front Door Open"}
+                    ]
                 }
             ]
         },
         {
-            "comment": "Process 3 (Marks Lever)",
+            "comment": "Process 3 - Leo extra dialogue",
             "blocks": [
                 {
-                    "type": "MyQstFlags",
-                    "comment": "Wait for player to pull Lever",
-                    "check_flags": [5]
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 116}
+                    ]
                 },
                 {
                     "type": "Raw",
-                    "flags": [],
-                    "check_commands": [
-                        [
-                            {"type": "IsOpenDoorOmQuestSet", "Param1": 411, "Param2": 1, "Param3": 1, "Param4": 70003001}
-                        ],
-                        [
-                            {"type": "MyQstFlagOn", "Param1": 6}
-                        ]
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 5, "Param2": 8316}
                     ],
-                    "result_commands": []
+                    "check_commands": [
+                        {"type": "NewTalkNpcWithoutMarker", "Param1": 5, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 5, "Param2": 8317}
+                    ],
+                    "check_commands": [
+                        {"type": "NewTalkNpcWithoutMarker", "Param1": 5, "Param2": 1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 5, "Param2": 8318}
+                    ],
+                    "check_commands": [
+                        {"type": "NewTalkNpcWithoutMarker", "Param1": 5, "Param2": 1}
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020040.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020040.json
@@ -17,9 +17,6 @@
             "Param1": 20030
         }
     ],
-    "contents_release": [
-        { "type": "BloodbaneIsleWorldQuests", "flag_info": "NpcFunctions.BloodbaneAreaInfo"}
-    ],
     "rewards": [
         {
             "type": "exp",
@@ -309,6 +306,12 @@
                     "result_commands": [
                         {"type": "CallGeneralAnnounce", "Param1": 1, "Param2": 696, "comment": "Area Master for Bloodbane Isle has been unlocked."},
                         {"type": "PlayMessage", "Param1": 18174, "Param2": 0, "comment": "Area Master for Bloodbane Isle has been unlocked. Talk to Bertrand at the Expedition Garrison."}
+                    ],
+                    "contents_release": [
+                        {
+                            "type": "BloodbaneIsleWorldQuests",
+                            "flag_info": "NpcFunctions.BloodbaneAreaInfo"
+                        }
                     ]
                 }
             ]

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020140.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020140.json
@@ -42,10 +42,12 @@
                 "id": 337,
                 "group_id": 1
             },
+            "starting_index": 1,
             "enemies": [
                 {
                     "comment": "Altered Zuhl",
                     "enemy_id": "0x020403",
+                    "named_enemy_params_id": 943,
                     "level": 66,
                     "exp": 217000,
                     "is_boss": true

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020160.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020160.json
@@ -156,12 +156,19 @@
                     ]
                 },
                 {
-                    "type": "IsStageNo",
+                    "type": "Raw",
                     "announce_type": "Update",
                     "checkpoint": true,
-                    "stage_id": {
-                        "id": 371
-                    }
+                    "check_commands": [
+                        {"type": "SceHitIn", "Param1": 121, "Param2": 0}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        [{"type": "StageNoWithoutMarker", "Param1": 120}],
+                        [{"type": "SceHitIn", "Param1": 120, "Param2": 1}, {"type": "DummyNotProgress"}]
+                    ]
                 },
                 {
                     "type": "DiscoverEnemy",

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020170.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020170.json
@@ -17,9 +17,6 @@
             "Param1": 20160
         }
     ],
-    "contents_release": [
-        { "type": "FaranaPlainsWorldQuests", "flag_info": "NpcFunctions.FaranaPlainsAreaInfo" }
-    ],
     "rewards": [
         {
             "type": "exp",
@@ -284,6 +281,18 @@
                     "checkpoint": true,
                     "npc_id": "Joseph",
                     "message_id": 15678
+                },
+                {
+                    "type": "IsStageNo",
+                    "stage_id": {
+                        "id": 3
+                    },
+                    "contents_release": [
+                        {
+                            "type": "FaranaPlainsWorldQuests",
+                            "flag_info": "NpcFunctions.FaranaPlainsAreaInfo"
+                        }
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020180.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020180.json
@@ -17,9 +17,6 @@
             "Param1": 20170
         }
     ],
-    "contents_release": [
-        { "type": "MorrowForestWorldQuests", "flag_info": "NpcFunctions.MorrowForestAreaInfo" }
-    ],
     "rewards": [
         {
             "type": "exp",
@@ -302,6 +299,18 @@
                     "checkpoint": true,
                     "npc_id": "Joseph",
                     "message_id": 15708
+                },
+                {
+                    "type": "IsStageNo",
+                    "stage_id": {
+                        "id": 3
+                    },
+                    "contents_release": [
+                        {
+                            "type": "MorrowForestWorldQuests",
+                            "flag_info": "NpcFunctions.MorrowForestAreaInfo"
+                        }
+                    ]
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020190.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020190.json
@@ -140,24 +140,14 @@
                 {
                     "type": "IsStageNo",
                     "announce_type": "Update",
-                    "show_marker": false,
                     "checkpoint": true,
                     "stage_id": {
                         "id": 376
                     },
                     "flags": [
-                        {
-                            "type": "MyQst",
-                            "action": "Set",
-                            "value": 1,
-                            "comment": "Spawns party gather to hack around door locked by area rank"
-                        }
-                    ],
-                    "contents_release": [
-                        {
-                            "type": "None",
-                            "flag_info": "KingalCanyon.ShadoleanGreatTemple"
-                        }
+                        {"type": "MyQst", "action": "Set", "value": 1704, "comment": "Unlocks Shadolean gate"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 6750, "quest_id": 70030001, "comment": "Shadolean - Main quest"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 6751, "quest_id": 70030001, "comment": "Shadolean - Post main quest"}
                     ]
                 },
                 {
@@ -261,94 +251,22 @@
                     "checkpoint": true,
                     "npc_id": "Joseph",
                     "message_id": 15722
-                }
-            ]
-        },
-        {
-            "comment": "Spawns gather point to teleport the player into the dungeon",
-            "blocks": [
-                {
-                    "type": "MyQstFlags",
-                    "check_flags": [
-                        1
-                    ]
                 },
-                {
-                    "type": "PartyGather",
-                    "stage_id": {
-                        "id": 373
-                    },
-                    "location": {
-                        "x": 54009,
-                        "y": 2241,
-                        "z": -75627
-                    }
-                },
-                {
-                    "type": "raw",
-                    "check_commands": [
-                        {
-                            "type": "StageNo",
-                            "Param1": 432
-                        }
-                    ],
-                    "result_commands": [
-                        {
-                            "type": "StageJump",
-                            "Param1": 432,
-                            "Param2": 0
-                        }
-                    ]
-                },
-                {
-                    "type": "raw",
-                    "check_commands": [
-                        {
-                            "type": "StageNoNotEq",
-                            "Param1": 432
-                        }
-                    ]
-                },
-                {
-                    "type": "ReturnCheckPoint",
-                    "process_no": 1,
-                    "block_no": 1
-                }
-            ]
-        },
-        {
-            "comment": "Forces player to correct stage. Flags are set currently to force player to StageNo 439 but the quest takes place on StageNo 432",
-            "blocks": [
                 {
                     "type": "IsStageNo",
-                    "show_marker": false,
                     "stage_id": {
-                        "id": 455
-                    }
-                },
-                {
-                    "type": "Raw",
-                    "check_commands": [
-                        {
-                            "type": "StageNo",
-                            "Param1": 432
-                        }
+                        "id": 3
+                    },
+                    "flags": [
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 6750, "quest_id": 70030001, "comment": "Shadolean - Main quest"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 6751, "quest_id": 70030001, "comment": "Shadolean - Post main quest"}
                     ],
-                    "result_commands": [
+                    "contents_release": [
                         {
-                            "type": "StageJump",
-                            "Param1": 432,
-                            "Param2": 0
+                            "type": "None",
+                            "flag_info": "KingalCanyon.ShadoleanGreatTemple"
                         }
                     ]
-                },
-                {
-                    "type": "ReturnCheckPoint",
-                    "stage_id": {
-                        "id": 376
-                    },
-                    "process_no": 2,
-                    "block_no": 1
                 }
             ]
         }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020190.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020190.json
@@ -17,9 +17,6 @@
             "Param1": 20180
         }
     ],
-    "contents_release": [
-        { "type": "KingalCanyonWorldQuests", "flag_info": "NpcFunctions.KingalCanyonAreaInfo" }
-    ],
     "rewards": [
         {
             "type": "exp",
@@ -88,14 +85,6 @@
                             "value": 3957,
                             "comment": "Cecily, Gurdolin, Lise and Elliot"
                         }
-                    ],
-                    "contents_release": [
-                        {
-                            "flag_info": "FaranaPlains.KingalCanyonBorderCheckpoint"
-                        },
-                        {
-                            "flag_info": "KingalCanyon.GlyndwrGates"
-                        }
                     ]
                 },
                 {
@@ -109,12 +98,27 @@
                     "message_id": 18528
                 },
                 {
-                    "type": "IsStageNo",
+                    "type": "Raw",
                     "announce_type": "Update",
                     "checkpoint": true,
-                    "stage_id": {
-                        "id": 373
-                    }
+                    "check_commands": [
+                        {"type": "SceHitIn", "Param1": 120, "Param2": 0}
+                    ],
+                    "contents_release": [
+                        {
+                            "flag_info": "FaranaPlains.KingalCanyonBorderCheckpoint"
+                        },
+                        {
+                            "flag_info": "KingalCanyon.GlyndwrGates"
+                        }
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        [{"type": "StageNoWithoutMarker", "Param1": 122}],
+                        [{"type": "IsReleaseWarpPointAnyone", "Param1": 20}, {"type": "DummyNotProgress"}]
+                    ]
                 },
                 {
                     "type": "Raw",
@@ -265,6 +269,10 @@
                         {
                             "type": "None",
                             "flag_info": "KingalCanyon.ShadoleanGreatTemple"
+                        },
+                        {
+                            "type": "KingalCanyonWorldQuests",
+                            "flag_info": "NpcFunctions.KingalCanyonAreaInfo"
                         }
                     ]
                 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q00020210.json
@@ -247,6 +247,12 @@
                         "id": 371
                     },
                     "event_id": 35,
+                    "flags": [
+                        {"type": "WorldManageLayout", "action": "Set", "value": 4372, "quest_id": 70023001, "comment": "Stage 880 warp - Vegasa"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 4373, "quest_id": 70023001, "comment": "Stage 881 warp - Vegasa"},
+                        {"type": "WorldManageLayout", "action": "Set", "value": 4507, "quest_id": 70023001, "comment": "Stage 880 warp - Gathering Area"},
+                        {"type": "WorldManageLayout", "action": "Clear", "value": 4508, "quest_id": 70023001, "comment": "Stage 881 warp - Gathering Area"}
+                    ],
                     "contents_release": [
                         {"flag_info": "FaranaPlains.VegasaCorridorSouth"},
                         {"flag_info": "MorrowForest.VegasaCorridorWest"},
@@ -287,6 +293,9 @@
                 {
                     "type": "DiscoverEnemy",
                     "announce_type": "Update",
+                    "flags": [
+                        {"type": "WorldManageQuest", "action": "Set", "value": 2564, "quest_id": 70023001, "comment": "Unlocks Hollow of Gatherings"}
+                    ],
                     "checkpoint": true,
                     "groups": [ 3 ]
                 },
@@ -376,36 +385,6 @@
                     "message_id": 15844
                 }
             ]
-        },
-        {
-            "comment": "Forces player to correct stage. Flags are set currently to force player to StageNo 881 but the quest takes place on StageNo 880",
-            "blocks": [
-                {
-                    "type": "IsStageNo",
-                    "show_marker": false,
-                    "stage_id": {
-                        "id": 383
-                    }
-                },
-                {
-                    "type": "Raw",
-                    "check_commands": [
-                        {"type": "StageNo", "Param1": 880}
-                    ],
-                    "result_commands": [
-                        {"type": "StageJump", "Param1": 880, "Param2": 0}
-                    ]
-                },
-                {
-                    "type": "ReturnCheckPoint",
-                    "stage_id": {
-                        "id": 382
-                    },
-                    "process_no": 1,
-                    "block_no": 1
-                }
-            ]
         }
-
     ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016.json
@@ -228,7 +228,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 11},
+                        {"type": "CheckAreaRank", "Param1": 14, "Param2": 11},
                         {"type": "StageNo", "Param1": 121}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014016_1.json
@@ -229,7 +229,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 11},
+                        {"type": "CheckAreaRank", "Param1": 14, "Param2": 11},
                         {"type": "StageNo", "Param1": 121}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018.json
@@ -176,7 +176,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 14},
+                        {"type": "CheckAreaRank", "Param1": 14, "Param2": 14},
                         {"type": "StageNo", "Param1": 121}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014018_1.json
@@ -177,7 +177,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 14},
+                        {"type": "CheckAreaRank", "Param1": 14, "Param2": 14},
                         {"type": "StageNo", "Param1": 121}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019.json
@@ -176,7 +176,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 13},
+                        {"type": "CheckAreaRank", "Param1": 14, "Param2": 13},
                         {"type": "StageNo", "Param1": 121}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21014019_1.json
@@ -177,7 +177,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 14, "Param1": 13},
+                        {"type": "CheckAreaRank", "Param1": 14, "Param2": 13},
                         {"type": "StageNo", "Param1": 121}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016.json
@@ -205,7 +205,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 11},
+                        {"type": "CheckAreaRank", "Param1": 15, "Param2": 11},
                         {"type": "StageNo", "Param1": 120}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015016_1.json
@@ -205,7 +205,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 11},
+                        {"type": "CheckAreaRank", "Param1": 15, "Param2": 11},
                         {"type": "StageNo", "Param1": 120}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018.json
@@ -312,7 +312,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 13},
+                        {"type": "CheckAreaRank", "Param1": 15, "Param2": 13},
                         {"type": "StageNo", "Param1": 120}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015018_1.json
@@ -313,7 +313,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 13},
+                        {"type": "CheckAreaRank", "Param1": 15, "Param2": 13},
                         {"type": "StageNo", "Param1": 120}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019.json
@@ -166,7 +166,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 12},
+                        {"type": "CheckAreaRank", "Param1": 15, "Param2": 12},
                         {"type": "StageNo", "Param1": 120}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21015019_1.json
@@ -167,7 +167,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 15, "Param1": 12},
+                        {"type": "CheckAreaRank", "Param1": 15, "Param2": 12},
                         {"type": "StageNo", "Param1": 120}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019.json
@@ -186,7 +186,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 17, "Param1": 13},
+                        {"type": "CheckAreaRank", "Param1": 17, "Param2": 13},
                         {"type": "StageNo", "Param1": 122}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019_1.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q21017019_1.json
@@ -187,7 +187,7 @@
                 {
                     "type": "Raw",
                     "check_commands": [
-                        {"type": "CheckAreaRank", "Param1": 17, "Param1": 13},
+                        {"type": "CheckAreaRank", "Param1": 17, "Param2": 13},
                         {"type": "StageNo", "Param1": 122}
                     ]
                 },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018001.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018001.json
@@ -1,18 +1,18 @@
 {
   "state_machine": "GenericStateMachine",
   "type": "World",
-  "comment": "Investing for Independence",
-  "quest_id": 22018018,
-  "base_level": 85,
+  "comment": "The Fiends' Early Harvest",
+  "quest_id": 22018001,
+  "base_level": 80,
   "minimum_item_rank": 0,
   "discoverable": true,
-  "area_id": "FeryanaWilderness",
+  "area_id": "RathniteFoothills",
   "news_image": 902,
   "rewards": [
     {
       "type": "wallet",
       "wallet_type": "Gold",
-      "amount": 11000
+      "amount": 10227
     },
     {
       "type": "wallet",
@@ -47,76 +47,59 @@
           "num": 3
         }
       ]
-    },
-    {
-      "type": "random",
-      "loot_pool": [
-        {
-          "comment": "Superior Strong Gala Extract",
-          "item_id": 9364,
-          "num": 1,
-          "chance": 0.6
-        },
-        {
-          "comment": "Blazing Ore",
-          "item_id": 18142,
-          "num": 2,
-          "chance": 0.6
-        }
-      ]
     }
   ],
   "enemy_groups": [
     {
-      "comment": "GroupId: 24 - Skeleton Mages, Sludgemen, Bounty Mole Troll",
+      "comment": "GroupId: 32 - Bounty Cragger, Sirens",
       "stage_id": {
-        "id": 463,
-        "group_id": 24
+        "id": 461,
+        "group_id": 32
       },
       "starting_index": 4,
       "enemies": [
         {
-          "comment": "Sludgeman",
-          "enemy_id": "0x010510",
-          "level": 85,
-          "exp": 4200
-        },
-        {
-          "comment": "Sludgeman",
-          "enemy_id": "0x010510",
-          "level": 85,
-          "exp": 4200
-        },
-        {
-          "comment": "Mole Troll",
-          "enemy_id": "0x015041",
+          "comment": "Cragger",
+          "enemy_id": "0x015508",
           "named_enemy_params_id": 2112,
-          "level": 85,
+          "level": 80,
           "exp": 294000,
           "is_boss": true
         },
         {
-          "comment": "Skeleton Mage",
-          "enemy_id": "0x010308",
-          "level": 85,
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
           "exp": 4200
         },
         {
-          "comment": "Skeleton Mage",
-          "enemy_id": "0x010308",
-          "level": 85,
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
           "exp": 4200
         },
         {
-          "comment": "Skeleton Mage",
-          "enemy_id": "0x010308",
-          "level": 85,
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
           "exp": 4200
         },
         {
-          "comment": "Skeleton Mage",
-          "enemy_id": "0x010308",
-          "level": 85,
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
+          "exp": 4200
+        },
+        {
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
+          "exp": 4200
+        },
+        {
+          "comment": "Siren",
+          "enemy_id": "0x010605",
+          "level": 80,
           "exp": 4200
         }
       ]
@@ -126,17 +109,17 @@
     {
       "type": "NpcTalkAndOrder",
       "stage_id": {
-        "id": 520
+        "id": 511
       },
-      "npc_id": "Artin",
-      "message_id": 23594
+      "npc_id": "Bruno",
+      "message_id": 23459
     },
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
       "groups": [0],
       "result_commands": [
-        {"type": "QstTalkChg", "Param1": 3055, "Param2": 23595, "comment": "Extra dialogue - Artin"}
+        {"type": "QstTalkChg", "Param1": 2801, "Param2": 23460, "comment": "Extra dialogue - Bruno"}
       ]
     },
     {
@@ -148,11 +131,11 @@
     {
       "type": "TalkToNpc",
       "stage_id": {
-        "id": 520
+        "id": 511
       },
       "announce_type": "CheckpointAndUpdate",
-      "npc_id": "Artin",
-      "message_id": 23596
+      "npc_id": "Bruno",
+      "message_id": 23461
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018007.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018007.json
@@ -1,0 +1,148 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Time Restriction: Evening Harvest",
+    "quest_id": 22018007,
+    "base_level": 80,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "RathniteFoothills",
+    "order_conditions": [{"type": "AreaRank", "Param1": 18, "Param2": 7}, {"type": "MainQuestCompleted", "Param1": 30040}],
+    "news_image": 330,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 12846
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 750
+        },
+        {
+            "type": "exp",
+            "amount": 8400
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "RoyalCrestMedalRathniteDistrict",
+                    "num": 5
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 10
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 10
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [{"type": "IsMainQuestClear", "Param1": 30040}]
+                },
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 467
+                    },
+                    "npc_id": "Endale",
+                    "message_id": 23520
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 443},
+                        {"type": "IngameTimeRangeNotEq", "Param1": 4, "Param2": 18}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2800, "Param2": 23521}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "CheckpointAndUpdate",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 443, "Param2": 2800},
+                        {"type": "IngameTimeRangeNotEq", "Param1": 4, "Param2": 18}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 2800, "Param2": 23522}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "CheckpointAndUpdate",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 2800, "Param2": 23523}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 17885, "Param2": 5, "comment": "Blaze Grass"}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "CheckpointAndUpdate",
+                    "stage_id": {
+                        "id": 467
+                    },
+                    "npc_id": "Endale",
+                    "items": [
+                        {"id": 17885, "amount": 5, "comment": "Blaze Grass"}
+                    ],
+                    "message_id": 23524
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "IngameTimeRangeNotEq", "Param1": 4, "Param2": 18},
+                        {"type": "StageNoWithoutMarker", "Param1": 130}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 5544},
+                        {"type": "QstLayoutFlagOn", "Param1": 6178},
+                        {"type": "QstLayoutFlagOn", "Param1": 6179},
+                        {"type": "QstLayoutFlagOn", "Param1": 6524},
+                        {"type": "QstLayoutFlagOn", "Param1": 6182},
+                        {"type": "PlayMessage", "Param1": 25030, "Param2": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "IngameTimeRangeEq", "Param1": 4, "Param2": 18}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 5544},
+                        {"type": "QstLayoutFlagOff", "Param1": 6178},
+                        {"type": "QstLayoutFlagOff", "Param1": 6179},
+                        {"type": "QstLayoutFlagOff", "Param1": 6524},
+                        {"type": "QstLayoutFlagOff", "Param1": 6182},
+                        {"type": "PlayMessage", "Param1": 25031, "Param2": 0}
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018019.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018019.json
@@ -1,0 +1,101 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Happy Days Once Again",
+  "quest_id": 22018019,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "FeryanaWilderness",
+  "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30130}],
+  "news_image": 333,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 13750
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 8400
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Feryana District)",
+          "item_id": 18819,
+          "num": 5
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 10
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 10
+        }
+      ]
+    },
+    {
+      "type": "random",
+      "loot_pool": [
+        {
+          "comment": "Blazing Lizard Pelt",
+          "item_id": 21262,
+          "num": 1,
+          "chance": 0.6
+        },
+        {
+          "comment": "Crest of Shock Immunity",
+          "item_id": 9322,
+          "num": 1,
+          "chance": 0.6
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [{"type": "IsMainQuestClear", "Param1": 30130}]
+    },
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 463
+      },
+      "npc_id": "Khalil",
+      "message_id": 23606
+    },
+    {
+      "type": "DeliverItems",
+      "announce_type": "Accept",
+      "stage_id": {
+        "id": 478
+      },
+      "npc_id": "Josephine",
+      "items": [
+        {"id": 18821, "amount": 9, "comment": "Unappraised Flight Trinket (Soldier)"}
+      ],
+      "message_id": 23609,
+      "result_commands": [
+        {"type": "QstLayoutFlagOn", "Param1": 7311, "comment": "Does something?"},
+        {"type": "QstTalkChg", "Param1": 3054, "Param2": 23607, "comment": "Extra dialogue - Khalil"},
+        {"type": "QstTalkChg", "Param1": 2957, "Param2": 23608, "comment": "Extra dialogue - Josephine"}
+      ]
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018022.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018022.json
@@ -1,0 +1,146 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Time Restriction: Gathering Under Clear Skies",
+    "quest_id": 22018022,
+    "base_level": 88,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "FeryanaWilderness",
+    "order_conditions": [{"type": "ClearPersonalQuest", "Param1": 60319001}, {"type": "AreaRank", "Param1": 19, "Param2": 7}],
+    "news_image": 335,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5500
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "RoyalCrestMedalFeryanaDistrict",
+                    "num": 5
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 10
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 10
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [{"type": "IsMainQuestClear", "Param1": 30130}]
+                },
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 478
+                    },
+                    "npc_id": "Nayajiku",
+                    "message_id": 23530
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 451},
+                        {"type": "WeatherEq", "Param1": 1}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 3050, "Param2": 23531}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "CheckpointAndUpdate",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 451, "Param2": 3050},
+                        {"type": "WeatherEq", "Param1": 1}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 3050, "Param2": 23532}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "CheckpointAndUpdate",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 2821},
+                        {"type": "QstTalkChg", "Param1": 3050, "Param2": 23533}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 18142, "Param2": 5, "comment": "Blazing Ore"}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "CheckpointAndUpdate",
+                    "stage_id": {
+                        "id": 478
+                    },
+                    "npc_id": "Nayajiku",
+                    "items": [
+                        {"id": 18142, "amount": 5, "comment": "Blazing Ore"}
+                    ],
+                    "message_id": 23534
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [2821]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "WeatherEq", "Param1": 1},
+                        {"type": "StageNoWithoutMarker", "Param1": 132}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 6186},
+                        {"type": "QstLayoutFlagOn", "Param1": 6187},
+                        {"type": "QstLayoutFlagOn", "Param1": 6188},
+                        {"type": "QstLayoutFlagOn", "Param1": 6189},
+                        {"type": "PlayMessage", "Param1": 25306, "Param2": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "WeatherNotEq", "Param1": 1}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 6186},
+                        {"type": "QstLayoutFlagOff", "Param1": 6187},
+                        {"type": "QstLayoutFlagOff", "Param1": 6188},
+                        {"type": "QstLayoutFlagOff", "Param1": 6189},
+                        {"type": "PlayMessage", "Param1": 25307, "Param2": 0}
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018024.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018024.json
@@ -1,0 +1,171 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Eyes That Speak of a Deep Bond",
+  "quest_id": 22018024,
+  "base_level": 85,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "FeryanaWilderness",
+  "order_conditions": [{"type": "AreaRank", "Param1": 19, "Param2": 2}],
+  "news_image": 676,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 5500
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 25200
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Royal Crest Medal (Feryana District)",
+          "item_id": 18819,
+          "num": 5
+        },
+        {
+          "comment": "Cursed Letter",
+          "item_id": 17878,
+          "num": 1
+        },
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 10
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "comment": "GroupId: 4 - Empty",
+      "stage_id": {
+        "id": 499,
+        "group_id": 4
+      },
+      "starting_index": 8,
+      "enemies": []
+    },
+    {
+      "comment": "GroupId: 4 - Witch, Eliminator and Acid Blobs",
+      "stage_id": {
+        "id": 499,
+        "group_id": 4
+      },
+      "starting_index": 8,
+      "enemies": [
+        {
+          "comment": "Witch",
+          "enemy_id": "0x015604",
+          "level": 85,
+          "exp": 21000
+        },
+        {
+          "comment": "Acid Blob",
+          "enemy_id": "0x010911",
+          "level": 85,
+          "exp": 4200
+        },
+        {
+          "comment": "Acid Blob",
+          "enemy_id": "0x010911",
+          "level": 85,
+          "exp": 4200
+        },
+        {
+          "comment": "Acid Blob",
+          "enemy_id": "0x010911",
+          "level": 85,
+          "exp": 4200
+        },
+        {
+          "comment": "Eliminator",
+          "enemy_id": "0x010508",
+          "level": 85,
+          "exp": 4200
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 520
+      },
+      "npc_id": "Shekel",
+      "message_id": 23555
+    },
+    {
+      "type": "SpawnGroup",
+      "announce_type": "Accept",
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3053, "Param2": 23556, "comment": "Extra dialogue - Shekel"}
+      ],
+      "check_commands": [
+        {"type": "StageNo", "Param1": 1093}
+      ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "stage_id": {
+        "id": 499,
+        "group_id": 0,
+        "layer_no": 0
+      },
+      "npc_id": "Dudley",
+      "message_id": 24221,
+      "result_commands": [
+        {"type": "QstLayoutFlagOn", "Param1": 5480, "comment": "Spawns Dudley NPC"}
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "groups": [1],
+      "result_commands": [
+        {"type": "PlayMessage", "Param1": 23623, "Param2": 0},
+        {"type": "MyQstFlagOn", "Param1": 2870, "comment": "Dudley FSM"}
+      ]
+    },
+    {
+      "type": "NewTalkToNpc",
+      "announce_type": "Update",
+      "stage_id": {
+        "id": 499,
+        "group_id": 2,
+        "layer_no": 0
+      },
+      "npc_id": "Dudley",
+      "message_id": 23557,
+      "result_commands": [
+        {"type": "QstLayoutFlagOff", "Param1": 5480, "comment": "Clears Dudley NPC"},
+        {"type": "QstLayoutFlagOn", "Param1": 5483, "comment": "Spawns Dudley (Alive) NPC"}
+      ]
+    },
+    {
+      "type": "TalkToNpc",
+      "announce_type": "CheckpointAndUpdate",
+      "stage_id": {
+        "id": 520
+      },
+      "npc_id": "Shekel",
+      "message_id": 23553
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018034.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018034.json
@@ -68,111 +68,100 @@
   ],
   "enemy_groups": [
     {
-      "comment": "GroupId: 33 - Ghost Mail, Dark Corpse Torturers, Grudge Ghosts",
+      "comment": "GroupId: 31 - Ghost Mail, Dark Corpse Torturers, Grudge Ghosts",
       "stage_id": {
         "id": 464,
         "group_id": 31
       },
+      "starting_index": 11,
       "enemies": [
         {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Dark Corpse Torturer",
+          "enemy_id": "0x010520",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Dark Corpse Torturer",
+          "enemy_id": "0x010520",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ghost Mail",
           "enemy_id": "0x010311",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ghost Mail"
-        },
-        {
-          "enemy_id": "0x010520",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Dark Corpse Torturer"
-        },
-        {
-          "enemy_id": "0x010520",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Dark Corpse Torturer"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
+          "exp": 4200
         }
       ]
     },
     {
-      "comment": "GroupId: 34 - Dark Skeleton Brute, Dark Corpse Punishers, Grudge Ghosts",
+      "comment": "GroupId: 33 - Dark Skeleton Brute, Dark Corpse Punishers, Grudge Ghosts",
       "stage_id": {
         "id": 464,
         "group_id": 33
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Dark Skeleton Brute",
           "enemy_id": "0x010324",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Dark Skeleton Brute"
+          "exp": 4200
         },
         {
+          "comment": "Dark Corpse Punisher",
           "enemy_id": "0x010516",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Dark Corpse Punisher"
+          "exp": 4200
         },
         {
+          "comment": "Dark Corpse Punisher",
           "enemy_id": "0x010516",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Dark Corpse Punisher"
+          "exp": 4200
         },
         {
+          "comment": "Grudge Ghost",
           "enemy_id": "0x015622",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
+          "exp": 4200
         }
       ]
     },
@@ -182,53 +171,59 @@
         "id": 464,
         "group_id": 36
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "Skeleton Cyclops",
           "enemy_id": "0x015050",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Skeleton Cyclops"
+          "exp": 21000,
+          "is_boss": true,
+          "index": 4
         },
         {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200,
+          "index": 5
+        },
+        {
+          "comment": "Grudge Ghost",
+          "enemy_id": "0x015622",
+          "level": 90,
+          "exp": 4200,
+          "index": 6
+        },
+        {
+          "comment": "Skeleton Warg",
           "enemy_id": "0x010221",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Skeleton Warg"
+          "exp": 4200,
+          "index": 7
         },
         {
+          "comment": "Skeleton Warg",
           "enemy_id": "0x010221",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Skeleton Warg"
+          "exp": 4200,
+          "index": 8
         },
         {
+          "comment": "Grudge Ghost",
           "enemy_id": "0x015622",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
-        },
-        {
-          "enemy_id": "0x015622",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grudge Ghost"
+          "exp": 4200,
+          "index": 13
         }
       ]
     }
   ],
   "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [{"type": "IsMainQuestClear", "Param1": 30140}]
+    },
     {
       "type": "NpcTalkAndOrder",
       "stage_id": {
@@ -240,7 +235,10 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [0]
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3202, "Param2": 27837, "comment": "Extra dialogue - Umit"}
+      ]
     },
     {
       "type": "KillGroup",
@@ -275,7 +273,7 @@
       "stage_id": {
         "id": 584
       },
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "npc_id": "Umit",
       "message_id": 27838
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018035.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018035.json
@@ -62,50 +62,44 @@
           "enemy_id": "0x015870",
           "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 147000,
+          "exp": 294000,
           "is_boss": true
         },
         {
           "comment": "Ancestor Orc - Fighter",
           "enemy_id": "0x015831",
-          "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 29400
+          "exp": 4200
         },
         {
           "comment": "Ancestor Orc - Fighter",
           "enemy_id": "0x015831",
-          "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 29400
+          "exp": 4200
         },
         {
           "comment": "Ancestor Orc - Fighter",
           "enemy_id": "0x015831",
-          "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 29400
+          "exp": 4200
         },
         {
           "comment": "Ancestor Orc - Blunt",
           "enemy_id": "0x015832",
-          "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 29400
+          "exp": 4200
         },
         {
           "comment": "Ancestor Orc - Blunt",
           "enemy_id": "0x015832",
-          "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 29400
+          "exp": 4200
         },
         {
           "comment": "Ancestor Orc - Blunt",
           "enemy_id": "0x015832",
-          "named_enemy_params_id": 2112,
           "level": 90,
-          "exp": 29400
+          "exp": 4200
         }
       ]
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018035.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018035.json
@@ -1,0 +1,150 @@
+{
+  "state_machine": "GenericStateMachine",
+  "type": "World",
+  "comment": "Indomitable Proof",
+  "quest_id": 22018035,
+  "base_level": 90,
+  "minimum_item_rank": 0,
+  "discoverable": true,
+  "area_id": "MegadosysPlateau",
+  "news_image": 902,
+  "rewards": [
+    {
+      "type": "wallet",
+      "wallet_type": "Gold",
+      "amount": 11000
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "RiftPoints",
+      "amount": 300
+    },
+    {
+      "type": "wallet",
+      "wallet_type": "AreaPoints",
+      "amount": 500
+    },
+    {
+      "type": "exp",
+      "amount": 56000
+    },
+    {
+      "type": "select",
+      "loot_pool": [
+        {
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 3
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 3
+        },
+        {
+          "comment": "Panacea",
+          "item_id": 41,
+          "num": 3
+        }
+      ]
+    }
+  ],
+  "enemy_groups": [
+    {
+      "stage_id": {
+        "id": 589,
+        "group_id": 4
+      },
+      "starting_index": 6,
+      "enemies": [
+        {
+          "comment": "Progenitor",
+          "enemy_id": "0x015870",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 147000,
+          "is_boss": true
+        },
+        {
+          "comment": "Ancestor Orc - Fighter",
+          "enemy_id": "0x015831",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 29400
+        },
+        {
+          "comment": "Ancestor Orc - Fighter",
+          "enemy_id": "0x015831",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 29400
+        },
+        {
+          "comment": "Ancestor Orc - Fighter",
+          "enemy_id": "0x015831",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 29400
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 29400
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 29400
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "named_enemy_params_id": 2112,
+          "level": 90,
+          "exp": 29400
+        }
+      ]
+    }
+  ],
+  "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [{"type": "IsMainQuestClear", "Param1": 30140}]
+    },
+    {
+      "type": "NpcTalkAndOrder",
+      "stage_id": {
+        "id": 584
+      },
+      "npc_id": "Lucas",
+      "message_id": 27924
+    },
+    {
+      "type": "DiscoverEnemy",
+      "announce_type": "Accept",
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3201, "Param2": 27925, "comment": "Extra dialogue - Lucas"}
+      ]
+    },
+    {
+      "type": "KillGroup",
+      "announce_type": "Update",
+      "reset_group": false,
+      "groups": [0]
+    },
+    {
+      "type": "TalkToNpc",
+      "stage_id": {
+        "id": 584
+      },
+      "announce_type": "CheckpointAndUpdate",
+      "npc_id": "Lucas",
+      "message_id": 27926
+    }
+  ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018036.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018036.json
@@ -74,67 +74,65 @@
         "id": 597,
         "group_id": 1
       },
+      "starting_index": 8,
       "enemies": [
         {
-          "enemy_id": "0x015831",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ancestor Orc"
-        },
-        {
-          "enemy_id": "0x015831",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ancestor Orc"
-        },
-        {
-          "enemy_id": "0x015831",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ancestor Orc"
-        },
-        {
-          "enemy_id": "0x015831",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ancestor Orc"
-        },
-        {
-          "enemy_id": "0x015831",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ancestor Orc"
-        },
-        {
-          "enemy_id": "0x015831",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Ancestor Orc"
-        },
-        {
-          "enemy_id": "0x015839",
-          "level": 90,
-          "exp": 44000,
-          "is_boss": false,
-          "comment": "Captain Ancestor Orc"
-        },
-        {
+          "comment": "Cragger",
           "enemy_id": "0x015508",
           "level": 90,
-          "exp": 44000,
-          "is_boss": true,
-          "comment": "Cragger"
+          "exp": 21000,
+          "is_boss": true
+        },
+        {
+          "comment": "Captain Ancestor Orc",
+          "enemy_id": "0x015839",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Ancestor Orc - Blunt",
+          "enemy_id": "0x015832",
+          "level": 90,
+          "exp": 4200
         }
       ]
     }
   ],
   "blocks": [
+    {
+      "type": "Raw",
+      "check_commands": [{"type": "IsMainQuestClear", "Param1": 30140}]
+    },
     {
       "type": "NpcTalkAndOrder",
       "stage_id": {
@@ -145,24 +143,26 @@
     },
     {
       "type": "DeliverItems",
+      "announce_type": "Accept",
       "stage_id": {
         "id": 584
       },
       "npc_id": "Umit",
-      "announce_type": "Accept",
       "items": [
-        {
-          "id": 21214,
-          "amount": 5,
-          "comment": "Rose Megadosys"
-        }
-    ],
-      "message_id": 27929
+        {"id": 21214, "amount": 5, "comment": "Rose Megadosys"}
+      ],
+      "message_id": 27930,
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3202, "Param2": 27929, "comment": "Extra dialogue - Umit"}
+      ]
     },
     {
       "type": "DiscoverEnemy",
-      "announce_type": "Update",
-      "groups": [0]
+      "announce_type": "CheckpointAndUpdate",
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3202, "Param2": 27931, "comment": "Extra dialogue - Umit"}
+      ]
     },
     {
       "type": "KillGroup",
@@ -175,9 +175,9 @@
       "stage_id": {
         "id": 584
       },
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "npc_id": "Umit",
-      "message_id": 27931
+      "message_id": 27932
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018037.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018037.json
@@ -74,48 +74,44 @@
         "id": 504,
         "group_id": 1
       },
+      "starting_index": 2,
       "enemies": [
         {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010323",
+          "level": 93,
+          "exp": 4200
+        },
+        {
+          "comment": "Bolt Skeleton Brute",
+          "enemy_id": "0x010323",
+          "level": 93,
+          "exp": 4200
+        },
+        {
+          "comment": "Misery Ghost",
+          "enemy_id": "0x015621",
+          "level": 93,
+          "exp": 4200
+        },
+        {
+          "comment": "Misery Ghost",
+          "enemy_id": "0x015621",
+          "level": 93,
+          "exp": 4200
+        },
+        {
+          "comment": "Medusa",
           "enemy_id": "0x015610",
           "level": 93,
-          "exp": 44000,
-          "is_boss": true,
-          "comment": "Medusa"
+          "exp": 21000,
+          "is_boss": true
         },
         {
-          "enemy_id": "0x010323",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Bolt Skeleton Brute"
-        },
-        {
-          "enemy_id": "0x010323",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Bolt Skeleton Brute"
-        },
-        {
+          "comment": "Misery Ghost",
           "enemy_id": "0x015621",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Misery Ghost"
-        },
-        {
-          "enemy_id": "0x015621",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Misery Ghost"
-        },
-        {
-          "enemy_id": "0x015621",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Misery Ghost"
+          "exp": 4200
         }
       ]
     }
@@ -136,7 +132,10 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [0]
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3201, "Param2": 27935, "comment": "Extra dialogue - Lucas"}
+      ]
     },
     {
       "type": "KillGroup",
@@ -149,9 +148,9 @@
       "stage_id": {
         "id": 584
       },
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "npc_id": "Lucas",
-      "message_id": 27937
+      "message_id": 27936
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018038.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018038.json
@@ -69,132 +69,120 @@
   ],
   "enemy_groups": [
     {
-      "comment": "GroupId: 13 - Sword Soldier Dwarf Orcs, War Ready Saurians (Light), War Ready Grimwargs (Light)",
+      "comment": "GroupId: 13 - Axe Soldier Dwarf Orcs, War Ready Saurians (Light), War Ready Grimwargs (Light)",
       "stage_id": {
         "id": 464,
         "group_id": 13
       },
+      "placement_type": "manual",
       "enemies": [
         {
+          "comment": "War Ready Saurian (Light)",
+          "enemy_id": "0x010470",
+          "level": 93,
+          "exp": 4200,
+          "index": 3
+        },
+        {
+          "comment": "War Ready Saurian (Light)",
+          "enemy_id": "0x010470",
+          "level": 93,
+          "exp": 4200,
+          "index": 4
+        },
+        {
+          "comment": "War Ready Saurian (Light)",
+          "enemy_id": "0x010470",
+          "level": 93,
+          "exp": 4200,
+          "index": 5
+        },
+        {
+          "comment": "Axe Soldier Dwarf Orc",
           "enemy_id": "0x015821",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Sword Soldier Dwarf Orc"
+          "exp": 4200,
+          "index": 6
         },
         {
+          "comment": "War Ready Saurian (Light)",
+          "enemy_id": "0x010470",
+          "level": 93,
+          "exp": 4200,
+          "index": 10
+        },
+        {
+          "comment": "Axe Soldier Dwarf Orc",
           "enemy_id": "0x015821",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Sword Soldier Dwarf Orc"
+          "exp": 4200,
+          "index": 11
         },
         {
-          "enemy_id": "0x010470",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Saurian (Light)"
-        },
-        {
-          "enemy_id": "0x010470",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Saurian (Light)"
-        },
-        {
-          "enemy_id": "0x010470",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Saurian (Light)"
-        },
-        {
-          "enemy_id": "0x010470",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Saurian (Light)"
-        },
-        {
+          "comment": "War Ready Grimwarg (Light)",
           "enemy_id": "0x010230",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Grimwarg (Light)"
-        },
-        {
-          "enemy_id": "0x010230",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Grimwarg (Light)"
-        },
-        {
-          "enemy_id": "0x010230",
-          "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Grimwarg (Light)"
+          "exp": 4200,
+          "index": 12
         }
       ]
     },
     {
-      "comment": "GroupId: 55 - Sword Soldier Dwarf Orcs, War Ready Saurians (Light), War Ready Giant Saurians",
+      "comment": "GroupId: 55 - Blunt Soldier Dwarf Orcs, War Ready Saurians (Light), War Ready Giant Saurians",
       "stage_id": {
         "id": 464,
         "group_id": 55
       },
+      "placement_type": "manual",
       "enemies": [
         {
-          "enemy_id": "0x015821",
+          "comment": "Blunt Soldier Dwarf Orc",
+          "enemy_id": "0x015822",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Sword Soldier Dwarf Orc"
+          "exp": 4200,
+          "index": 4
         },
         {
-          "enemy_id": "0x015821",
+          "comment": "Blunt Soldier Dwarf Orc",
+          "enemy_id": "0x015822",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Sword Soldier Dwarf Orc"
+          "exp": 4200,
+          "index": 5
         },
         {
+          "comment": "War Ready Saurian (Light)",
           "enemy_id": "0x010470",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Saurian (Light)"
+          "exp": 4200,
+          "index": 6
         },
         {
+          "comment": "War Ready Saurian (Light)",
           "enemy_id": "0x010470",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Saurian (Light)"
+          "exp": 4200,
+          "index": 6
         },
         {
+          "comment": "War Ready Giant Saurian",
           "enemy_id": "0x010471",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Giant Saurian"
+          "exp": 4200,
+          "index": 12
         },
         {
+          "comment": "War Ready Giant Saurian",
           "enemy_id": "0x010471",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Giant Saurian"
+          "exp": 4200,
+          "index": 13
         },
         {
+          "comment": "War Ready Giant Saurian",
           "enemy_id": "0x010471",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Giant Saurian"
+          "exp": 4200,
+          "index": 14
         }
       ]
     },
@@ -204,34 +192,32 @@
         "id": 590,
         "group_id": 4
       },
+      "starting_index": 5,
       "enemies": [
         {
+          "comment": "War-Ready Goremanticore (Light)",
           "enemy_id": "0x015220",
           "level": 93,
-          "exp": 44000,
-          "is_boss": true,
-          "comment": "War-Ready Goremanticore (Light)"
+          "exp": 21000,
+          "is_boss": true
         },
         {
+          "comment": "War Ready Grimwarg (Light)",
           "enemy_id": "0x010230",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Grimwarg (Light)"
+          "exp": 4200
         },
         {
+          "comment": "War Ready Grimwarg (Light)",
           "enemy_id": "0x010230",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Grimwarg (Light)"
+          "exp": 4200
         },
         {
+          "comment": "War Ready Grimwarg (Light)",
           "enemy_id": "0x010230",
           "level": 93,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "War Ready Grimwarg (Light)"
+          "exp": 4200
         }
       ]
     }
@@ -252,7 +238,10 @@
     {
       "type": "DiscoverEnemy",
       "announce_type": "Accept",
-      "groups": [0]
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 4513, "Param2": 27940, "comment": "Extra dialogue - Kirsty"}
+      ]
     },
     {
       "type": "KillGroup",
@@ -287,7 +276,7 @@
       "stage_id": {
         "id": 464
       },
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "npc_id": "Kirsty0",
       "message_id": 27941
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018039.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018039.json
@@ -52,60 +52,57 @@
   ],
   "enemy_groups": [
     {
+      "comment": "GroupId: 16 - Empty",
+      "stage_id": {
+        "id": 597,
+        "group_id": 16
+      },
+      "starting_index": 4,
+      "enemies": []
+    },
+    {
       "comment": "GroupId: 16 - Witch, Harpies, Giant Geo Saurians",
       "stage_id": {
         "id": 597,
         "group_id": 16
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Witch",
           "enemy_id": "0x015604",
           "level": 90,
-          "exp": 44000,
-          "is_boss": false,
-          "comment": "Witch"
+          "exp": 21000
         },
         {
-          "enemy_id": "0x010600",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Harpy"
-        },
-        {
-          "enemy_id": "0x010600",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Harpy"
-        },
-        {
-          "enemy_id": "0x010600",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Harpy"
-        },
-        {
-          "enemy_id": "0x010600",
-          "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Harpy"
-        },
-        {
+          "comment": "Giant Geo Saurian",
           "enemy_id": "0x010421",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Giant Geo Saurian"
+          "exp": 4200
         },
         {
+          "comment": "Giant Geo Saurian",
           "enemy_id": "0x010421",
           "level": 90,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Giant Geo Saurian"
+          "exp": 4200
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "level": 90,
+          "exp": 4200
+        },
+        {
+          "comment": "Harpy",
+          "enemy_id": "0x010600",
+          "level": 90,
+          "exp": 4200
         }
       ]
     }
@@ -113,7 +110,9 @@
   "blocks": [
     {
       "type": "Raw",
-      "check_commands": [{"type": "IsMainQuestClear", "Param1": 30150}]
+      "check_commands": [
+        {"type": "IsMainQuestClear", "Param1": 30150}
+      ]
     },
     {
       "type": "NpcTalkAndOrder",
@@ -124,45 +123,61 @@
       "message_id": 27945
     },
     {
-      "type": "NewTalkToNpc",
-      "stage_id": {
-        "id": 597
-      },
+      "type": "SpawnGroup",
       "announce_type": "Accept",
-      "npc_id": "Revento",
-      "message_id": 27952,
       "groups": [0],
-      "flags": [
-        {
-          "type": "QstLayout",
-          "action": "Set",
-          "value": 7352
-        }
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 4513, "Param2": 27946, "comment": "Extra dialogue - Eddys"}
+      ],
+      "check_commands": [
+        {"type": "StageNo", "Param1": 1006}
       ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [0]
-    },
-    {
-      "type": "TalkToNpc",
+      "type": "NewTalkToNpc",
       "stage_id": {
-        "id": 597
+        "id": 597,
+        "group_id": 0,
+        "layer_no": 0
       },
-      "announce_type": "Update",
       "npc_id": "Revento",
-      "message_id": 0
+      "message_id": 27952,
+      "result_commands": [
+        {"type": "QstLayoutFlagOn", "Param1": 7352, "comment": "Spawns Levente NPC"}
+      ]
+    },
+    {
+        "type": "KillGroup",
+        "announce_type": "Update",
+        "groups": [1],
+        "result_commands": [
+          {"type": "PlayMessage", "Param1": 27949, "Param2": 0},
+          {"type": "MyQstFlagOn", "Param1": 4314, "comment": "Levente FSM"}
+        ]
+    },
+    {
+        "type": "NewTalkToNpc",
+        "announce_type": "Update",
+        "stage_id": {
+            "id": 597,
+            "group_id": 2,
+            "layer_no": 0
+        },
+        "npc_id": "Revento",
+        "message_id": 27947,
+        "result_commands": [
+          {"type": "QstLayoutFlagOff", "Param1": 7352, "comment": "Clears Levente NPC"},
+          {"type": "QstLayoutFlagOn", "Param1": 7356, "comment": "Spawns Levente (Alive) NPC"}
+        ]
     },
     {
       "type": "TalkToNpc",
+      "announce_type": "CheckpointAndUpdate",
       "stage_id": {
         "id": 464
       },
-      "announce_type": "Update",
       "npc_id": "Kirsty0",
-      "message_id": 27944
+      "message_id": 27943
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018040.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018040.json
@@ -82,20 +82,23 @@
       "message_id": 27953
     },
     {
-      "type": "DeliverItems",
-      "stage_id": {
-        "id": 487
-      },
-      "npc_id": "Fred",
+      "type": "NewDeliverItems",
       "announce_type": "Accept",
+      "stage_id": {
+        "id": 464,
+        "group_id": 0,
+        "layer_no": 0
+      },
+      "npc_id": "Hester",
       "items": [
-        {
-          "id": 21244,
-          "amount": 9,
-          "comment": "Spirit Purifier Stone Shards"
-        }
+        {"id": 21244, "amount": 9, "comment": "Spirit Purifier Stone Shards"}
       ],
-      "message_id": 27956
+      "message_id": 27956,
+      "result_commands": [
+        {"type": "QstLayoutFlagOn", "Param1": 7358, "comment": "Spawns Hester"},
+        {"type": "QstTalkChg", "Param1": 3263, "Param2": 27954, "comment": "Extra dialogue - Fred"},
+        {"type": "QstTalkChg", "Param1": 590, "Param2": 27955, "comment": "Extra dialogue - Hester"}
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018041.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018041.json
@@ -1,0 +1,166 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Fury in the Fog",
+    "quest_id": 22018041,
+    "base_level": 92,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MegadosysPlateau",
+    "news_image": 339,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5500
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "RoyalCrestMedalMegadosysDistrict",
+                    "num": 5
+                },
+                {
+                    "item_id": "GoremanticoresWhiteBeard",
+                    "num": 1
+                },
+                {
+                    "item_id": "WarDemonsAncestorNasalCartilage",
+                    "num": 3
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 464,
+                "group_id": 200
+            },
+            "enemies": [
+                {
+                    "comment": "Ancestor Orc - Tosser",
+                    "enemy_id": "0x015833",
+                    "level": 92,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Ancestor Orc - Blunt",
+                    "enemy_id": "0x015832",
+                    "level": 92,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Ancestor Orc - Blunt",
+                    "enemy_id": "0x015832",
+                    "level": 92,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Ancestor Orc - Fighter",
+                    "enemy_id": "0x015831",
+                    "level": 92,
+                    "exp": 4200
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 464,
+                "group_id": 34
+            },
+			"starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Goremanticore",
+                    "enemy_id": "0x015211",
+                    "level": 92,
+                    "exp": 21000,
+					"is_boss": true
+                },
+                {
+                    "comment": "Injured Ancestor Orc - Blunt",
+                    "enemy_id": "0x015832",
+					"named_enemy_params_id": 1480,
+                    "level": 92,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Eliminator",
+                    "enemy_id": "0x010508",
+                    "level": 92,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Eliminator",
+                    "enemy_id": "0x010508",
+                    "level": 92,
+                    "exp": 4200
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "CheckAreaRank", "Param1": 20, "Param1": 1},
+                        {"type": "StageNo", "Param1": 133}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "DieEnemy", "Param1": 133, "Param2": 14, "Param3": -1}
+                    ]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Accept",
+                    "groups": [0],
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100035}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Update",
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 815},
+                        {"type": "QstLayoutFlagOn", "Param1": 7368}
+                    ],
+                    "check_commands": [
+                        {"type": "QuestOmSetTouch", "Param1": 133, "Param2": 0, "Param3": 0}
+                    ]
+                },
+                {
+                    "type": "DiscoverEnemy",
+                    "announce_type": "Update",
+                    "groups": [1],
+                    "result_commands": [
+                        {"type": "CallGeneralAnnounce", "Param1": 0, "Param2": 100036},
+                        {"type": "QstLayoutFlagOff", "Param1": 7368}
+					]
+                },
+                {
+                    "type": "KillGroup",
+                    "announce_type": "Update",
+					"reset_group": false,
+                    "groups": [1]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018043.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018043.json
@@ -1,0 +1,228 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Disturbing Portent",
+    "quest_id": 22018043,
+    "base_level": 95,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MegadosysPlateau",
+    "order_conditions": [{"type": "AreaRank", "Param1": 20, "Param2": 8}, {"type": "MainQuestCompleted", "Param1": 30200}],
+    "news_image": 679,
+    "rewards": [
+        {
+            "type": "exp",
+            "amount": 50400
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5500
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "AreaPoints",
+            "amount": 500
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "RoyalCrestMedalMegadosysDistrict",
+                    "num": 5
+                },
+                {
+                    "item_id": "LargeDemonsStripedPelt",
+                    "num": 1
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 10
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 517,
+                "group_id": 50
+            },
+            "starting_index": 3,
+            "enemies": [
+                {
+                    "comment": "Axe Soldier Dwarf Orc",
+                    "enemy_id": "0x015821",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Blunt Soldier Dwarf Orc",
+                    "enemy_id": "0x015822",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Blunt Soldier Dwarf Orc",
+                    "enemy_id": "0x015822",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "War-Ready Giant Saurian",
+                    "enemy_id": "0x010471",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "War-Ready Giant Saurian",
+                    "enemy_id": "0x010471",
+                    "level": 95,
+                    "exp": 4200
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 517,
+                "group_id": 77
+            },
+            "starting_index": 4,
+            "enemies": [
+                {
+                    "comment": "Fodden",
+                    "enemy_id": "0x015042",
+                    "level": 95,
+                    "exp": 21000,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Grigori",
+                    "enemy_id": "0x015900",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Grigori",
+                    "enemy_id": "0x015900",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Grigori",
+                    "enemy_id": "0x015900",
+                    "level": 95,
+                    "exp": 4200
+                }
+            ]
+        },
+        {
+            "stage_id": {
+                "id": 518,
+                "group_id": 11
+            },
+            "starting_index": 5,
+            "enemies": [
+                {
+                    "comment": "Cockatrice",
+                    "enemy_id": "0x015301",
+                    "level": 95,
+                    "exp": 21000,
+                    "is_boss": true
+                },
+                {
+                    "comment": "War-Ready Gorecyclops",
+                    "enemy_id": "0x015060",
+                    "infection_type": 3,
+                    "level": 95,
+                    "exp": 21000,
+                    "is_boss": true
+                },
+                {
+                    "comment": "War-Ready Grimwarg",
+                    "enemy_id": "0x010230",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "War-Ready Grimwarg",
+                    "enemy_id": "0x010230",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "War-Ready Grimwarg",
+                    "enemy_id": "0x010230",
+                    "level": 95,
+                    "exp": 4200
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "Raw",
+            "check_commands": [
+                {"type": "IsMainQuestClear", "Param1": 30200}
+            ]
+        },
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 487
+            },
+            "npc_id": "Jan",
+            "message_id": 27961
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Accept",
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 3259, "Param2": 27962}
+            ],
+            "groups": [0]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [0]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [1]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [1]
+        },
+        {
+            "type": "SeekOutEnemiesAtMarkedLocation",
+            "announce_type": "Update",
+            "groups": [2]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "reset_group": false,
+            "groups": [2]
+        },
+        {
+            "type": "TalkToNpc",
+            "stage_id": {
+                "id": 487
+            },
+            "announce_type": "CheckpointAndUpdate",
+            "npc_id": "Jan",
+            "message_id": 27963
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018044.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018044.json
@@ -30,101 +30,355 @@
       "amount": 37800
     },
     {
-      "type": "random",
+      "type": "select",
       "loot_pool": [
         {
-          "comment": "Blazing Lizard Pelt",
-          "item_id": 21262,
-          "num": 1,
-          "chance": 0.6
+          "comment": "Royal Crest Medal (Megadosys District)",
+          "item_id": 18820,
+          "num": 5
         },
         {
-          "comment": "Cursed Spine",
-          "item_id": 19651,
-          "num": 1,
-          "chance": 0.4
+          "comment": "Superior Healing Remedy",
+          "item_id": 7555,
+          "num": 10
+        },
+        {
+          "comment": "Superior Strong Gala Extract",
+          "item_id": 9364,
+          "num": 10
         }
       ]
     }
   ],
   "enemy_groups": [
     {
-      "comment": "GroupId: 7 - Gigant Machina, Flame Skeleton Brutes, Pyro Slimes",
+      "comment": "Random Group 1 - Gigant Machina, Flame Skeleton Brutes, Pyro Slimes",
       "stage_id": {
         "id": 518,
-        "group_id": 7
+        "group_id": 29
       },
+      "starting_index": 5,
       "enemies": [
         {
+          "comment": "Gigant Machina",
           "enemy_id": "0x015850",
           "level": 95,
-          "exp": 44000,
-          "is_boss": true,
-          "comment": "Gigant Machina"
+          "exp": 21000,
+          "is_boss": true
         },
         {
+          "comment": "Flame Skeleton Brute",
           "enemy_id": "0x010320",
           "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Flame Skeleton Brute"
+          "exp": 4200
         },
         {
+          "comment": "Flame Skeleton Brute",
           "enemy_id": "0x010320",
           "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Flame Skeleton Brute"
+          "exp": 4200
         },
         {
+          "comment": "Pyro Slime",
           "enemy_id": "0x010905",
           "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Pyro Slime"
+          "exp": 4200
         },
         {
+          "comment": "Pyro Slime",
           "enemy_id": "0x010905",
           "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Pyro Slime"
+          "exp": 4200
+        },
+        {
+          "comment": "Pyro Slime",
+          "enemy_id": "0x010905",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Pyro Slime",
+          "enemy_id": "0x010905",
+          "level": 95,
+          "exp": 4200
+        }
+      ]
+    },
+    {
+      "comment": "Random Group 2 - Frost Machina, Frost Skeleton Brutes, Freezing Slimes",
+      "stage_id": {
+        "id": 518,
+        "group_id": 29
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Frost Machina",
+          "enemy_id": "0x015851",
+          "level": 95,
+          "exp": 21000,
+          "is_boss": true
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Frost Skeleton Brute",
+          "enemy_id": "0x010321",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Freezing Slime",
+          "enemy_id": "0x010906",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Freezing Slime",
+          "enemy_id": "0x010906",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Freezing Slime",
+          "enemy_id": "0x010906",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Freezing Slime",
+          "enemy_id": "0x010906",
+          "level": 95,
+          "exp": 4200
+        }
+      ]
+    },
+    {
+      "comment": "Random Group 3 - Gigant Machina, Skeleton Sorcerers, Ghosts",
+      "stage_id": {
+        "id": 518,
+        "group_id": 29
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Gigant Machina",
+          "enemy_id": "0x015850",
+          "level": 95,
+          "exp": 21000,
+          "is_boss": true
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Skeleton Sorcerer",
+          "enemy_id": "0x010309",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Ghost",
+          "enemy_id": "0x015620",
+          "level": 95,
+          "exp": 4200
+        }
+      ]
+    },
+    {
+      "comment": "Random Group 4 - Frost Machina, Greater Goblins, Snow Harpies",
+      "stage_id": {
+        "id": 518,
+        "group_id": 29
+      },
+      "starting_index": 5,
+      "enemies": [
+        {
+          "comment": "Frost Machina",
+          "enemy_id": "0x015851",
+          "level": 95,
+          "exp": 21000,
+          "is_boss": true
+        },
+        {
+          "comment": "Greater Goblin",
+          "enemy_id": "0x010130",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Greater Goblin",
+          "enemy_id": "0x010130",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Snow Harpy",
+          "enemy_id": "0x010601",
+          "level": 95,
+          "exp": 4200
         }
       ]
     }
   ],
-  "blocks": [
+  "processes": [
     {
-      "type": "Raw",
-      "check_commands": [{"type": "IsMainQuestClear", "Param1": 30200}]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [{"type": "IsMainQuestClear", "Param1": 30200}]
+        },
+        {
+          "type": "NpcTalkAndOrder",
+          "stage_id": {
+            "id": 487
+          },
+          "npc_id": "Muget",
+          "message_id": 27965
+        },
+        {
+          "type": "Raw",
+          "announce_type": "Accept",
+          "result_commands": [
+            {"type": "MyQstFlagOn", "Param1": 0},
+            {"type": "QstTalkChg", "Param1": 3255, "Param2": 27966}
+          ],
+          "check_commands": [
+            {"type": "IsEnemyFound", "Param1": 463, "Param2": 29, "Param3": -1}
+          ]
+        },
+        {
+          "type": "Raw",
+          "announce_type": "Update",
+          "check_commands": [
+            {"type": "DieEnemy", "Param1": 463, "Param2": 29, "Param3": -1}
+          ]
+        },
+        {
+          "type": "TalkToNpc",
+          "stage_id": {
+            "id": 487
+          },
+          "announce_type": "CheckpointAndUpdate",
+          "npc_id": "Muget",
+          "message_id": 27967
+        }
+      ]
     },
     {
-      "type": "NpcTalkAndOrder",
-      "stage_id": {
-        "id": 487
-      },
-      "npc_id": "Muget",
-      "message_id": 27964
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [
+            {"type": "MyQstFlagOn", "Param1": 0}
+          ]
+        },
+        {
+          "type": "Raw",
+          "result_commands": [
+            {"type": "SetRandom", "Param1": 1, "Param2": 1, "Param3": 4}
+          ]
+        }
+      ]
     },
     {
-      "type": "DiscoverEnemy",
-      "announce_type": "Accept",
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [
+            {"type": "RandomEq", "Param1": 1, "Param2": 1}
+          ]
+        },
+        {
+          "type": "SpawnGroup",
+          "groups": [0]
+        }
+      ]
     },
     {
-      "type": "KillGroup",
-      "announce_type": "Update",
-      "reset_group": false,
-      "groups": [0]
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [
+            {"type": "RandomEq", "Param1": 1, "Param2": 2}
+          ]
+        },
+        {
+          "type": "SpawnGroup",
+          "groups": [1]
+        }
+      ]
     },
     {
-      "type": "TalkToNpc",
-      "stage_id": {
-        "id": 487
-      },
-      "announce_type": "Update",
-      "npc_id": "Muget",
-      "message_id": 27968
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [
+            {"type": "RandomEq", "Param1": 1, "Param2": 3}
+          ]
+        },
+        {
+          "type": "SpawnGroup",
+          "groups": [2]
+        }
+      ]
+    },
+    {
+      "blocks": [
+        {
+          "type": "Raw",
+          "check_commands": [
+            {"type": "RandomEq", "Param1": 1, "Param2": 4}
+          ]
+        },
+        {
+          "type": "SpawnGroup",
+          "groups": [3]
+        }
+      ]
     }
   ]
 }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018045.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018045.json
@@ -7,7 +7,7 @@
   "minimum_item_rank": 0,
   "discoverable": true,
   "area_id": "MegadosysPlateau",
-  "news_image": 330,
+  "news_image": 679,
   "order_conditions": [{"type": "AreaRank", "Param1": 20, "Param2": 8}, {"type": "MainQuestCompleted", "Param1": 30200}],
   "rewards": [
     {
@@ -69,60 +69,49 @@
   ],
   "enemy_groups": [
     {
-      "comment": "GroupId: 29 - Skeleton Cyclops, Strix, Grigori",
+      "comment": "GroupId: 20 - Skeleton Cyclops, Strix, Grigori",
       "stage_id": {
         "id": 518,
-        "group_id": 29
+        "group_id": 20
       },
+      "starting_index": 4,
       "enemies": [
         {
+          "comment": "Skeleton Cyclops",
           "enemy_id": "0x015050",
           "level": 95,
-          "exp": 44000,
-          "is_boss": false,
-          "comment": "Skeleton Cyclops"
+          "exp": 21000,
+          "is_boss": true
         },
         {
-          "enemy_id": "0x010610",
-          "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Strix"
-        },
-        {
-          "enemy_id": "0x010610",
-          "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Strix"
-        },
-        {
-          "enemy_id": "0x010610",
-          "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Strix"
-        },
-        {
-          "enemy_id": "0x010610",
-          "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Strix"
-        },
-        {
+          "comment": "Grigori",
           "enemy_id": "0x015900",
           "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grigori"
+          "exp": 4200
         },
         {
+          "comment": "Grigori",
           "enemy_id": "0x015900",
           "level": 95,
-          "exp": 18000,
-          "is_boss": false,
-          "comment": "Grigori"
+          "exp": 4200
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 95,
+          "exp": 4200
+        },
+        {
+          "comment": "Strix",
+          "enemy_id": "0x010610",
+          "level": 95,
+          "exp": 4200
         }
       ]
     }
@@ -142,24 +131,26 @@
     },
     {
       "type": "DeliverItems",
+      "announce_type": "Accept",
       "stage_id": {
         "id": 487
       },
       "npc_id": "Demir",
-      "announce_type": "Accept",
       "items": [
-        {
-          "id": 21235,
-          "amount": 5,
-          "comment": "Water Purification Stone Powder"
-        }
+        {"id": 21235, "amount": 5, "comment": "Water Purification Stone Powder"}
       ],
-      "message_id": 27972
+      "message_id": 27971,
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3258, "Param2": 27970}
+      ]
     },
     {
       "type": "DiscoverEnemy",
-      "announce_type": "Update",
-      "groups": [0]
+      "announce_type": "CheckpointAndUpdate",
+      "groups": [0],
+      "result_commands": [
+        {"type": "QstTalkChg", "Param1": 3258, "Param2": 27972}
+      ]
     },
     {
       "type": "KillGroup",
@@ -172,7 +163,7 @@
       "stage_id": {
         "id": 487
       },
-      "announce_type": "Update",
+      "announce_type": "CheckpointAndUpdate",
       "npc_id": "Demir",
       "message_id": 27973
     }

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018046.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018046.json
@@ -1,0 +1,148 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "Time Restriction: Early Dawn Bug Hunting",
+    "quest_id": 22018046,
+    "base_level": 93,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MegadosysPlateau",
+    "order_conditions": [{"type": "MainQuestCompleted", "Param1": 30200}],
+    "news_image": 338,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 13750
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 555
+        },
+        {
+            "type": "exp",
+            "amount": 8400
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "RoyalCrestMedalMegadosysDistrict",
+                    "num": 5
+                },
+                {
+                    "item_id": "SuperiorHealingRemedy",
+                    "num": 10
+                },
+                {
+                    "item_id": "SuperiorStrongGalaExtract",
+                    "num": 10
+                }
+            ]
+        }
+    ],
+    "processes": [
+        {
+            "blocks": [
+                {
+                    "type": "Raw",
+                    "check_commands": [{"type": "IsMainQuestClear", "Param1": 30200}]
+                },
+                {
+                    "type": "NpcTalkAndOrder",
+                    "stage_id": {
+                        "id": 487
+                    },
+                    "npc_id": "Doris",
+                    "message_id": 27980
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "Accept",
+                    "check_commands": [
+                        {"type": "StageNo", "Param1": 461},
+                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 3200, "Param2": 27981}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "CheckpointAndUpdate",
+                    "check_commands": [
+                        {"type": "TalkNpc", "Param1": 461, "Param2": 3200},
+                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10}
+                    ],
+                    "result_commands": [
+                        {"type": "QstTalkChg", "Param1": 3200, "Param2": 27982}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "announce_type": "CheckpointAndUpdate",
+                    "result_commands": [
+                        {"type": "MyQstFlagOn", "Param1": 0},
+                        {"type": "QstTalkChg", "Param1": 3200, "Param2": 27983}
+                    ],
+                    "check_commands": [
+                        {"type": "HaveItemAllBag", "Param1": 21215, "Param2": 5, "comment": "Giant Caterpillar"}
+                    ]
+                },
+                {
+                    "type": "DeliverItems",
+                    "announce_type": "CheckpointAndUpdate",
+                    "stage_id": {
+                        "id": 487
+                    },
+                    "npc_id": "Doris",
+                    "items": [
+                        {"id": 21215, "amount": 5, "comment": "Giant Caterpillar"}
+                    ],
+                    "message_id": 27984
+                }
+            ]
+        },
+        {
+            "blocks": [
+                {
+                    "type": "MyQstFlags",
+                    "check_flags": [0]
+                },
+                {
+                    "type": "Raw",
+                    "check_commands": [
+                        {"type": "IngameTimeRangeEq", "Param1": 5, "Param2": 10},
+                        {"type": "StageNoWithoutMarker", "Param1": 133}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOn", "Param1": 7392},
+                        {"type": "QstLayoutFlagOn", "Param1": 7393},
+                        {"type": "QstLayoutFlagOn", "Param1": 7394},
+                        {"type": "QstLayoutFlagOn", "Param1": 7502},
+                        {"type": "QstLayoutFlagOn", "Param1": 7509},
+                        {"type": "PlayMessage", "Param1": 27985, "Param2": 0}
+                    ],
+                    "check_commands": [
+                        {"type": "IngameTimeRangeNotEq", "Param1": 5, "Param2": 10}
+                    ]
+                },
+                {
+                    "type": "Raw",
+                    "result_commands": [
+                        {"type": "QstLayoutFlagOff", "Param1": 7392},
+                        {"type": "QstLayoutFlagOff", "Param1": 7393},
+                        {"type": "QstLayoutFlagOff", "Param1": 7394},
+                        {"type": "QstLayoutFlagOff", "Param1": 7502},
+                        {"type": "QstLayoutFlagOff", "Param1": 7509},
+                        {"type": "PlayMessage", "Param1": 27986, "Param2": 0}
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018048.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018048.json
@@ -161,7 +161,7 @@
         },
         {
             "type": "TalkToNpc",
-            "announce_type": "Update",
+            "announce_type": "CheckpointAndUpdate",
             "stage_id": {
                 "id": 487
             },

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018048.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q22018048.json
@@ -1,0 +1,172 @@
+{
+    "state_machine": "GenericStateMachine",
+    "type": "World",
+    "comment": "A Foreign Investigation",
+    "quest_id": 22018048,
+    "base_level": 95,
+    "minimum_item_rank": 0,
+    "discoverable": true,
+    "area_id": "MegadosysPlateau",
+    "order_conditions": [{"type": "AreaRank", "Param1": 20, "Param2": 8}, {"type": "MainQuestCompleted", "Param1": 30200}],
+    "news_image": 679,
+    "rewards": [
+        {
+            "type": "wallet",
+            "wallet_type": "Gold",
+            "amount": 5500
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "RiftPoints",
+            "amount": 665
+        },
+        {
+            "type": "exp",
+            "amount": 37800
+        },
+        {
+            "type": "wallet",
+            "wallet_type": "AreaPoints",
+            "amount": 500
+        },
+        {
+            "type": "select",
+            "loot_pool": [
+                {
+                    "item_id": "RoyalCrestMedalMegadosysDistrict",
+                    "num": 5
+                },
+                {
+                    "item_id": "CrackedAmulet",
+                    "num": 3
+                },
+                {
+                    "item_id": "CursedLetter",
+                    "num": 1
+                }
+            ]
+        }
+    ],
+    "enemy_groups" : [
+        {
+            "stage_id": {
+                "id": 518,
+                "group_id": 26
+            },
+            "enemies": []
+        },
+        {
+            "stage_id": {
+                "id": 518,
+                "group_id": 26
+            },
+            "starting_index": 5,
+            "enemies": [
+                {
+                    "comment": "Empress Ghost",
+                    "enemy_id": "0x010211",
+                    "level": 95,
+                    "exp": 21000,
+                    "is_boss": true
+                },
+                {
+                    "comment": "Bearded Grigori",
+                    "enemy_id": "0x015920",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Bearded Grigori",
+                    "enemy_id": "0x015920",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Grudge Ghost",
+                    "enemy_id": "0x015622",
+                    "level": 95,
+                    "exp": 4200
+                },
+                {
+                    "comment": "Grudge Ghost",
+                    "enemy_id": "0x015622",
+                    "level": 95,
+                    "exp": 4200
+                }
+            ]
+        }
+    ],
+    "blocks": [
+        {
+            "type": "Raw",
+            "check_commands": [
+                {"type": "IsMainQuestClear", "Param1": 30200}
+            ]
+        },
+        {
+            "type": "NpcTalkAndOrder",
+            "stage_id": {
+                "id": 487
+            },
+            "npc_id": "Eddys",
+            "message_id": 28023
+        },
+        {
+            "type": "SpawnGroup",
+            "announce_type": "Accept",
+            "groups": [0],
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 3261, "Param2": 28024, "comment": "Extra dialogue - Eddys"}
+            ],
+            "check_commands": [
+                {"type": "StageNo", "Param1": 463}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "stage_id": {
+                "id": 518,
+                "group_id": 0,
+                "layer_no": 0
+            },
+            "npc_id": "Revento",
+            "message_id": 28030,
+            "result_commands": [
+                {"type": "QstLayoutFlagOn", "Param1": 7405, "comment": "Spawns Levente NPC"}
+            ]
+        },
+        {
+            "type": "KillGroup",
+            "announce_type": "Update",
+            "groups": [1],
+            "result_commands": [
+                {"type": "PlayMessage", "Param1": 28027, "Param2": 0},
+                {"type": "MyQstFlagOn", "Param1": 4335, "comment": "Levente FSM"}
+            ]
+        },
+        {
+            "type": "NewTalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 518,
+                "group_id": 2,
+                "layer_no": 0
+            },
+            "npc_id": "Revento",
+            "message_id": 28025,
+            "result_commands": [
+                {"type": "QstLayoutFlagOff", "Param1": 7405, "comment": "Clears Levente NPC"},
+                {"type": "QstLayoutFlagOn", "Param1": 7409, "comment": "Spawns Levente (Alive) NPC"}
+            ]
+        },
+        {
+            "type": "TalkToNpc",
+            "announce_type": "Update",
+            "stage_id": {
+                "id": 487
+            },
+            "npc_id": "Eddys",
+            "message_id": 28021
+        }
+    ]
+}

--- a/Arrowgene.Ddon.Shared/Files/Assets/quests/q60300401.json
+++ b/Arrowgene.Ddon.Shared/Files/Assets/quests/q60300401.json
@@ -8,14 +8,8 @@
     "minimum_item_rank": 0,
     "discoverable": false,
     "stage_id": { "id": 584 },
-    "enabled": false,
-    "order_conditions": [
-        {
-            "type": "MinimumVocationLevel",
-            "Param1": 11,
-            "Param2": 18
-        }
-    ],
+    "adventure_guide_category": "VocationQuest",
+    "order_conditions": [{"type": "MinimumVocationLevel", "Param1": 11, "Param2": 18}, {"type": "MainQuestCompleted", "Param1": 30150}],
     "rewards": [
         {
             "type": "wallet",
@@ -43,6 +37,14 @@
     ],
     "blocks": [
         {
+            "type": "Raw",
+            "check_commands": [
+                {"type": "PlJobEq", "Param1": 11},
+                {"type": "JobLevelNotLess", "Param1": 1, "Param2": 18},
+                {"type": "IsMainQuestClear", "Param1": 30150}
+            ]
+        },
+        {
             "type": "NpcTalkAndOrder",
             "stage_id": {
                 "id": 584,
@@ -59,7 +61,10 @@
             },
             "announce_type": "Accept",
             "npc_id": "Kirsty0",
-            "message_id": 28179
+            "message_id": 28179,
+            "result_commands": [
+                {"type": "QstTalkChg", "Param1": 3202, "Param2": 28178}
+            ]
         }
     ]
 }

--- a/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
+++ b/Arrowgene.Ddon.Shared/Model/Quest/QuestFlags.cs
@@ -396,7 +396,7 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             public static QuestFlagInfo OpenLeverDoor { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(1672, QuestId.Q70000001, StageInfo);
         }
 
-        public static class BloodbaneIsle0
+        public static class BloodbaneIsle
         {
             private static StageInfo StageInfo = Stage.BloodbaneIsle0;
 
@@ -850,12 +850,12 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// <summary>
             /// Opens gates leading to The King's Hidden Chamber
             /// </summary>
-            public static QuestFlagInfo TheKingsHiddenChamberGates { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4402, QuestId.Q70032001);
+            public static QuestFlagInfo TheKingsHiddenChamber { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4402, QuestId.Q70032001);
 
             /// <summary>
-            /// Unknown what it does, but a world quest checks for it
+            /// Unlocks World Quest "Flames of Darkness"
             /// </summary>
-            public static QuestFlagInfo Q70032001Unk1 { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4580, QuestId.Q70032001);
+            public static QuestFlagInfo FlamesOfDarkness { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4580, QuestId.Q70032001);
 
             /// <summary>
             /// Spawns closed well for Eli Guard Tower
@@ -893,9 +893,30 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             public static QuestFlagInfo Doris { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(7497, QuestId.Q70032001, StageInfo);
 
             /// <summary>
+            /// Spawns substory quest giver Mephis
+            /// </summary>
+            public static QuestFlagInfo Mephis { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(7747, QuestId.Q70032001, StageInfo);
+
+            /// <summary>
             /// Activates warp to Megado Corridor
             /// </summary>
             public static QuestFlagInfo MegadoCorridor { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(5185, QuestId.Q70034001);
+
+            /// <summary>
+            /// Activates warp to Darkness Shrouded Megado Corridor
+            /// Uses the same door as Megado Corridor, so only one should be active at any time
+            /// </summary>
+            public static QuestFlagInfo DarknessShroudedMegadoCorridor { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(5216, QuestId.Q70034001);
+
+            /// <summary>
+            /// Spawns door to Marquise Kurt's Residence
+            /// </summary>
+            public static QuestFlagInfo MarquiseKurtsResidence { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(7654, QuestId.Q70032001, StageInfo);
+
+            /// <summary>
+            /// Unlocks door to Old Epitaph Road Shrine
+            /// </summary>
+            public static QuestFlagInfo OldEpitaphRoadShrine { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4451, QuestId.Q70032001);
         }
 
         public static class FortressCityMegadoRoyalPalaceLevel
@@ -911,11 +932,6 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             /// Activates warp to Urteca Mountains
             /// </summary>
             public static QuestFlagInfo UrtecaMountainsWarp { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(7827, QuestId.Q70033001, StageInfo);
-
-            /// <summary>
-            /// Unlocks door to Old Epitaph Road Shrine
-            /// </summary>
-            public static QuestFlagInfo OldEpitaphRoadShrine { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4451, QuestId.Q70032001);
         }
 
         public static class OldHeroicSpiritShrine
@@ -1005,9 +1021,9 @@ namespace Arrowgene.Ddon.Shared.Model.Quest
             public static QuestFlagInfo RockBridge { get; private set; } = QuestFlagInfo.WorldManageLayoutFlag(7888, QuestId.Q70033001, StageInfo);
 
             /// <summary>
-            /// Opens gate to the lava room in the middle of the map
+            /// Opens gate leading to the rock bridge, required for S3.3 MSQ
             /// </summary>
-            public static QuestFlagInfo LavaRoomGateOpen { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4914, QuestId.Q70033001);
+            public static QuestFlagInfo BridgeGate { get; private set; } = QuestFlagInfo.WorldManageQuestFlag(4914, QuestId.Q70033001);
         }
 
         public static class FirefallMountainCampsite


### PR DESCRIPTION
Season 3.2 Main and Personal quests have been implemented. Megadosys World Quests have also been reviewed, along with a minor revision to caution spots, and area rank locks for Megadosys have been enabled. Additionally, the Crown and Scepter quest series have been added to the disabled folder, and QuestFlags.cs has been updated with some new flags and minor adjustments to some existing ones.

Several main quests have also been updated:

- The Entrusted Future: doors no longer relock if you exit the stage.
- Exploring the Den of Monsters: World Quest unlock has been moved to the end of the quest, unlocking them immediately without needing a relog.
- The Entrusted One: Zuhl has been moved closer to the player and their missing named title has been added.
- The Lost Hometown: Quest markers have been added to guide players to Farana Plains.
- The Village of Soldiers: World Quest unlock has been moved to the end of the quest, unlocking them immediately without needing a relog.
- Homecoming: World Quest unlock has been moved to the end of the quest, unlocking them immediately without needing a relog.
- Gallant Footsteps: no longer needs a forced warp to the right map, quest markers have been added to guide players to Kingal Canyon, World Quest unlock for Kingal Canyon has been moved to the end of the quest, unlocking them immediately without needing a relog.
- The Spirit Land: no longer needs a forced warp to the right map, which should also fix Reason and Bonds teleporting the player to the wrong map.

Some tutorial quests have also been updated:

- High Scepter Tactics Trial: A Magick Sword: Now cancellable, goblin trial enemies are no longer invincible but spawn repeatedly as observed in playthroughs, combat shouts have been added to Barris, the player can now speak to Barris after collecting the mark.
- Seeking the Master: High Scepter: Has been enabled, checks for main quest progression.

And the following World Quests have been added:

- The Fiends' Early Harvest
- Time Restriction: Evening Harvest
- Happy Days Once Again
- Time Restriction: Gathering Under Clear Skies
- Eyes That Speak of a Deep Bond
- Indomitable Proof
- Fury in the Fog
- A Disturbing Portent
- Time Restriction: Early Dawn Bug Hunting
- A Foreign Investigation

Full list of added or enabled quests below:

- The Road to the Royal Capital
- Rally the Troops
- Attack on the Royal Capital
- An Omen of Destruction
- A Brief Dragon Force
- The Plight of Lookout Castle
- The Final Battle Of The Royal Capital
- Megadosys Plateau: Rescue Request
- Megadosys Plateau: Liberation Army Support
- Megadosys Plateau: Pursue and Defeat Enemies
- Megadosys Plateau: Prevent Enemy Attack
- Megadosys Plateau Trial: Material Procurement
- Megadosys Plateau Trial Shadow of Heresy
- The Ruler Overwhelmed by Power
- Adventure Spot Guide: Megadosys Plateau I
- Adventure Spot Guide: Megadosys Plateau II
- Adventure Spot Guide: Megadosys Plateau III
- The Fiends' Early Harvest
- Time Restriction: Evening Harvest
- Happy Days Once Again
- Time Restriction: Gathering Under Clear Skies
- Eyes That Speak of a Deep Bond
- Indomitable Proof
- Fury in the Fog
- A Disturbing Portent
- Time Restriction: Early Dawn Bug Hunting
- A Foreign Investigation
- Seeking the Master: High Scepter
- Crown and Scepter I
- Crown and Scepter II
- Crown and Scepter III
- Crown and Scepter IV

Final notes:

- I have borrowed a debug quest to have Doris spawn at the Eli Guard Tower until AR7, after which she will no longer spawn there.
- Doris EXM unlock has been moved to The Ruler Overwhelmed by Power (aka Ifrit trial).
- Catoblepas area and Old Tekia Grotto unlocks have been moved to the quest files, so their entries have been removed from the debug quest.